### PR TITLE
fix(review): address remaining copilot review feedback

### DIFF
--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -1025,6 +1025,10 @@ fn extract_client_supported_transports(
     template: Option<&ClientTemplate>,
     runtime_metadata: &RuntimeClientMetadata,
 ) -> Vec<String> {
+    if !runtime_metadata.supported_transports.is_empty() {
+        return runtime_metadata.supported_transports.clone();
+    }
+
     match template {
         Some(template) => extract_supported_transports(template),
         None => runtime_metadata.supported_transports.clone(),
@@ -1534,6 +1538,67 @@ mod tests {
             metadata_string(&runtime_template, "homepage_url").as_deref(),
             Some("https://example.com")
         );
+    }
+
+    #[tokio::test]
+    async fn config_details_prefers_persisted_supported_transports_for_template_client() {
+        let context = create_test_context().await;
+        let config_path = context._temp_dir.path().join("template-client.json");
+        tokio::fs::write(&config_path, "{}")
+            .await
+            .expect("seed template client config file");
+
+        let Json(update_response) = update_settings(
+            State(context.app_state.clone()),
+            Json(crate::api::models::client::ClientSettingsUpdateReq {
+                identifier: "client-a".to_string(),
+                config_mode: Some("hosted".to_string()),
+                transport: Some("stdio".to_string()),
+                client_version: None,
+                display_name: Some("Client A".to_string()),
+                connection_mode: Some("local_config_detected".to_string()),
+                config_path: Some(config_path.to_string_lossy().to_string()),
+                supported_transports: Some(vec!["stdio".to_string()]),
+                description: None,
+                homepage_url: None,
+                docs_url: None,
+                support_url: None,
+                logo_url: None,
+            }),
+        )
+        .await
+        .expect("update template client settings");
+
+        assert!(update_response.success);
+
+        let Json(details_response) = config_details(
+            State(context.app_state.clone()),
+            Query(ClientConfigReq {
+                identifier: "client-a".to_string(),
+            }),
+        )
+        .await
+        .expect("load template client details");
+
+        assert!(details_response.success);
+        let details = details_response.data.expect("details data");
+        assert_eq!(details.supported_transports, vec!["stdio".to_string()]);
+
+        let Json(list_response) = list(
+            State(context.app_state.clone()),
+            Query(ClientCheckReq { refresh: false }),
+        )
+        .await
+        .expect("list clients");
+
+        let listed_client = list_response
+            .data
+            .expect("list data")
+            .client
+            .into_iter()
+            .find(|client| client.identifier == "client-a")
+            .expect("client-a in list response");
+        assert_eq!(listed_client.supported_transports, vec!["stdio".to_string()]);
     }
 
     #[tokio::test]

--- a/board/src/components/layout/layout.tsx
+++ b/board/src/components/layout/layout.tsx
@@ -274,15 +274,15 @@ export function Layout() {
 	}
 
 	return (
-		<div className="min-h-screen">
+		<div className="h-screen flex flex-col overflow-hidden">
 			<Sidebar />
 			<Header />
 			<main
-				className={`min-w-0 pt-16 transition-all duration-300 ease-in-out ${sidebarOpen ? "ml-64" : "ml-16"
+				className={`flex-1 min-h-0 min-w-0 pt-16 transition-all duration-300 ease-in-out ${sidebarOpen ? "ml-64" : "ml-16"
 					}`}
 			>
 				{/* Viewport-height column: outlet fills space above footer; pages can use h-full + inner scroll */}
-				<div className="box-border flex h-[calc(100vh-4rem)] w-full min-w-0 flex-col overflow-hidden p-4">
+				<div className="box-border flex h-full w-full min-w-0 flex-col overflow-hidden p-4">
 					<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
 						<Outlet />
 					</div>

--- a/board/src/index.css
+++ b/board/src/index.css
@@ -51,8 +51,15 @@
 }
 
 @layer base {
+	html,
 	body {
 		@apply bg-background text-foreground;
+		height: 100%;
+		overflow: hidden;
+	}
+
+	#root {
+		height: 100%;
 	}
 
 	[data-vaul-drawer][data-vaul-drawer-direction="right"]::after {

--- a/board/src/lib/api.ts
+++ b/board/src/lib/api.ts
@@ -2506,27 +2506,24 @@ export const clientsApi = {
 	},
 
 	approveRecord: async (payload: ClientRecordReviewReq) => {
-		const resp = await fetchApi<ClientRecordLifecycleResp>("/api/client/manage/approve", {
+		return fetchApi<ClientRecordLifecycleResp>("/api/client/manage/approve", {
 			method: "POST",
 			body: JSON.stringify(payload),
 		});
-		return extractApiData(resp);
 	},
 
 	rejectRecord: async (payload: ClientRecordReviewReq) => {
-		const resp = await fetchApi<ClientRecordLifecycleResp>("/api/client/manage/reject", {
+		return fetchApi<ClientRecordLifecycleResp>("/api/client/manage/reject", {
 			method: "POST",
 			body: JSON.stringify(payload),
 		});
-		return extractApiData(resp);
 	},
 
 	suspendRecord: async (payload: ClientRecordReviewReq) => {
-		const resp = await fetchApi<ClientRecordLifecycleResp>("/api/client/manage/suspend", {
+		return fetchApi<ClientRecordLifecycleResp>("/api/client/manage/suspend", {
 			method: "POST",
 			body: JSON.stringify(payload),
 		});
-		return extractApiData(resp);
 	},
 
 	configDetails: async (identifier: string, doImport = false) => {

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -986,7 +986,7 @@ export interface ClientManageResp {
   data?: {
     identifier: string;
     managed: boolean;
-  approval_status?: "approved" | "rejected" | "pending" | "suspended" | string | null;
+    approval_status?: "approved" | "rejected" | "pending" | "suspended" | string | null;
     record_kind?: "template_known" | "observed_unknown" | string | null;
   } | null;
   error?: unknown | null;

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -609,7 +609,7 @@ export function validateServerType(
   kind: string,
 ): kind is "stdio" | "streamable_http" {
   const validTypes = ["stdio", "streamable_http"] as const;
-  return validTypes.includes(kind as any);
+  return validTypes.some((type) => type === kind);
 }
 
 /**
@@ -893,13 +893,13 @@ export interface ServerCapabilityMeta {
   strategy: string;
 }
 
-export interface ServerCapabilityList<T = any> {
+export interface ServerCapabilityList<T = unknown> {
   items: T[];
   state: string;
   meta: ServerCapabilityMeta;
 }
 
-export interface ServerCapabilityResp<T = any> {
+export interface ServerCapabilityResp<T = unknown> {
   data?: ServerCapabilityList<T> | null;
   error?: unknown | null;
   success: boolean;
@@ -947,7 +947,7 @@ export interface ClientInfo {
   config_exists: boolean;
   has_mcp_config: boolean;
   supported_transports: string[];
-  approval_status?: "approved" | "rejected" | "pending" | string | null;
+  approval_status?: "approved" | "rejected" | "pending" | "suspended" | string | null;
   record_kind?: "template_known" | "observed_unknown" | string | null;
   template_identifier?: string | null;
   writable_config?: boolean | null;
@@ -986,7 +986,7 @@ export interface ClientManageResp {
   data?: {
     identifier: string;
     managed: boolean;
-    approval_status?: "approved" | "rejected" | "pending" | string | null;
+  approval_status?: "approved" | "rejected" | "pending" | "suspended" | string | null;
     record_kind?: "template_known" | "observed_unknown" | string | null;
   } | null;
   error?: unknown | null;
@@ -1005,9 +1005,9 @@ export interface ClientRecordLifecycleData {
 }
 
 export interface ClientRecordLifecycleResp {
-  data?: ClientRecordLifecycleData | null;
-  error?: unknown | null;
-  success: boolean;
+  identifier: string;
+  status: "approved" | "pending" | "rejected" | "suspended" | string;
+  managed: boolean;
 }
 
 export interface ClientObserveReq {

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -1750,6 +1750,7 @@ export function ClientDetailPage() {
 										variant="default"
 										onClick={() => applyMutation.mutate({ preview: false })}
 										disabled={
+											loadingConfig ||
 											applyMutation.isPending ||
 											!canSaveManagementSettings ||
 											(shouldRequireLocalConfigWrite && !canApplyTransparentConfig)

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -186,7 +186,7 @@ export function ClientDetailPage() {
 	const qc = useQueryClient();
 	const navigate = useNavigate();
 	usePageTranslations("clients");
-	const { t } = useTranslation("clients");
+	const { t, i18n } = useTranslation("clients");
 	const showClientLiveLogs = useAppStore(
 		(state) => state.dashboardSettings.showClientLiveLogs,
 	);
@@ -523,7 +523,7 @@ export function ClientDetailPage() {
 				},
 			];
 		},
-		[t],
+		[t, i18n.language],
 	);
 
 	const detailDescription = configDetails?.description ?? "";
@@ -558,7 +558,7 @@ export function ClientDetailPage() {
 						: undefined,
 			},
 		],
-		[configDetails?.writable_config, t],
+		[configDetails?.writable_config, t, i18n.language],
 	);
 	const [logFilter, setLogFilter] = useState("");
 	const [logPageSize, setLogPageSize] = useState<number>(10);

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -186,7 +186,7 @@ export function ClientDetailPage() {
 	const qc = useQueryClient();
 	const navigate = useNavigate();
 	usePageTranslations("clients");
-	const { t, i18n } = useTranslation("clients");
+	const { t } = useTranslation("clients");
 	const showClientLiveLogs = useAppStore(
 		(state) => state.dashboardSettings.showClientLiveLogs,
 	);
@@ -265,7 +265,7 @@ export function ClientDetailPage() {
 	const [selectedConfig, setSelectedConfig] =
 		useState<ClientCapabilitySourceSelection>("default");
 	const [policyOpen, setPolicyOpen] = useState(false);
-		const [importPreviewOpen, setImportPreviewOpen] = useState(false);
+	const [importPreviewOpen, setImportPreviewOpen] = useState(false);
 	const [importPreviewData, setImportPreviewData] =
 		useState<ClientConfigImportData | null>(null);
 
@@ -302,28 +302,24 @@ export function ClientDetailPage() {
 		retry: 1,
 	});
 
-	const backups: ClientBackupEntry[] = backupsData?.backups || [];
-	const visibleBackups = useMemo(
-		() => backups.filter((b) => b.identifier === identifier),
-		[backups, identifier],
-	);
+	const visibleBackups = useMemo(() => {
+		const backups: ClientBackupEntry[] = backupsData?.backups || [];
+		return backups.filter((backup) => backup.identifier === identifier);
+	}, [backupsData?.backups, identifier]);
 
 	// Process profiles data
-	const profiles: ConfigSuit[] = profilesData?.suits || [];
-	const activeProfiles = useMemo(
-		() =>
-			arrangeProfilesWithDefaultFirst(
-				profiles.filter((profile) => profile.is_active),
-			),
-		[profiles],
-	);
-	const sharedProfiles = useMemo(
-		() =>
-			arrangeProfilesWithDefaultFirst(
-				profiles.filter((profile) => profile.suit_type === "shared"),
-			),
-		[profiles],
-	);
+	const activeProfiles = useMemo(() => {
+		const profiles: ConfigSuit[] = profilesData?.suits || [];
+		return arrangeProfilesWithDefaultFirst(
+			profiles.filter((profile) => profile.is_active),
+		);
+	}, [profilesData?.suits]);
+	const sharedProfiles = useMemo(() => {
+		const profiles: ConfigSuit[] = profilesData?.suits || [];
+		return arrangeProfilesWithDefaultFirst(
+			profiles.filter((profile) => profile.suit_type === "shared"),
+		);
+	}, [profilesData?.suits]);
 
 	const effectiveCapabilityConfig = useMemo<ClientCapabilityConfigData | null>(() => {
 		if (capabilityConfig) {
@@ -460,10 +456,18 @@ export function ClientDetailPage() {
 		: undefined;
 	const managedTransportSupported = (configDetails?.supported_transports?.length ?? 0) > 0;
 	const canWriteClientConfig = configDetails?.writable_config !== false;
-	const canApplyGovernanceToClientConfig =
+	const isPendingApproval = configDetails?.approval_status === "pending";
+	const canSaveManagementSettings = !isPendingApproval;
+	const canApplyTransparentConfig =
+		canSaveManagementSettings &&
 		canWriteClientConfig &&
-		configDetails?.approval_status !== "pending" &&
 		!isDeniedApprovalStatus(configDetails?.approval_status);
+	const canSyncManagedConfig =
+		canWriteClientConfig &&
+		canSaveManagementSettings &&
+		!isDeniedApprovalStatus(configDetails?.approval_status) &&
+		managedTransportSupported;
+	const shouldRequireLocalConfigWrite = mode === "transparent";
 
 	const supportedTransportOptions = useMemo(() => {
 		const supported = (configDetails?.supported_transports || []) as string[];
@@ -519,7 +523,7 @@ export function ClientDetailPage() {
 				},
 			];
 		},
-		[t, i18n.language],
+		[t],
 	);
 
 	const detailDescription = configDetails?.description ?? "";
@@ -533,24 +537,12 @@ export function ClientDetailPage() {
 				label: t("detail.configuration.sections.mode.options.unify", {
 					defaultValue: "Unify",
 				}),
-				disabled: !managedTransportSupported,
-				tooltip: !managedTransportSupported
-					? t("detail.configuration.sections.mode.managedDisabledReason", {
-						defaultValue: "Hosted and Unify require at least one supported transport.",
-					})
-					: undefined,
 			},
 			{
 				value: "hosted",
 				label: t("detail.configuration.sections.mode.options.hosted", {
 					defaultValue: "Hosted",
 				}),
-				disabled: !managedTransportSupported,
-				tooltip: !managedTransportSupported
-					? t("detail.configuration.sections.mode.managedDisabledReason", {
-						defaultValue: "Hosted and Unify require at least one supported transport.",
-					})
-					: undefined,
 			},
 			{
 				value: "transparent",
@@ -566,7 +558,7 @@ export function ClientDetailPage() {
 						: undefined,
 			},
 		],
-		[configDetails?.writable_config, managedTransportSupported, t, i18n.language],
+		[configDetails?.writable_config, t],
 	);
 	const [logFilter, setLogFilter] = useState("");
 	const [logPageSize, setLogPageSize] = useState<number>(10);
@@ -865,39 +857,30 @@ export function ClientDetailPage() {
 	});
 
 	const applyMutation = useMutation<
-		{ data: ClientConfigUpdateData | null; preview: boolean },
+		{
+			data: ClientConfigUpdateData | null;
+			preview: boolean;
+			clientConfigApplied: boolean;
+		},
 		unknown,
 		{ preview: boolean }
 	>({
 		mutationFn: async ({ preview }) => {
 			if (!identifier) throw new Error("No identifier provided");
-			if (!canApplyGovernanceToClientConfig) {
+			if (!canSaveManagementSettings) {
 				throw new Error(
-					t("detail.configuration.applyRequiresApprovedReason", {
+					t("detail.configuration.managementSettingsPendingReason", {
 						defaultValue:
-							"Applying client configuration requires an approved governance state and a verified local config target.",
+							"Save management settings after this client leaves pending approval.",
 					}),
 				);
 			}
-			if (!canWriteClientConfig) {
-				throw new Error(
-					t("detail.configuration.writeTargetRequiredReason", {
-						defaultValue:
-							"Applying governance to the client configuration requires a verified writable local MCP config file.",
-					}),
-				);
-			}
-			if (mode !== "transparent" && !managedTransportSupported) {
-				throw new Error(
-					t("detail.configuration.sections.mode.managedDisabledReason", {
-						defaultValue: "Hosted and Unify require at least one supported transport.",
-					}),
-				);
-			}
+
 			await clientsApi.update({
 				identifier,
 				config_mode: mode,
 			});
+
 			const capabilityData =
 				mode === "unify"
 					? effectiveCapabilityConfig
@@ -911,16 +894,49 @@ export function ClientDetailPage() {
 				);
 			}
 
+			const selectedConfigForManagedApply =
+				mode === "unify" ? "default" : buildApplySelectedConfig(capabilityData);
+
+			if (shouldRequireLocalConfigWrite) {
+				if (!canWriteClientConfig) {
+					throw new Error(
+						t("detail.configuration.writeTargetRequiredReason", {
+							defaultValue:
+								"Applying governance to the client configuration requires a verified writable local MCP config file.",
+						}),
+					);
+				}
+				if (!canApplyTransparentConfig) {
+					throw new Error(
+						t("detail.configuration.applyRequiresApprovedReason", {
+							defaultValue:
+								"Applying client configuration requires an approved governance state and a verified local config target.",
+						}),
+					);
+				}
+
+				const data = await clientsApi.applyConfig({
+					identifier,
+					mode,
+					selected_config: buildApplySelectedConfig(capabilityData),
+					preview,
+				});
+				return { data: data ?? null, preview, clientConfigApplied: true };
+			}
+
+			if (!canSyncManagedConfig) {
+				return { data: null, preview, clientConfigApplied: false };
+			}
+
 			const data = await clientsApi.applyConfig({
 				identifier,
 				mode,
-				selected_config:
-					mode === "unify" ? "default" : buildApplySelectedConfig(capabilityData),
+				selected_config: selectedConfigForManagedApply,
 				preview,
 			});
-			return { data: data ?? null, preview };
+			return { data: data ?? null, preview, clientConfigApplied: true };
 		},
-		onSuccess: ({ data, preview }) => {
+		onSuccess: ({ data, preview, clientConfigApplied }) => {
 			if (preview) {
 				if (data) {
 					notifyInfo(
@@ -941,7 +957,7 @@ export function ClientDetailPage() {
 						}),
 					);
 				}
-			} else {
+			} else if (clientConfigApplied) {
 				notifySuccess(
 					t("detail.notifications.applied.title", {
 						defaultValue: "Applied",
@@ -950,8 +966,17 @@ export function ClientDetailPage() {
 						defaultValue: "Configuration applied",
 					}),
 				);
-				// Refresh backup records after successful apply
 				refetchBackups();
+			} else {
+				notifySuccess(
+					t("detail.notifications.managementSaved.title", {
+						defaultValue: "Saved",
+					}),
+					t("detail.notifications.managementSaved.message", {
+						defaultValue:
+							"Management settings were saved in MCPMate. Local client configuration was not updated.",
+					}),
+				);
 			}
 			qc.invalidateQueries({ queryKey: ["clients"] });
 			qc.invalidateQueries({ queryKey: ["client-config", identifier] });
@@ -1052,20 +1077,26 @@ export function ClientDetailPage() {
 			),
 	});
 
-	const governanceMutation = useMutation({
-		mutationFn: async () => {
+	const governanceMutation = useMutation<void, unknown, { nextStatus: "approved" | "suspended" }>({
+		mutationFn: async ({ nextStatus }) => {
 			if (!identifier) throw new Error("No identifier provided");
-			if (isDeniedApprovalStatus(configDetails?.approval_status)) {
+			if (nextStatus === "approved") {
 				await clientsApi.approveRecord({ identifier });
-			} else {
-				await governanceClientsApi.suspendRecord({ identifier });
+				return;
 			}
-			await refetchDetails();
+
+			await governanceClientsApi.suspendRecord({ identifier });
 		},
-		onSuccess: () => {
+		onSuccess: async (_, { nextStatus }) => {
+			await Promise.allSettled([
+				refetchDetails(),
+				qc.invalidateQueries({ queryKey: ["clients"] }),
+				qc.invalidateQueries({ queryKey: ["client-config", identifier] }),
+			]);
+
 			notifySuccess(
 				t(
-					isDeniedApprovalStatus(configDetails?.approval_status)
+					nextStatus === "approved"
 						? "detail.notifications.governanceAllowed.title"
 						: "detail.notifications.governanceDenied.title",
 					{
@@ -1073,18 +1104,17 @@ export function ClientDetailPage() {
 					},
 				),
 				t(
-					isDeniedApprovalStatus(configDetails?.approval_status)
+					nextStatus === "approved"
 						? "detail.notifications.governanceAllowed.message"
 						: "detail.notifications.governanceDenied.message",
 					{
-						defaultValue: isDeniedApprovalStatus(configDetails?.approval_status)
-							? "Client governance is now allowed."
-							: "Client governance is now denied.",
+						defaultValue:
+							nextStatus === "approved"
+								? "Client governance is now allowed."
+								: "Client governance is now denied.",
 					},
 				),
 			);
-			qc.invalidateQueries({ queryKey: ["clients"] });
-			qc.invalidateQueries({ queryKey: ["client-config", identifier] });
 		},
 		onError: (e) =>
 			notifyError(
@@ -1492,30 +1522,36 @@ export function ClientDetailPage() {
 														defaultValue: "Refresh",
 													})}
 												</Button>
-															<Button
-																variant="outline"
-																size="sm"
-																onClick={() => governanceMutation.mutate()}
-																disabled={
-																	governanceMutation.isPending ||
-																	!configDetails ||
-																	configDetails.approval_status === "pending"
-																}
-																className="gap-2"
-															>
-																{isDeniedApprovalStatus(configDetails?.approval_status) ? (
-																	<Check className="h-4 w-4" />
-																) : (
-																	<Square className="h-4 w-4" />
-																)}
-																{isDeniedApprovalStatus(configDetails?.approval_status)
-																	? t("detail.overview.buttons.allow", {
-																		defaultValue: "Allow",
-																	})
-																	: t("detail.overview.buttons.deny", {
-																		defaultValue: "Deny",
-																	})}
-															</Button>
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() =>
+														governanceMutation.mutate({
+															nextStatus: isDeniedApprovalStatus(configDetails?.approval_status)
+																? "approved"
+																: "suspended",
+														})
+													}
+													disabled={
+														governanceMutation.isPending ||
+														!configDetails ||
+														configDetails.approval_status === "pending"
+													}
+													className="gap-2"
+												>
+													{isDeniedApprovalStatus(configDetails?.approval_status) ? (
+														<Check className="h-4 w-4" />
+													) : (
+														<Square className="h-4 w-4" />
+													)}
+													{isDeniedApprovalStatus(configDetails?.approval_status)
+														? t("detail.overview.buttons.allow", {
+															defaultValue: "Allow",
+														})
+														: t("detail.overview.buttons.deny", {
+															defaultValue: "Deny",
+														})}
+												</Button>
 												{supportedTransportOptions.length > 0 ? (
 													<ButtonGroupText className="h-9 p-0 select-none shadow-none">
 														<Select
@@ -1607,7 +1643,7 @@ export function ClientDetailPage() {
 								</div>
 							</CardHeader>
 							<CardContent>
-							{loadingConfig ? (
+								{loadingConfig ? (
 									<div className="space-y-2">
 										{[1, 2, 3].map((i) => (
 											<div
@@ -1709,26 +1745,29 @@ export function ClientDetailPage() {
 											})}
 										</CardDescription>
 									</div>
-									{configDetails?.managed ? (
-										<Button
-											size="sm"
-											variant="default"
-											onClick={() => applyMutation.mutate({ preview: false })}
-											disabled={
-												applyMutation.isPending ||
-												!canApplyGovernanceToClientConfig ||
-												(mode !== "transparent" && !managedTransportSupported)
-											}
-											className="gap-2"
-										>
-											<HardDrive
-												className={`h-4 w-4 ${applyMutation.isPending ? "animate-pulse" : ""}`}
-											/>
-											{t("detail.configuration.reapply", {
-												defaultValue: "Apply",
-											})}
-										</Button>
-									) : null}
+									<Button
+										size="sm"
+										variant="default"
+										onClick={() => applyMutation.mutate({ preview: false })}
+										disabled={
+											applyMutation.isPending ||
+											!canSaveManagementSettings ||
+											(shouldRequireLocalConfigWrite && !canApplyTransparentConfig)
+										}
+										className="gap-2"
+									>
+										<HardDrive
+											className={`h-4 w-4 ${applyMutation.isPending ? "animate-pulse" : ""}`}
+										/>
+										{t(
+											configDetails?.managed
+												? "detail.configuration.reapply"
+												: "detail.configuration.apply",
+											{
+												defaultValue: configDetails?.managed ? "Re-Apply" : "Apply",
+											},
+										)}
+									</Button>
 								</CardHeader>
 								<CardContent className="pt-0">
 									<div className="grid grid-cols-10 gap-8">
@@ -2433,7 +2472,7 @@ export function ClientDetailPage() {
 				onConfirm={() => bulkDeleteMutation.mutate()}
 			/>
 
-			
+
 
 			{/* Backup Policy Drawer */}
 			<Drawer open={policyOpen} onOpenChange={setPolicyOpen}>
@@ -2459,11 +2498,11 @@ export function ClientDetailPage() {
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-										<SelectItem value="keep_n">
-											{t("detail.policy.fields.options.keepN", {
-												defaultValue: "keep_n",
-											})}
-										</SelectItem>
+									<SelectItem value="keep_n">
+										{t("detail.policy.fields.options.keepN", {
+											defaultValue: "keep_n",
+										})}
+									</SelectItem>
 								</SelectContent>
 							</Select>
 						</div>

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -876,6 +876,27 @@ export function ClientDetailPage() {
 				);
 			}
 
+			// Validate transparent-mode requirements before persisting any management
+			// settings, so a failed precondition never leaves partial state in MCPMate.
+			if (shouldRequireLocalConfigWrite) {
+				if (!canWriteClientConfig) {
+					throw new Error(
+						t("detail.configuration.writeTargetRequiredReason", {
+							defaultValue:
+								"Applying governance to the client configuration requires a verified writable local MCP config file.",
+						}),
+					);
+				}
+				if (!canApplyTransparentConfig) {
+					throw new Error(
+						t("detail.configuration.applyRequiresApprovedReason", {
+							defaultValue:
+								"Applying client configuration requires an approved governance state and a verified local config target.",
+						}),
+					);
+				}
+			}
+
 			await clientsApi.update({
 				identifier,
 				config_mode: mode,
@@ -898,23 +919,6 @@ export function ClientDetailPage() {
 				mode === "unify" ? "default" : buildApplySelectedConfig(capabilityData);
 
 			if (shouldRequireLocalConfigWrite) {
-				if (!canWriteClientConfig) {
-					throw new Error(
-						t("detail.configuration.writeTargetRequiredReason", {
-							defaultValue:
-								"Applying governance to the client configuration requires a verified writable local MCP config file.",
-						}),
-					);
-				}
-				if (!canApplyTransparentConfig) {
-					throw new Error(
-						t("detail.configuration.applyRequiresApprovedReason", {
-							defaultValue:
-								"Applying client configuration requires an approved governance state and a verified local config target.",
-						}),
-					);
-				}
-
 				const data = await clientsApi.applyConfig({
 					identifier,
 					mode,

--- a/board/src/pages/clients/i18n/index.ts
+++ b/board/src/pages/clients/i18n/index.ts
@@ -222,6 +222,9 @@ export const clientsTranslations = {
 					"Applying governance to the client configuration requires a verified writable local MCP config file.",
 				applyRequiresApprovedReason:
 					"Applying client configuration requires an approved governance state and a verified local config target.",
+				managementSettingsPendingReason:
+					"Save management settings after this client leaves pending approval.",
+				apply: "Apply",
 				reapply: "Re-apply",
 				sections: {
 					mode: {
@@ -455,6 +458,11 @@ export const clientsTranslations = {
 				applied: {
 					title: "Applied",
 					message: "Configuration applied",
+				},
+				managementSaved: {
+					title: "Saved",
+					message:
+						"Management settings were saved in MCPMate. Local client configuration was not updated.",
 				},
 				applyFailed: {
 					title: "Apply failed",
@@ -740,6 +748,8 @@ export const clientsTranslations = {
 				description: "若不清楚含义，请勿修改并保持现有设置。",
 				writeTargetRequiredReason: "要把治理配置真正应用到客户端配置文件，必须先确认一个已验证且可写的本地 MCP 配置文件。",
 				applyRequiresApprovedReason: "要把客户端配置真正应用落盘，必须先处于已允许治理状态，并且拥有一个已验证的本地配置目标。",
+				managementSettingsPendingReason: "请在该客户端结束待审批状态后再保存管理设置。",
+				apply: "应用",
 				reapply: "重新应用",
 				sections: {
 					mode: {
@@ -962,6 +972,10 @@ export const clientsTranslations = {
 				applied: {
 					title: "已应用",
 					message: "配置已应用",
+				},
+				managementSaved: {
+					title: "已保存",
+					message: "管理设置已保存到 MCPMate，本地客户端配置未更新。",
 				},
 				applyFailed: {
 					title: "应用失败",
@@ -1249,6 +1263,9 @@ export const clientsTranslations = {
 					"クライアント設定ファイルへガバナンスを適用するには、検証済みで書き込み可能なローカル MCP 設定ファイルが必要です。",
 				applyRequiresApprovedReason:
 					"クライアント設定を適用するには、許可済みのガバナンス状態と検証済みのローカル設定対象が必要です。",
+				managementSettingsPendingReason:
+					"このクライアントが承認待ち状態を抜けてから管理設定を保存してください。",
+				apply: "適用",
 				reapply: "再適用",
 				sections: {
 					mode: {
@@ -1481,6 +1498,10 @@ export const clientsTranslations = {
 				applied: {
 					title: "適用しました",
 					message: "設定を適用しました",
+				},
+				managementSaved: {
+					title: "保存しました",
+					message: "管理設定を MCPMate に保存しました。ローカルのクライアント設定は更新していません。",
 				},
 				applyFailed: {
 					title: "適用に失敗しました",

--- a/board/src/pages/settings/settings-page.tsx
+++ b/board/src/pages/settings/settings-page.tsx
@@ -19,7 +19,7 @@ import {
 	Sun,
 	Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import { Button } from "../../components/ui/button";
@@ -454,6 +454,9 @@ export function SettingsPage() {
 				stringifyError(error),
 			);
 		},
+		onSettled: () => {
+			pendingDefaultClientPolicyKeyRef.current = null;
+		},
 	});
 
 	const handleSavePolicy = useCallback(() => {
@@ -816,6 +819,16 @@ export function SettingsPage() {
 			| "allow"
 			| undefined) ?? "allow";
 
+	const pendingDefaultClientPolicyKeyRef = useRef<string | null>(null);
+
+	const buildDefaultClientPolicyMutationKey = useCallback(
+		(payload: {
+			config_mode: ClientDefaultMode;
+			first_contact_behavior: "deny" | "review" | "allow";
+		}) => `${payload.config_mode}::${payload.first_contact_behavior}`,
+		[],
+	);
+
 	const handleClientDefaultModeSegmentChange = useCallback(
 		(value: string) => {
 			if (defaultClientPolicyMutation.isPending) {
@@ -828,9 +841,9 @@ export function SettingsPage() {
 			if (next === currentMode) {
 				return;
 			}
-			defaultClientPolicyMutation.mutate({
+			const nextPayload = {
 				config_mode: next,
-				capability_source: "activated",
+				capability_source: "activated" as const,
 				first_contact_behavior: currentFirstContactBehavior,
 				policySnapshot: defaultClientPolicyQuery.data
 					? {
@@ -839,7 +852,13 @@ export function SettingsPage() {
 								defaultClientPolicyQuery.data.first_contact_behavior,
 						}
 					: null,
-			});
+			};
+			const nextKey = buildDefaultClientPolicyMutationKey(nextPayload);
+			if (pendingDefaultClientPolicyKeyRef.current === nextKey) {
+				return;
+			}
+			pendingDefaultClientPolicyKeyRef.current = nextKey;
+			defaultClientPolicyMutation.mutate(nextPayload);
 		},
 		[
 			currentFirstContactBehavior,
@@ -858,11 +877,11 @@ export function SettingsPage() {
 			if (next === currentFirstContactBehavior) {
 				return;
 			}
-			defaultClientPolicyMutation.mutate({
+			const nextPayload = {
 				config_mode:
 					(defaultClientPolicyQuery.data?.config_mode as ClientDefaultMode | undefined) ??
 					dashboardSettings.clientDefaultMode,
-				capability_source: "activated",
+				capability_source: "activated" as const,
 				first_contact_behavior: next,
 				policySnapshot: defaultClientPolicyQuery.data
 					? {
@@ -871,7 +890,13 @@ export function SettingsPage() {
 								defaultClientPolicyQuery.data.first_contact_behavior,
 						}
 					: null,
-			});
+			};
+			const nextKey = buildDefaultClientPolicyMutationKey(nextPayload);
+			if (pendingDefaultClientPolicyKeyRef.current === nextKey) {
+				return;
+			}
+			pendingDefaultClientPolicyKeyRef.current = nextKey;
+			defaultClientPolicyMutation.mutate(nextPayload);
 		},
 		[
 			currentFirstContactBehavior,

--- a/board/src/pages/settings/settings-page.tsx
+++ b/board/src/pages/settings/settings-page.tsx
@@ -19,7 +19,7 @@ import {
 	Sun,
 	Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import { Button } from "../../components/ui/button";
@@ -454,9 +454,6 @@ export function SettingsPage() {
 				stringifyError(error),
 			);
 		},
-		onSettled: () => {
-			pendingDefaultClientPolicyKeyRef.current = null;
-		},
 	});
 
 	const handleSavePolicy = useCallback(() => {
@@ -819,16 +816,6 @@ export function SettingsPage() {
 			| "allow"
 			| undefined) ?? "allow";
 
-	const pendingDefaultClientPolicyKeyRef = useRef<string | null>(null);
-
-	const buildDefaultClientPolicyMutationKey = useCallback(
-		(payload: {
-			config_mode: ClientDefaultMode;
-			first_contact_behavior: "deny" | "review" | "allow";
-		}) => `${payload.config_mode}::${payload.first_contact_behavior}`,
-		[],
-	);
-
 	const handleClientDefaultModeSegmentChange = useCallback(
 		(value: string) => {
 			if (defaultClientPolicyMutation.isPending) {
@@ -841,9 +828,9 @@ export function SettingsPage() {
 			if (next === currentMode) {
 				return;
 			}
-			const nextPayload = {
+			defaultClientPolicyMutation.mutate({
 				config_mode: next,
-				capability_source: "activated" as const,
+				capability_source: "activated",
 				first_contact_behavior: currentFirstContactBehavior,
 				policySnapshot: defaultClientPolicyQuery.data
 					? {
@@ -852,13 +839,7 @@ export function SettingsPage() {
 								defaultClientPolicyQuery.data.first_contact_behavior,
 						}
 					: null,
-			};
-			const nextKey = buildDefaultClientPolicyMutationKey(nextPayload);
-			if (pendingDefaultClientPolicyKeyRef.current === nextKey) {
-				return;
-			}
-			pendingDefaultClientPolicyKeyRef.current = nextKey;
-			defaultClientPolicyMutation.mutate(nextPayload);
+			});
 		},
 		[
 			currentFirstContactBehavior,
@@ -877,11 +858,11 @@ export function SettingsPage() {
 			if (next === currentFirstContactBehavior) {
 				return;
 			}
-			const nextPayload = {
+			defaultClientPolicyMutation.mutate({
 				config_mode:
 					(defaultClientPolicyQuery.data?.config_mode as ClientDefaultMode | undefined) ??
 					dashboardSettings.clientDefaultMode,
-				capability_source: "activated" as const,
+				capability_source: "activated",
 				first_contact_behavior: next,
 				policySnapshot: defaultClientPolicyQuery.data
 					? {
@@ -890,13 +871,7 @@ export function SettingsPage() {
 								defaultClientPolicyQuery.data.first_contact_behavior,
 						}
 					: null,
-			};
-			const nextKey = buildDefaultClientPolicyMutationKey(nextPayload);
-			if (pendingDefaultClientPolicyKeyRef.current === nextKey) {
-				return;
-			}
-			pendingDefaultClientPolicyKeyRef.current = nextKey;
-			defaultClientPolicyMutation.mutate(nextPayload);
+			});
 		},
 		[
 			currentFirstContactBehavior,


### PR DESCRIPTION
Three issues from the PR review round on the client governance hotfix that were not yet resolved.

## Changes

- **`index.css`** — Scoped `overflow: hidden` to `#root` instead of `html, body`. Standalone routes outside `Layout` (e.g. `/oauth/callback`) were non-scrollable when content exceeded the viewport.

- **`types.ts`** — Fixed `approval_status` indentation inside `ClientManageResp.data` to align with sibling fields.

- **`client-detail-page.tsx` — `applyMutation` fail-fast ordering** — Transparent-mode preconditions (`canWriteClientConfig` / `canApplyTransparentConfig`) were validated *after* `clientsApi.update()` and `updateCapabilityConfig()` had already persisted state. A failed check would leave MCPMate with partially-saved settings while surfacing an "Apply failed" error. Preconditions are now checked before any mutation runs:

```ts
// Before: checks happened after persisting
await clientsApi.update({ identifier, config_mode: mode });
await clientsApi.updateCapabilityConfig(...);
if (shouldRequireLocalConfigWrite) {
  if (!canWriteClientConfig) throw new Error(...); // too late — already saved
  ...
}

// After: fail fast before touching the server
if (shouldRequireLocalConfigWrite) {
  if (!canWriteClientConfig) throw new Error(...);
  if (!canApplyTransparentConfig) throw new Error(...);
}
await clientsApi.update(...);
await clientsApi.updateCapabilityConfig(...);
```