### PR TITLE
fix(desktop): preserve route when reopening window

### DIFF
--- a/board/src/components/layout/layout.tsx
+++ b/board/src/components/layout/layout.tsx
@@ -146,7 +146,6 @@ export function Layout() {
 	}, []);
 
 	React.useEffect(() => {
-		let unlistenMain: (() => void) | undefined;
 		let unlistenSettings: (() => void) | undefined;
 		let unlistenImportServer: (() => void) | undefined;
 		let unlistenCoreState: (() => void) | undefined;
@@ -162,9 +161,6 @@ export function Layout() {
 				if (cancelled) {
 					return;
 				}
-				unlistenMain = await listen("mcpmate://open-main", () => {
-					navigate("/");
-				});
 				unlistenSettings = await listen(
 					"mcpmate://open-settings",
 					(event) => {
@@ -203,9 +199,6 @@ export function Layout() {
 		void bind();
 		return () => {
 			cancelled = true;
-			if (unlistenMain) {
-				void unlistenMain();
-			}
 			if (unlistenSettings) {
 				void unlistenSettings();
 			}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -425,9 +425,6 @@ pub fn run() -> Result<()> {
                                 if let Err(err) = shell::ensure_window_visibility(&handle) {
                                     warn!(error = %err, "Failed to show main window from tray");
                                 }
-                                if let Err(err) = handle.emit(shell::EVENT_OPEN_MAIN, json!({})) {
-                                    warn!(error = %err, "Failed to emit open-main event to frontend");
-                                }
                             });
                         }
                         shell::MENU_OPEN_SETTINGS => {
@@ -483,9 +480,6 @@ pub fn run() -> Result<()> {
 										emit_core_state_changed(&handle, &view);
                                                 if let Err(err) = shell::ensure_window_visibility(&handle) {
                                                     warn!(error = %err, "Failed to reveal main window after starting service");
-                                                }
-                                                if let Err(err) = handle.emit(shell::EVENT_OPEN_MAIN, json!({})) {
-                                                    warn!(error = %err, "Failed to emit open-main after starting service");
                                                 }
                                             }
                                             Err(err) => {
@@ -677,9 +671,6 @@ pub fn run() -> Result<()> {
             RunEvent::Reopen { .. } => {
                 if let Err(err) = shell::ensure_window_visibility(app_handle) {
                     warn!(error = %err, "Failed to restore main window on app reopen");
-                }
-                if let Err(err) = app_handle.emit(shell::EVENT_OPEN_MAIN, json!({})) {
-                    warn!(error = %err, "Failed to emit open-main on app reopen");
                 }
             }
             RunEvent::Exit => {
@@ -951,8 +942,8 @@ async fn mcp_shell_manage_local_core_service(
         .await
         .map_err(|err| err.to_string())?;
 
-    if let Some(audit_action) = audit_action {
-        if let Err(err) = audit::emit_desktop_audit_event(
+    if let Some(audit_action) = audit_action
+        && let Err(err) = audit::emit_desktop_audit_event(
             audit_action,
             mcpmate::audit::AuditStatus::Success,
             Some(action_name.clone()),
@@ -967,9 +958,8 @@ async fn mcp_shell_manage_local_core_service(
             None,
         )
         .await
-        {
-            warn!(error = %err, "Failed to emit desktop audit event for service action");
-        }
+    {
+        warn!(error = %err, "Failed to emit desktop audit event for service action");
     }
 
     Ok(view)

--- a/desktop/src-tauri/src/shell.rs
+++ b/desktop/src-tauri/src/shell.rs
@@ -51,7 +51,6 @@ pub const MENU_OPEN_SETTINGS: &str = "mcpmate.tray.open_settings";
 pub const MENU_SHOW_ABOUT: &str = "mcpmate.tray.show_about";
 pub const MENU_QUIT: &str = "mcpmate.tray.quit";
 
-pub const EVENT_OPEN_MAIN: &str = "mcpmate://open-main";
 pub const EVENT_OPEN_SETTINGS: &str = "mcpmate://open-settings";
 pub const EVENT_CORE_STATE_CHANGED: &str = "mcpmate://core/status-changed";
 


### PR DESCRIPTION
## Summary
- stop emitting the desktop open-main event when dock and tray reopen actions only need to reveal the existing window
- remove the frontend open-main route reset so MCPMate preserves the current page and in-progress flows
- keep desktop verification clean by collapsing an unrelated nested audit check that clippy flagged in the same file

## Validation
- bun install
- bun run build
- cargo check -q
- cargo clippy --all-targets --all-features -- -D warnings

## Notes
- cargo fmt --all --check still reports pre-existing formatting drift in unrelated backend/desktop files in this worktree baseline; this hotfix does not introduce new fmt-only edits