### PR TITLE
fix: upgrade rmcp to 1.3.0 and harden streamable HTTP auth

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3020,7 +3020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4530,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4565,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6511,7 +6511,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -48,7 +48,7 @@ reqwest = { version = "0.13", features = [
   "stream",
   "rustls",
 ], default-features = false }
-rmcp = { version = "1.2.0", features = [
+rmcp = { version = "1.3.0", features = [
   "__reqwest",
   "auth",
   "client",

--- a/backend/src/common/http.rs
+++ b/backend/src/common/http.rs
@@ -1,12 +1,17 @@
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use std::collections::HashMap;
 
-/// Strip "Bearer " prefix (case-insensitive) from a string, returning the stripped content or None.
+/// Strip a leading `Bearer` scheme (ASCII case-insensitive) and following whitespace from `s`.
+/// Returns the remainder (credential) or `None` if the scheme is not Bearer.
 fn strip_bearer_case_insensitive(s: &str) -> Option<&str> {
     let trimmed = s.trim();
-    trimmed
-        .strip_prefix("Bearer ")
-        .or_else(|| trimmed.strip_prefix("bearer "))
+    let scheme_end = trimmed.find(char::is_whitespace)?;
+    let (scheme, rest) = trimmed.split_at(scheme_end);
+    if scheme.eq_ignore_ascii_case("bearer") {
+        Some(rest.trim_start())
+    } else {
+        None
+    }
 }
 
 /// Extract bearer token value from `headers` map.
@@ -70,6 +75,8 @@ mod tests {
     fn test_trim_bearer_prefix() {
         assert_eq!(trim_bearer_prefix("Bearer ABC"), "ABC");
         assert_eq!(trim_bearer_prefix("bearer XYZ "), "XYZ");
+        assert_eq!(trim_bearer_prefix("BEARER mixed-case"), "mixed-case");
+        assert_eq!(trim_bearer_prefix("BeArEr\ttab-sep"), "tab-sep");
         assert_eq!(trim_bearer_prefix("NOPREFIX"), "NOPREFIX");
         assert_eq!(trim_bearer_prefix("  Bearer  TKN-123  "), "TKN-123");
     }
@@ -83,6 +90,10 @@ mod tests {
         let mut h2 = HashMap::new();
         h2.insert("authorization".to_string(), "bearer tok-2".to_string());
         assert_eq!(extract_bearer_token(&Some(h2)), Some("tok-2".to_string()));
+
+        let mut h2b = HashMap::new();
+        h2b.insert("Authorization".to_string(), "BEARER tok-2b".to_string());
+        assert_eq!(extract_bearer_token(&Some(h2b)), Some("tok-2b".to_string()));
 
         let mut h3 = HashMap::new();
         h3.insert("AUTHORIZATION".to_string(), "Token something".to_string());

--- a/backend/src/common/http.rs
+++ b/backend/src/common/http.rs
@@ -1,6 +1,14 @@
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use std::collections::HashMap;
 
+/// Strip "Bearer " prefix (case-insensitive) from a string, returning the stripped content or None.
+fn strip_bearer_case_insensitive(s: &str) -> Option<&str> {
+    let trimmed = s.trim();
+    trimmed
+        .strip_prefix("Bearer ")
+        .or_else(|| trimmed.strip_prefix("bearer "))
+}
+
 /// Extract bearer token value from `headers` map.
 /// Expects `Authorization: Bearer <token>`; returns `<token>` without the prefix.
 pub fn extract_bearer_token(headers: &Option<HashMap<String, String>>) -> Option<String> {
@@ -14,28 +22,15 @@ pub fn extract_bearer_token(headers: &Option<HashMap<String, String>>) -> Option
         }
     }
     let val = auth_val?;
-    let trimmed = val.trim();
-    // Accept common forms like "Bearer <token>" (case-insensitive)
-    if let Some(rest) = trimmed.strip_prefix("Bearer ") {
-        return Some(rest.trim().to_string());
-    }
-    if let Some(rest) = trimmed.strip_prefix("bearer ") {
-        return Some(rest.trim().to_string());
-    }
-    // If no prefix, we conservatively reject to avoid sending malformed headers
-    None
+    strip_bearer_case_insensitive(val).map(|rest| rest.trim().to_string())
 }
 
 /// Remove a leading "Bearer " (case-insensitive) prefix from a token string.
 pub fn trim_bearer_prefix<S: AsRef<str>>(s: S) -> String {
-    let val = s.as_ref().trim();
-    if let Some(rest) = val.strip_prefix("Bearer ") {
-        return rest.trim().to_string();
-    }
-    if let Some(rest) = val.strip_prefix("bearer ") {
-        return rest.trim().to_string();
-    }
-    val.to_string()
+    let val = s.as_ref();
+    strip_bearer_case_insensitive(val)
+        .map(|rest| rest.trim().to_string())
+        .unwrap_or_else(|| val.trim().to_string())
 }
 
 /// Build a Streamable HTTP client config using URL and optional headers.
@@ -44,7 +39,7 @@ pub fn make_streamable_config(
     url: &str,
     headers: &Option<HashMap<String, String>>,
 ) -> StreamableHttpClientTransportConfig {
-    let mut cfg = StreamableHttpClientTransportConfig::with_uri(url);
+    let mut cfg = StreamableHttpClientTransportConfig::with_uri(url).reinit_on_expired_session(true);
     if let Some(token) = extract_bearer_token(headers) {
         cfg = cfg.auth_header(token);
     }
@@ -56,7 +51,7 @@ pub fn make_streamable_config_with_bearer(
     url: &str,
     bearer: Option<&str>,
 ) -> StreamableHttpClientTransportConfig {
-    let mut cfg = StreamableHttpClientTransportConfig::with_uri(url);
+    let mut cfg = StreamableHttpClientTransportConfig::with_uri(url).reinit_on_expired_session(true);
     if let Some(token) = bearer {
         let trimmed = trim_bearer_prefix(token);
         if !trimmed.is_empty() {
@@ -101,9 +96,11 @@ mod tests {
         let cfg = make_streamable_config("http://x/mcp", &Some(h));
         assert_eq!(cfg.uri.as_ref(), "http://x/mcp");
         assert_eq!(cfg.auth_header.as_deref(), Some("tok-3"));
+        assert!(cfg.reinit_on_expired_session);
 
         let cfg2 = make_streamable_config_with_bearer("http://y/mcp", Some("Bearer tok-4"));
         assert_eq!(cfg2.uri.as_ref(), "http://y/mcp");
         assert_eq!(cfg2.auth_header.as_deref(), Some("tok-4"));
+        assert!(cfg2.reinit_on_expired_session);
     }
 }

--- a/backend/src/common/http.rs
+++ b/backend/src/common/http.rs
@@ -27,7 +27,9 @@ pub fn extract_bearer_token(headers: &Option<HashMap<String, String>>) -> Option
         }
     }
     let val = auth_val?;
-    strip_bearer_case_insensitive(val).map(|rest| rest.trim().to_string())
+    strip_bearer_case_insensitive(val)
+        .map(|rest| rest.trim().to_string())
+        .filter(|token| !token.is_empty())
 }
 
 /// Remove a leading "Bearer " (case-insensitive) prefix from a token string.
@@ -98,6 +100,19 @@ mod tests {
         let mut h3 = HashMap::new();
         h3.insert("AUTHORIZATION".to_string(), "Token something".to_string());
         assert_eq!(extract_bearer_token(&Some(h3)), None);
+
+        // Empty/whitespace-only credential must return None, not Some("")
+        let mut h4 = HashMap::new();
+        h4.insert("Authorization".to_string(), "Bearer ".to_string());
+        assert_eq!(extract_bearer_token(&Some(h4)), None);
+
+        let mut h5 = HashMap::new();
+        h5.insert("Authorization".to_string(), "Bearer    ".to_string());
+        assert_eq!(extract_bearer_token(&Some(h5)), None);
+
+        let mut h6 = HashMap::new();
+        h6.insert("Authorization".to_string(), "Bearer\t".to_string());
+        assert_eq!(extract_bearer_token(&Some(h6)), None);
     }
 
     #[test]

--- a/backend/src/core/proxy/server/common.rs
+++ b/backend/src/core/proxy/server/common.rs
@@ -655,13 +655,12 @@ impl UnifiedHttpServer {
             self.config.streamable_http_path,
         );
 
-        let streamable_http_config = StreamableHttpServerConfig {
-            sse_keep_alive: self.config.keep_alive_interval,
-            sse_retry: Some(std::time::Duration::from_secs(3)),
-            stateful_mode: true,
-            json_response: false,
-            cancellation_token: self.config.cancellation_token.clone(),
-        };
+        let streamable_http_config = StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(self.config.keep_alive_interval)
+            .with_sse_retry(Some(std::time::Duration::from_secs(3)))
+            .with_stateful_mode(true)
+            .with_json_response(false)
+            .with_cancellation_token(self.config.cancellation_token.clone());
 
         let session_manager = std::sync::Arc::new(LocalSessionManager::default());
 

--- a/backend/src/core/proxy/server/gateway.rs
+++ b/backend/src/core/proxy/server/gateway.rs
@@ -555,13 +555,12 @@ impl ProxyServer {
         tracing::info!("Starting Streamable HTTP server on {} at path {}", bind_address, path);
         let server_clone = self.clone();
         let factory = move || Ok(server_clone.clone());
-        let server_config = rmcp::transport::StreamableHttpServerConfig {
-            sse_keep_alive: Some(std::time::Duration::from_secs(15)),
-            sse_retry: Some(std::time::Duration::from_secs(3)),
-            stateful_mode: true,
-            json_response: false,
-            cancellation_token: self.cancellation_token.clone(),
-        };
+        let server_config = rmcp::transport::StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(Some(std::time::Duration::from_secs(15)))
+            .with_sse_retry(Some(std::time::Duration::from_secs(3)))
+            .with_stateful_mode(true)
+            .with_json_response(false)
+            .with_cancellation_token(self.cancellation_token.clone());
         let session_manager = std::sync::Arc::new(
             rmcp::transport::streamable_http_server::session::local::LocalSessionManager::default(),
         );
@@ -722,6 +721,13 @@ impl ProxyServer {
         self.call_sessions_by_request.remove(request_id);
     }
 
+    fn build_base_event_data(route: &DownstreamRoute) -> Map<String, Value> {
+        let mut data = Map::new();
+        data.insert("client_id".to_string(), Value::String(route.client_id.clone()));
+        data.insert("session_id".to_string(), Value::String(route.session_id.clone()));
+        data
+    }
+
     pub async fn forward_upstream_progress(
         &self,
         _server_id: &str,
@@ -741,9 +747,7 @@ impl ProxyServer {
             progress = ?param.progress,
             "Forwarded progress to downstream"
         );
-        let mut data = Map::new();
-        data.insert("client_id".to_string(), Value::String(route.client_id.clone()));
-        data.insert("session_id".to_string(), Value::String(route.session_id.clone()));
+        let mut data = Self::build_base_event_data(&route);
         data.insert("progress".to_string(), Value::from(param.progress));
         if let Some(total) = param.total {
             data.insert("total".to_string(), Value::from(total));
@@ -794,9 +798,7 @@ impl ProxyServer {
             reason = ?param.reason,
             "Forwarded cancellation to downstream"
         );
-        let mut data = Map::new();
-        data.insert("client_id".to_string(), Value::String(route.client_id.clone()));
-        data.insert("session_id".to_string(), Value::String(route.session_id.clone()));
+        let mut data = Self::build_base_event_data(&route);
         data.insert("request_id".to_string(), Value::String(param.request_id.to_string()));
         crate::audit::interceptor::emit_event(
             self.audit_service.as_ref(),
@@ -845,9 +847,7 @@ impl ProxyServer {
             level = ?param.level,
             "Forwarded log message to downstream"
         );
-        let mut data = Map::new();
-        data.insert("client_id".to_string(), Value::String(route.client_id.clone()));
-        data.insert("session_id".to_string(), Value::String(route.session_id.clone()));
+        let mut data = Self::build_base_event_data(&route);
         data.insert(
             "level".to_string(),
             Value::String(

--- a/backend/src/core/proxy/server/tools.rs
+++ b/backend/src/core/proxy/server/tools.rs
@@ -464,10 +464,8 @@ pub(super) async fn call_tool(
         params = params.with_arguments(arguments);
     }
     let req = ClientRequest::CallToolRequest(CallToolRequest::new(params));
-    let options = PeerRequestOptions {
-        timeout: Some(std::time::Duration::from_secs(call_timeout_secs)),
-        meta: None,
-    };
+    let mut options = PeerRequestOptions::no_options();
+    options.timeout = Some(std::time::Duration::from_secs(call_timeout_secs));
     let handle = peer
         .send_cancellable_request(req, options)
         .await

--- a/backend/src/core/transport/http.rs
+++ b/backend/src/core/transport/http.rs
@@ -46,7 +46,11 @@ async fn connect_http_internal(
 
     let (service, tools, capabilities) = match transport_type {
         TransportType::StreamableHttp => {
-            let transport = StreamableHttpClientTransport::<reqwest::Client>::from_uri(url.as_str());
+            let config = make_streamable_config(url, &server_config.headers);
+            let transport = StreamableHttpClientTransport::<reqwest::Client>::with_client(
+                reqwest::Client::new(),
+                config,
+            );
             build_service_tools(server_name, transport, service_timeout, tools_timeout).await?
         }
         TransportType::Stdio => {

--- a/backend/src/core/transport/mod.rs
+++ b/backend/src/core/transport/mod.rs
@@ -2,8 +2,6 @@
 // Provides abstractions for different transport types (stdio, sse, http, unified)
 
 pub mod http;
-#[cfg(test)]
-mod http_auth_tests;
 
 // sse functions are merged into http module
 pub mod client;

--- a/backend/src/inspector/service.rs
+++ b/backend/src/inspector/service.rs
@@ -480,10 +480,8 @@ async fn start_tool_call_internal(
         CallToolRequestParams::new(upstream_tool_name).with_arguments(req.arguments.clone().unwrap_or_default());
     let request = ClientRequest::CallToolRequest(CallToolRequest::new(params));
 
-    let options = PeerRequestOptions {
-        timeout: Some(timeout),
-        meta: None,
-    };
+    let mut options = PeerRequestOptions::no_options();
+    options.timeout = Some(timeout);
 
     let call_id = crate::generate_id!("inspcall");
     let handle = peer

--- a/backend/src/mcper/builtin/broker.rs
+++ b/backend/src/mcper/builtin/broker.rs
@@ -1425,14 +1425,10 @@ impl BrokerService {
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             .unwrap_or(60);
+        let mut options = PeerRequestOptions::no_options();
+        options.timeout = Some(std::time::Duration::from_secs(timeout_secs));
         let handle = peer
-            .send_cancellable_request(
-                request,
-                PeerRequestOptions {
-                    timeout: Some(std::time::Duration::from_secs(timeout_secs)),
-                    meta: None,
-                },
-            )
+            .send_cancellable_request(request, options)
             .await
             .context("Failed to send Unify broker tool call")?;
 

--- a/backend/tests/http_auth.rs
+++ b/backend/tests/http_auth.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
@@ -10,17 +8,15 @@ use axum::{
     response::Response,
     Router,
 };
+use mcpmate::common::server::ServerType;
+use mcpmate::core::models::MCPServerConfig;
+use mcpmate::core::transport::{connect_http_server, TransportType};
 use tokio::net::TcpListener;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use crate::common::server::ServerType;
-use crate::core::models::MCPServerConfig;
-use crate::core::transport::{connect_http_server, TransportType};
-
 #[derive(Clone, Default)]
 struct CapturedAuth {
-    // store raw Authorization header values by method
     post: Arc<tokio::sync::Mutex<Vec<Option<String>>>>,
     get: Arc<tokio::sync::Mutex<Vec<Option<String>>>>,
     delete: Arc<tokio::sync::Mutex<Vec<Option<String>>>>,
@@ -37,16 +33,17 @@ async fn capture_auth_middleware(
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
+
     match method {
         Method::POST => captured.post.lock().await.push(auth),
         Method::GET => captured.get.lock().await.push(auth),
         Method::DELETE => captured.delete.lock().await.push(auth),
         _ => {}
     }
+
     next.run(req).await
 }
 
-// Minimal server implementing rmcp ServerHandler defaults
 #[derive(Clone, Default)]
 struct DummyServer;
 
@@ -58,7 +55,6 @@ impl rmcp::ServerHandler for DummyServer {
 
 #[tokio::test]
 async fn streamable_http_carries_bearer_on_init_sse_delete() -> anyhow::Result<()> {
-    // Start a streamable HTTP server under /mcp with a header-capturing middleware
     let captured = CapturedAuth::default();
     let service: rmcp::transport::streamable_http_server::tower::StreamableHttpService<
         DummyServer,
@@ -66,14 +62,14 @@ async fn streamable_http_carries_bearer_on_init_sse_delete() -> anyhow::Result<(
     > = rmcp::transport::streamable_http_server::tower::StreamableHttpService::new(
         || Ok(DummyServer),
         Default::default(),
-        rmcp::transport::streamable_http_server::StreamableHttpServerConfig {
-            stateful_mode: true,
-            sse_keep_alive: None,
-            sse_retry: Some(Duration::from_secs(3)),
-            json_response: false,
-            cancellation_token: CancellationToken::new(),
-        },
+        rmcp::transport::streamable_http_server::StreamableHttpServerConfig::default()
+            .with_stateful_mode(true)
+            .with_sse_keep_alive(None)
+            .with_sse_retry(Some(Duration::from_secs(3)))
+            .with_json_response(false)
+            .with_cancellation_token(CancellationToken::new()),
     );
+
     let router = Router::new()
         .nest_service("/mcp", service)
         .layer(from_fn_with_state(captured.clone(), capture_auth_middleware));
@@ -89,7 +85,6 @@ async fn streamable_http_carries_bearer_on_init_sse_delete() -> anyhow::Result<(
         })
     };
 
-    // Build server config with Authorization header
     let url = format!("http://{addr}/mcp");
     let mut headers = std::collections::HashMap::new();
     headers.insert(
@@ -105,22 +100,17 @@ async fn streamable_http_carries_bearer_on_init_sse_delete() -> anyhow::Result<(
         headers: Some(headers),
     };
 
-    // Connect via backend helper (uses make_streamable_config to set auth_header)
     let (service, _tools, _caps) =
         connect_http_server("auth-test", &server_cfg, TransportType::StreamableHttp).await?;
 
-    // Allow some time for init + SSE subscription
     sleep(Duration::from_millis(200)).await;
 
-    // Trigger graceful shutdown to invoke delete-session in the worker drop guard
-    let _ = service.cancel().await; // ignore reason
+    let _ = service.cancel().await;
 
-    // Allow delete-session request to be sent
     sleep(Duration::from_millis(200)).await;
     shutdown.cancel();
     let _ = shutdown_task.await;
 
-    // Assertions: at least one POST/GET/DELETE carried the Authorization header
     let posts = captured.post.lock().await.clone();
     let gets = captured.get.lock().await.clone();
     let deletes = captured.delete.lock().await.clone();

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4383,7 +4383,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http",
@@ -5957,9 +5957,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5992,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",


### PR DESCRIPTION
## Summary
- upgrade backend rmcp dependencies and compatibility call sites to 1.3.0, including non-exhaustive config builders and `PeerRequestOptions::no_options()` migrations
- make streamable HTTP auth/session behavior explicit by enabling `reinit_on_expired_session(true)`, simplifying bearer token handling, and moving the HTTP auth lifecycle check into `backend/tests/http_auth.rs`
- sync the desktop Tauri lockfile to the same rmcp release and verify backend plus desktop checks still pass

## Validation
- `cd backend && cargo check`
- `cd backend && cargo test --test http_auth -- --nocapture`
- `cd backend && cargo test common::http::tests -- --nocapture`
- `cd backend && cargo clippy --all-targets --all-features -- -D warnings`
- `cd desktop/src-tauri && cargo check`