### PR TITLE
fix(runtime): seed bundled presets and align desktop service env

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -87,6 +87,8 @@ Full API documentation available at `http://localhost:8080/docs` when the server
 
 Configuration is stored in SQLite at `~/.mcpmate/mcpmate.db` by default.
 
+On first startup, if the `server_config` table is empty, MCPMate seeds the database with the bundled preset MCP servers from `backend/config/mcp.json`. This seed data is compiled into the binary, so it does not depend on the process working directory.
+
 Override data directory:
 ```bash
 MCPMATE_DATA_DIR=/custom/path cargo run

--- a/backend/config/mcp.json
+++ b/backend/config/mcp.json
@@ -4,7 +4,7 @@
 			"args": [
 				"-y",
 				"@21st-dev/magic@latest",
-				"API_KEY=\"c5dc57e6cec36564e6d056af192bb264551ba5911168eb25f1a7f08b9b2ca1d7\""
+				"API_KEY=\"REPLACE_WITH_YOUR_21MAGIC_API_KEY\""
 			],
 			"command": "npx",
 			"type": "stdio"

--- a/backend/src/config/database.rs
+++ b/backend/src/config/database.rs
@@ -9,7 +9,7 @@ use tracing;
 use crate::{
     common::paths::global_paths,
     common::profile::ProfileType,
-    config::{import, initialization, models},
+    config::{defaults, import, initialization, models},
     core::capability::naming,
 };
 
@@ -45,6 +45,10 @@ impl Database {
         };
 
         tracing::info!("Initializing database connection to {}", database_url);
+
+        global_paths()
+            .ensure_directories()
+            .context("Failed to initialize MCPMate runtime directories")?;
 
         // Ensure the parent directory exists
         if let Some(parent) = db_path.parent() {
@@ -109,34 +113,25 @@ impl Database {
         // Create database instance
         let db = Self { pool, path: db_path };
 
-        // Import configuration from JSON files if available
-        let default_config_path = std::path::Path::new("config/mcp.json");
-        if default_config_path.exists() {
-            // Check if database already has server configurations
-            let has_server_configs = match sqlx::query_scalar::<_, i64>(&format!(
-                "SELECT COUNT(*) FROM {}",
-                crate::common::constants::database::tables::SERVER_CONFIG
-            ))
-            .fetch_one(&db.pool)
-            .await
-            {
-                Ok(count) => count > 0,
-                Err(e) => {
-                    tracing::error!("Failed to check if server_config table has data: {}", e);
-                    false
-                }
-            };
+        let has_server_configs = match sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {}",
+            crate::common::constants::database::tables::SERVER_CONFIG
+        ))
+        .fetch_one(&db.pool)
+        .await
+        {
+            Ok(count) => count > 0,
+            Err(e) => {
+                tracing::error!("Failed to check if server_config table has data: {}", e);
+                false
+            }
+        };
 
-            // Import configuration if database is empty
-            if !has_server_configs {
-                if let Err(e) = db.import_from_files(default_config_path).await {
-                    tracing::warn!("Failed to import MCP configuration: {}", e);
-                } else {
-                    tracing::debug!(
-                        "Imported MCP server configuration from {}",
-                        default_config_path.display()
-                    );
-                }
+        if !has_server_configs {
+            if let Err(e) = defaults::seed_default_servers(&db.pool).await {
+                tracing::warn!("Failed to import bundled MCP configuration: {}", e);
+            } else {
+                tracing::debug!("Imported bundled MCP server configuration into empty database");
             }
         }
 

--- a/backend/src/config/database.rs
+++ b/backend/src/config/database.rs
@@ -46,9 +46,12 @@ impl Database {
 
         tracing::info!("Initializing database connection to {}", database_url);
 
-        global_paths()
-            .ensure_directories()
-            .context("Failed to initialize MCPMate runtime directories")?;
+        let uses_default_database_path = !database_url.starts_with("sqlite:");
+        if uses_default_database_path {
+            global_paths()
+                .ensure_directories()
+                .context("Failed to initialize MCPMate runtime directories")?;
+        }
 
         // Ensure the parent directory exists
         if let Some(parent) = db_path.parent() {

--- a/backend/src/config/defaults.rs
+++ b/backend/src/config/defaults.rs
@@ -1,0 +1,11 @@
+use sqlx::{Pool, Sqlite};
+
+use anyhow::Result;
+
+use super::import;
+
+pub const DEFAULT_MCP_CONFIG_JSON: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/config/mcp.json"));
+
+pub async fn seed_default_servers(pool: &Pool<Sqlite>) -> Result<()> {
+    import::import_from_mcp_config_content(pool, DEFAULT_MCP_CONFIG_JSON).await
+}

--- a/backend/src/config/import.rs
+++ b/backend/src/config/import.rs
@@ -8,6 +8,66 @@ use sqlx::{Pool, Sqlite};
 use std::collections::HashMap;
 use std::{fs::File, path::Path, sync::Arc};
 
+fn global_redb_cache() -> Result<Arc<RedbCacheManager>> {
+    RedbCacheManager::global().map_err(|error| anyhow::anyhow!(format!("Failed to init REDB cache: {}", error)))
+}
+
+async fn has_server_configs(pool: &Pool<Sqlite>) -> Result<bool> {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM server_config")
+        .fetch_one(pool)
+        .await
+        .map(|count| count > 0)
+        .map_err(|error| anyhow::anyhow!("Failed to check if server_config table has data: {}", error))
+}
+
+async fn import_config_with_cache(
+    pool: &Pool<Sqlite>,
+    mcp_config: Config,
+    redb_cache: &Arc<RedbCacheManager>,
+) -> Result<()> {
+    let items: HashMap<String, crate::api::models::server::ServersImportConfig> = mcp_config
+        .mcp_servers
+        .into_iter()
+        .map(|(name, server_config)| {
+            (
+                name,
+                crate::api::models::server::ServersImportConfig {
+                    kind: server_config.kind.as_str().to_string(),
+                    command: server_config.command,
+                    args: server_config.args,
+                    url: server_config.url,
+                    env: server_config.env,
+                    headers: None,
+                    registry_server_id: None,
+                    meta: None,
+                },
+            )
+        })
+        .collect();
+
+    let dummy_pool = Arc::new(tokio::sync::Mutex::new(crate::core::pool::UpstreamConnectionPool::new(
+        Arc::new(Default::default()),
+        None,
+    )));
+    let _ = crate::config::server::import_batch(
+        pool,
+        &dummy_pool,
+        redb_cache,
+        items,
+        crate::config::server::ImportOptions {
+            by_name: true,
+            by_fingerprint: true,
+            conflict_policy: crate::config::server::ConflictPolicy::Skip,
+            preview: false,
+            target_profile: None,
+        },
+    )
+    .await?;
+
+    tracing::info!("Configuration import completed successfully");
+    Ok(())
+}
+
 /// Import configuration from JSON files to database
 pub async fn import_from_mcp_config(
     pool: &Pool<Sqlite>,
@@ -15,23 +75,8 @@ pub async fn import_from_mcp_config(
 ) -> Result<()> {
     tracing::info!("Importing configuration from JSON files to database");
 
-    // Check if database already has server configurations
-    let has_server_configs = match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM server_config")
-        .fetch_one(pool)
-        .await
-    {
-        Ok(count) => count > 0,
-        Err(e) => {
-            tracing::error!("Failed to check if server_config table has data: {}", e);
-            return Err(anyhow::anyhow!(
-                "Failed to check if server_config table has data: {}",
-                e
-            ));
-        }
-    };
-
     // If database already has server configurations, skip import
-    if has_server_configs {
+    if has_server_configs(pool).await? {
         tracing::info!("Database already has server configurations, skipping import");
         return Ok(());
     }
@@ -60,50 +105,26 @@ pub async fn import_from_mcp_config(
         }
     };
 
-    // Initialize Redb cache manager using global singleton
-    let redb_cache =
-        RedbCacheManager::global().map_err(|e| anyhow::anyhow!(format!("Failed to init REDB cache: {}", e)))?;
+    let redb_cache = global_redb_cache()?;
 
-    // Convert Config to ServersImportConfig map
-    let mut items: HashMap<String, crate::api::models::server::ServersImportConfig> = HashMap::new();
-    for (name, sc) in mcp_config.mcp_servers.into_iter() {
-        items.insert(
-            name,
-            crate::api::models::server::ServersImportConfig {
-                kind: sc.kind.as_str().to_string(),
-                command: sc.command,
-                args: sc.args,
-                url: sc.url,
-                env: sc.env,
-                headers: None,
-                registry_server_id: None,
-                meta: None,
-            },
-        );
+    import_config_with_cache(pool, mcp_config, &redb_cache).await
+}
+
+pub async fn import_from_mcp_config_content(
+    pool: &Pool<Sqlite>,
+    content: &str,
+) -> Result<()> {
+    tracing::info!("Importing configuration from in-memory content to database");
+
+    if has_server_configs(pool).await? {
+        tracing::info!("Database already has server configurations, skipping import");
+        return Ok(());
     }
 
-    // Use unified import core (by_name + by_fingerprint, skip on conflict)
-    let dummy_pool = Arc::new(tokio::sync::Mutex::new(crate::core::pool::UpstreamConnectionPool::new(
-        Arc::new(Default::default()),
-        None,
-    )));
-    let _ = crate::config::server::import_batch(
-        pool,
-        &dummy_pool,
-        &redb_cache,
-        items,
-        crate::config::server::ImportOptions {
-            by_name: true,
-            by_fingerprint: true,
-            conflict_policy: crate::config::server::ConflictPolicy::Skip,
-            preview: false,
-            target_profile: None,
-        },
-    )
-    .await?;
+    let mcp_config = load_mcp_config_from_str(content).context("Failed to parse in-memory MCP config")?;
+    let redb_cache = global_redb_cache()?;
 
-    tracing::info!("Configuration import completed successfully");
-    Ok(())
+    import_config_with_cache(pool, mcp_config, &redb_cache).await
 }
 
 /// Load MCP configuration from a file
@@ -117,8 +138,11 @@ fn load_mcp_config_from_file<P: AsRef<Path>>(path: P) -> Result<Config> {
     file.read_to_string(&mut content)
         .with_context(|| format!("Failed to read config file content: {}", path.as_ref().display()))?;
 
-    // Try to parse the JSON
-    match serde_json::from_str::<Config>(&content) {
+    load_mcp_config_from_str(&content)
+}
+
+fn load_mcp_config_from_str(content: &str) -> Result<Config> {
+    match serde_json::from_str::<Config>(content) {
         Ok(config) => {
             tracing::debug!("Successfully parsed config file");
             Ok(config)
@@ -127,7 +151,7 @@ fn load_mcp_config_from_file<P: AsRef<Path>>(path: P) -> Result<Config> {
             tracing::error!("Failed to parse config file: {}", e);
 
             // Try to parse as Value to get more information
-            match serde_json::from_str::<serde_json::Value>(&content) {
+            match serde_json::from_str::<serde_json::Value>(content) {
                 Ok(value) => {
                     tracing::debug!("File is valid JSON, but doesn't match Config struct: {:?}", value);
                 }
@@ -138,5 +162,64 @@ fn load_mcp_config_from_file<P: AsRef<Path>>(path: P) -> Result<Config> {
 
             Err(anyhow::anyhow!("Failed to parse config file: {}", e))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::initialization::run_initialization;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use tempfile::TempDir;
+
+    const TEST_MCP_CONFIG: &str = r#"{
+        "mcpServers": {
+            "Context7": {
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp@latest"],
+                "type": "stdio"
+            },
+            "Gitmcp": {
+                "url": "https://gitmcp.io/modelcontextprotocol/rust-sdk",
+                "type": "streamable_http"
+            }
+        }
+    }"#;
+
+    async fn create_test_pool() -> (TempDir, Pool<Sqlite>, Arc<RedbCacheManager>) {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool");
+
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .expect("enable foreign keys");
+        run_initialization(&pool).await.expect("initialize schema");
+
+        let cache = Arc::new(
+            RedbCacheManager::new(temp_dir.path().join("capability.redb"), Default::default()).expect("cache manager"),
+        );
+
+        (temp_dir, pool, cache)
+    }
+
+    #[tokio::test]
+    async fn import_from_mcp_config_content_imports_servers_without_file_path() {
+        let (_temp_dir, pool, cache) = create_test_pool().await;
+        let config = load_mcp_config_from_str(TEST_MCP_CONFIG).expect("parse config");
+
+        import_config_with_cache(&pool, config, &cache)
+            .await
+            .expect("import config");
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM server_config")
+            .fetch_one(&pool)
+            .await
+            .expect("count servers");
+        assert_eq!(count, 2);
     }
 }

--- a/backend/src/config/import.rs
+++ b/backend/src/config/import.rs
@@ -9,15 +9,18 @@ use std::collections::HashMap;
 use std::{fs::File, path::Path, sync::Arc};
 
 fn global_redb_cache() -> Result<Arc<RedbCacheManager>> {
-    RedbCacheManager::global().map_err(|error| anyhow::anyhow!(format!("Failed to init REDB cache: {}", error)))
+    RedbCacheManager::global().map_err(|error| anyhow::anyhow!("Failed to init REDB cache: {}", error))
 }
 
 async fn has_server_configs(pool: &Pool<Sqlite>) -> Result<bool> {
-    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM server_config")
-        .fetch_one(pool)
-        .await
-        .map(|count| count > 0)
-        .map_err(|error| anyhow::anyhow!("Failed to check if server_config table has data: {}", error))
+    sqlx::query_scalar::<_, i64>(&format!(
+        "SELECT COUNT(*) FROM {}",
+        crate::common::constants::database::tables::SERVER_CONFIG
+    ))
+    .fetch_one(pool)
+    .await
+    .map(|count| count > 0)
+    .map_err(|error| anyhow::anyhow!("Failed to check if server_config table has data: {}", error))
 }
 
 async fn import_config_with_cache(
@@ -216,10 +219,13 @@ mod tests {
             .await
             .expect("import config");
 
-        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM server_config")
-            .fetch_one(&pool)
-            .await
-            .expect("count servers");
+        let count: i64 = sqlx::query_scalar(&format!(
+            "SELECT COUNT(*) FROM {}",
+            crate::common::constants::database::tables::SERVER_CONFIG
+        ))
+        .fetch_one(&pool)
+        .await
+        .expect("count servers");
         assert_eq!(count, 2);
     }
 }

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -4,6 +4,7 @@
 pub mod audit_database;
 pub mod client;
 pub mod database;
+pub mod defaults;
 pub mod import;
 pub mod initialization;
 pub mod models;

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -78,6 +78,8 @@ builds the bridge sidecar, and outputs a notarized DMG to `$HOME/Downloads`.
 
 On startup the shell resolves the per-app data directory through Tauri's `PathResolver::app_data_dir()` and passes that path into MCPMate's runtime (via `MCPMATE_DATA_DIR`). This avoids REDB/SQLite contention with existing CLI instances.
 
+Both localhost runtime modes use that same base directory: service installs run with the data directory as their working directory, and desktop-managed launches now set the child process working directory explicitly as well. That keeps first-run initialization and bundled preset seeding consistent across the desktop startup paths.
+
 You can override runtime ports or modes without recompiling by exporting the following variables before launching:
 
 | Variable                  | Purpose                                      | Default   |

--- a/desktop/src-tauri/src/core_service.rs
+++ b/desktop/src-tauri/src/core_service.rs
@@ -1,14 +1,10 @@
-use std::{
-    ffi::OsString,
-    path::PathBuf,
-    time::Duration,
-};
+use std::{ffi::OsString, path::PathBuf, time::Duration};
 
 use anyhow::{Context, Result};
 use mcpmate::common::global_paths;
 use service_manager::{
-    RestartPolicy, ServiceInstallCtx, ServiceLabel, ServiceLevel, ServiceManager,
-    ServiceStartCtx, ServiceStatus, ServiceStatusCtx, ServiceStopCtx, ServiceUninstallCtx,
+    RestartPolicy, ServiceInstallCtx, ServiceLabel, ServiceLevel, ServiceManager, ServiceStartCtx,
+    ServiceStatus, ServiceStatusCtx, ServiceStopCtx, ServiceUninstallCtx,
 };
 use tauri::{AppHandle, Manager};
 
@@ -71,7 +67,8 @@ fn service_label() -> Result<ServiceLabel> {
 }
 
 fn service_manager() -> Result<Box<dyn ServiceManager>> {
-    let mut manager = <dyn ServiceManager>::native().context("failed to create native service manager")?;
+    let mut manager =
+        <dyn ServiceManager>::native().context("failed to create native service manager")?;
     manager
         .set_level(resolve_service_level())
         .context("failed to configure service manager level")?;
@@ -82,7 +79,13 @@ pub fn resolve_local_core_binary(app: &AppHandle) -> Result<PathBuf> {
     let exe_suffix = std::env::consts::EXE_SUFFIX;
     let target = std::env::var("TAURI_ENV_TARGET_TRIPLE")
         .or_else(|_| std::env::var("TARGET"))
-        .unwrap_or_else(|_| format!("{}-unknown-{}", std::env::consts::ARCH, std::env::consts::OS));
+        .unwrap_or_else(|_| {
+            format!(
+                "{}-unknown-{}",
+                std::env::consts::ARCH,
+                std::env::consts::OS
+            )
+        });
     let mut candidates: Vec<PathBuf> = Vec::new();
 
     // For release builds, check MacOS directory first (where Tauri bundles sidecars)
@@ -138,45 +141,70 @@ pub async fn install_local_service(
     read_local_service_status(config).await
 }
 
-pub fn uninstall_local_service(_config: &DesktopCoreSourceConfig) -> Result<LocalCoreServiceStatusView> {
-	let status = {
-		let manager = service_manager()?;
-		manager.status(ServiceStatusCtx { label: service_label()? })?
-	};
+pub fn uninstall_local_service(
+    _config: &DesktopCoreSourceConfig,
+) -> Result<LocalCoreServiceStatusView> {
+    let status = {
+        let manager = service_manager()?;
+        manager.status(ServiceStatusCtx {
+            label: service_label()?,
+        })?
+    };
 
-	if matches!(status, ServiceStatus::NotInstalled) {
-		return Ok(LocalCoreServiceStatusView {
-			status: LocalCoreServiceStatusKind::NotInstalled,
-			label: "Not Installed".to_string(),
-			detail: "The localhost core service has not been installed yet.".to_string(),
-			level: level_label(resolve_service_level()),
-			installed: false,
-			running: false,
-		});
-	}
+    if matches!(status, ServiceStatus::NotInstalled) {
+        return Ok(LocalCoreServiceStatusView {
+            status: LocalCoreServiceStatusKind::NotInstalled,
+            label: "Not Installed".to_string(),
+            detail: "The localhost core service has not been installed yet.".to_string(),
+            level: level_label(resolve_service_level()),
+            installed: false,
+            running: false,
+        });
+    }
 
-	{
-		let manager = service_manager()?;
-		let _ = manager.stop(ServiceStopCtx { label: service_label()? });
-		manager
-			.uninstall(ServiceUninstallCtx { label: service_label()? })
-			.context("failed to uninstall local core service")?;
-	}
+    {
+        let manager = service_manager()?;
+        let _ = manager.stop(ServiceStopCtx {
+            label: service_label()?,
+        });
+        manager
+            .uninstall(ServiceUninstallCtx {
+                label: service_label()?,
+            })
+            .context("failed to uninstall local core service")?;
+    }
 
-	Ok(LocalCoreServiceStatusView {
-		status: LocalCoreServiceStatusKind::NotInstalled,
-		label: "Not Installed".to_string(),
-		detail: "The localhost core service was removed from the OS service manager.".to_string(),
-		level: level_label(resolve_service_level()),
-		installed: false,
-		running: false,
-	})
+    Ok(LocalCoreServiceStatusView {
+        status: LocalCoreServiceStatusKind::NotInstalled,
+        label: "Not Installed".to_string(),
+        detail: "The localhost core service was removed from the OS service manager.".to_string(),
+        level: level_label(resolve_service_level()),
+        installed: false,
+        running: false,
+    })
 }
 
-fn service_install_ctx(app: &AppHandle, config: &DesktopCoreSourceConfig) -> Result<ServiceInstallCtx> {
+fn service_install_ctx(
+    app: &AppHandle,
+    config: &DesktopCoreSourceConfig,
+) -> Result<ServiceInstallCtx> {
     let base_dir = global_paths().base_dir().to_path_buf();
     let label = service_label()?;
     let program = resolve_local_core_binary(app)?;
+    let environment = crate::runtime_env::merge_service_environment(vec![
+        (
+            "MCPMATE_DATA_DIR".to_string(),
+            base_dir.display().to_string(),
+        ),
+        (
+            "MCPMATE_API_PORT".to_string(),
+            config.localhost.api_port.to_string(),
+        ),
+        (
+            "MCPMATE_MCP_PORT".to_string(),
+            config.localhost.mcp_port.to_string(),
+        ),
+    ]);
 
     Ok(ServiceInstallCtx {
         label,
@@ -198,17 +226,7 @@ fn service_install_ctx(app: &AppHandle, config: &DesktopCoreSourceConfig) -> Res
         contents: None,
         username: None,
         working_directory: Some(base_dir.clone()),
-        environment: Some(vec![
-            ("MCPMATE_DATA_DIR".to_string(), base_dir.display().to_string()),
-            (
-                "MCPMATE_API_PORT".to_string(),
-                config.localhost.api_port.to_string(),
-            ),
-            (
-                "MCPMATE_MCP_PORT".to_string(),
-                config.localhost.mcp_port.to_string(),
-            ),
-        ]),
+        environment: Some(environment),
         autostart: true,
         restart_policy: RestartPolicy::OnFailure {
             delay_secs: Some(5),
@@ -279,7 +297,9 @@ pub async fn wait_for_port_available(port: u16) -> Result<()> {
     anyhow::bail!("Port {} did not become available after 15 seconds", port)
 }
 
-pub async fn read_local_service_status(config: &DesktopCoreSourceConfig) -> Result<LocalCoreServiceStatusView> {
+pub async fn read_local_service_status(
+    config: &DesktopCoreSourceConfig,
+) -> Result<LocalCoreServiceStatusView> {
     let (level, status) = {
         let manager = service_manager()?;
         let level = level_label(manager.level());
@@ -303,7 +323,9 @@ pub async fn read_local_service_status(config: &DesktopCoreSourceConfig) -> Resu
         ServiceStatus::Stopped(reason) => LocalCoreServiceStatusView {
             status: LocalCoreServiceStatusKind::Stopped,
             label: "Stopped".to_string(),
-            detail: reason.unwrap_or_else(|| "The localhost core service is installed but not running.".to_string()),
+            detail: reason.unwrap_or_else(|| {
+                "The localhost core service is installed but not running.".to_string()
+            }),
             level,
             installed: true,
             running: false,
@@ -313,7 +335,9 @@ pub async fn read_local_service_status(config: &DesktopCoreSourceConfig) -> Resu
                 LocalCoreServiceStatusView {
                     status: LocalCoreServiceStatusKind::Running,
                     label: "Running".to_string(),
-                    detail: "The localhost core service is running and responding to health checks.".to_string(),
+                    detail:
+                        "The localhost core service is running and responding to health checks."
+                            .to_string(),
                     level,
                     installed: true,
                     running: true,
@@ -334,9 +358,14 @@ pub async fn read_local_service_status(config: &DesktopCoreSourceConfig) -> Resu
     Ok(view)
 }
 
-pub fn ensure_local_service_definition(app: &AppHandle, config: &DesktopCoreSourceConfig) -> Result<()> {
+pub fn ensure_local_service_definition(
+    app: &AppHandle,
+    config: &DesktopCoreSourceConfig,
+) -> Result<()> {
     let manager = service_manager()?;
-    let status = manager.status(ServiceStatusCtx { label: service_label()? })?;
+    let status = manager.status(ServiceStatusCtx {
+        label: service_label()?,
+    })?;
     let install_ctx = service_install_ctx(app, config)?;
 
     if !matches!(status, ServiceStatus::NotInstalled) {
@@ -357,7 +386,10 @@ pub fn ensure_local_service_definition(app: &AppHandle, config: &DesktopCoreSour
     Ok(())
 }
 
-pub async fn start_local_service(app: &AppHandle, config: &DesktopCoreSourceConfig) -> Result<LocalCoreServiceStatusView> {
+pub async fn start_local_service(
+    app: &AppHandle,
+    config: &DesktopCoreSourceConfig,
+) -> Result<LocalCoreServiceStatusView> {
     ensure_local_service_definition(app, config)?;
     {
         let manager = service_manager()?;
@@ -371,7 +403,10 @@ pub async fn start_local_service(app: &AppHandle, config: &DesktopCoreSourceConf
     read_local_service_status(config).await
 }
 
-pub async fn restart_local_service(app: &AppHandle, config: &DesktopCoreSourceConfig) -> Result<LocalCoreServiceStatusView> {
+pub async fn restart_local_service(
+    app: &AppHandle,
+    config: &DesktopCoreSourceConfig,
+) -> Result<LocalCoreServiceStatusView> {
     ensure_local_service_definition(app, config)?;
     {
         let manager = service_manager()?;
@@ -388,15 +423,22 @@ pub async fn restart_local_service(app: &AppHandle, config: &DesktopCoreSourceCo
     read_local_service_status(config).await
 }
 
-pub async fn stop_local_service(config: &DesktopCoreSourceConfig) -> Result<LocalCoreServiceStatusView> {
+pub async fn stop_local_service(
+    config: &DesktopCoreSourceConfig,
+) -> Result<LocalCoreServiceStatusView> {
     let label = service_label()?;
 
     let status = {
         let manager = service_manager()?;
-        manager.status(ServiceStatusCtx { label: label.clone() })?
+        manager.status(ServiceStatusCtx {
+            label: label.clone(),
+        })?
     };
 
-    if matches!(status, ServiceStatus::NotInstalled | ServiceStatus::Stopped(_)) {
+    if matches!(
+        status,
+        ServiceStatus::NotInstalled | ServiceStatus::Stopped(_)
+    ) {
         return read_local_service_status(config).await;
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod audit;
 mod core_service;
 mod deep_link;
 mod oauth_callback_access;
+mod runtime_env;
 mod runtime_ports;
 mod shell;
 mod source_config;
@@ -1016,96 +1017,7 @@ fn mcp_oauth_open_authorization_url(
 }
 
 fn configure_tauri_environment() {
-    const SKIP_BOARD_STATIC: &str = "MCPMATE_SKIP_BOARD_STATIC";
-
-    if std::env::var_os(SKIP_BOARD_STATIC).is_none() {
-        unsafe {
-            std::env::set_var(SKIP_BOARD_STATIC, "1");
-        }
-    }
-
-    // macOS packaged apps often inherit a minimal PATH when launched from Finder,
-    // which breaks spawning of developer runtimes (bunx/npx/python) from the backend.
-    // To make debug builds work out of the box, we: (1) ensure absolute shims for
-    // common commands under ~/.mcpmate/bin, (2) prepend that bin plus typical Homebrew
-    // locations to PATH.
-    #[cfg(target_os = "macos")]
-    {
-        use std::{fs, io::Write, os::unix::fs::PermissionsExt, path::PathBuf};
-
-        // Resolve MCPMate base dir the same way backend does by default
-        let base_dir = match MCPMatePaths::new() {
-            Ok(p) => p.base_dir().to_path_buf(),
-            Err(_) => {
-                let home = std::env::var("HOME").unwrap_or_else(|_| String::from("/"));
-                PathBuf::from(home).join(".mcpmate")
-            }
-        };
-
-        // Prepare ~/.mcpmate/bin and ~/.mcpmate/runtimes/* helper dirs
-        let bin_dir = base_dir.join("bin");
-        let _ = fs::create_dir_all(&bin_dir);
-
-        let bunx_path = base_dir.join("runtimes").join("bun").join("bunx");
-
-        // Write a tiny shim for `npx` that prefers our managed bunx, then falls back to system npx
-        let npx_shim = bin_dir.join("npx");
-        if !npx_shim.exists() {
-            let mut f = fs::File::create(&npx_shim).ok();
-            if let Some(mut file) = f.take() {
-                let script = format!(
-                    "#!/bin/sh\nset -e\nBUNX=\"{}\"\nif [ -x \"$BUNX\" ]; then exec \"$BUNX\" \"$@\"; fi\n# fallback to system npx if present\nif command -v npx >/dev/null 2>&1; then exec \"$(command -v npx)\" \"$@\"; fi\necho 'npx is unavailable (no bunx in ~/.mcpmate/runtimes and npx not found in PATH)' 1>&2\nexit 127\n",
-                    bunx_path.display()
-                );
-                let _ = file.write_all(script.as_bytes());
-                let _ = fs::set_permissions(&npx_shim, fs::Permissions::from_mode(0o755));
-            }
-        }
-
-        // Provide a conservative Python shim that prefers the system interpreter
-        let python3_candidates = [
-            "/usr/bin/python3",
-            "/opt/homebrew/bin/python3",
-            "/usr/local/bin/python3",
-        ];
-        let py_shim_paths = [bin_dir.join("python3"), bin_dir.join("python")];
-        for shim in &py_shim_paths {
-            if !shim.exists()
-                && let Ok(mut file) = fs::File::create(shim)
-            {
-                let mut found = None;
-                for c in &python3_candidates {
-                    if std::path::Path::new(c).exists() {
-                        found = Some(*c);
-                        break;
-                    }
-                }
-                let body = if let Some(p) = found {
-                    format!("#!/bin/sh\nexec \"{}\" \"$@\"\n", p)
-                } else {
-                    "#!/bin/sh\nexec /usr/bin/env python3 \"$@\"\n".to_string()
-                };
-                let _ = file.write_all(body.as_bytes());
-                let _ = fs::set_permissions(shim, fs::Permissions::from_mode(0o755));
-            }
-        }
-
-        // Compose PATH: ~/.mcpmate/bin + runtimes + common Homebrew prefixes + existing PATH
-        let mut extra_paths: Vec<String> = vec![
-            bin_dir.display().to_string(),
-            base_dir.join("runtimes").join("bun").display().to_string(),
-            base_dir.join("runtimes").join("uv").display().to_string(),
-            "/opt/homebrew/bin".into(),
-            "/usr/local/bin".into(),
-        ];
-        if let Ok(current) = std::env::var("PATH") {
-            extra_paths.push(current);
-        }
-        let new_path = extra_paths.join(":");
-        unsafe {
-            std::env::set_var("PATH", new_path);
-        }
-    }
+    runtime_env::configure_process_environment();
 }
 
 fn initialize_menu(app: &mut tauri::App) -> Result<()> {
@@ -1291,6 +1203,7 @@ fn spawn_desktop_managed_core(
     config: &DesktopCoreSourceConfig,
 ) -> Result<Child> {
     let binary = resolve_local_core_binary(app)?;
+    let base_dir = global_paths().base_dir().to_path_buf();
     let mut command = Command::new(binary);
     command
         .arg("--api-port")
@@ -1300,7 +1213,8 @@ fn spawn_desktop_managed_core(
         .arg("--log-level")
         .arg("info")
         .stdin(Stdio::null())
-        .env("MCPMATE_DATA_DIR", global_paths().base_dir())
+        .current_dir(&base_dir)
+        .env("MCPMATE_DATA_DIR", &base_dir)
         .env("MCPMATE_API_PORT", config.localhost.api_port.to_string())
         .env("MCPMATE_MCP_PORT", config.localhost.mcp_port.to_string());
     configure_desktop_managed_stdio(&mut command);

--- a/desktop/src-tauri/src/runtime_env.rs
+++ b/desktop/src-tauri/src/runtime_env.rs
@@ -1,0 +1,170 @@
+use std::{collections::BTreeMap, env, fs, io::Write, path::PathBuf};
+
+use anyhow::Result;
+use mcpmate::common::MCPMatePaths;
+
+pub fn configure_process_environment() {
+    const SKIP_BOARD_STATIC: &str = "MCPMATE_SKIP_BOARD_STATIC";
+
+    if env::var_os(SKIP_BOARD_STATIC).is_none() {
+        unsafe {
+            env::set_var(SKIP_BOARD_STATIC, "1");
+        }
+    }
+
+    for (key, value) in desktop_runtime_environment() {
+        unsafe {
+            env::set_var(key, value);
+        }
+    }
+}
+
+pub fn service_environment_entries() -> Vec<(String, String)> {
+    desktop_runtime_environment().into_iter().collect()
+}
+
+pub fn merge_service_environment(mut base: Vec<(String, String)>) -> Vec<(String, String)> {
+    base.extend(service_environment_entries());
+    base
+}
+
+fn desktop_runtime_environment() -> BTreeMap<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut env_entries = BTreeMap::new();
+        if let Ok(path) = ensure_desktop_runtime_path() {
+            env_entries.insert("PATH".to_string(), path);
+        }
+
+        if let Ok(home) = env::var("HOME") {
+            if !home.trim().is_empty() {
+                env_entries.insert("HOME".to_string(), home);
+            }
+        }
+
+        return env_entries;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        BTreeMap::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_desktop_runtime_path() -> Result<String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let base_dir = resolve_base_dir();
+    let bin_dir = base_dir.join("bin");
+    fs::create_dir_all(&bin_dir)?;
+
+    let bunx_path = base_dir.join("runtimes").join("bun").join("bunx");
+
+    let npx_shim = bin_dir.join("npx");
+    ensure_executable_shim(
+        &npx_shim,
+        &format!(
+            "#!/bin/sh\nset -e\nBUNX=\"{}\"\nif [ -x \"$BUNX\" ]; then exec \"$BUNX\" \"$@\"; fi\nif command -v npx >/dev/null 2>&1; then exec \"$(command -v npx)\" \"$@\"; fi\necho 'npx is unavailable (no bunx in ~/.mcpmate/runtimes and npx not found in PATH)' 1>&2\nexit 127\n",
+            bunx_path.display()
+        ),
+    )?;
+
+    let python3_candidates = [
+        "/usr/bin/python3",
+        "/opt/homebrew/bin/python3",
+        "/usr/local/bin/python3",
+    ];
+    let py_shim_paths = [bin_dir.join("python3"), bin_dir.join("python")];
+    for shim in &py_shim_paths {
+        let found = python3_candidates
+            .iter()
+            .find(|candidate| std::path::Path::new(candidate).exists());
+        let body = if let Some(path) = found {
+            format!("#!/bin/sh\nexec \"{}\" \"$@\"\n", path)
+        } else {
+            "#!/bin/sh\nexec /usr/bin/env python3 \"$@\"\n".to_string()
+        };
+        ensure_executable_shim(shim, &body)?;
+    }
+
+    let mut extra_paths: Vec<String> = vec![
+        bin_dir.display().to_string(),
+        base_dir.join("runtimes").join("bun").display().to_string(),
+        base_dir.join("runtimes").join("uv").display().to_string(),
+        "/opt/homebrew/bin".into(),
+        "/usr/local/bin".into(),
+    ];
+    if let Ok(current) = env::var("PATH") {
+        extra_paths.push(current);
+    }
+
+    Ok(extra_paths.join(":"))
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_executable_shim(path: &std::path::Path, body: &str) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if path.exists() {
+        return Ok(());
+    }
+
+    let mut file = fs::File::create(path)?;
+    file.write_all(body.as_bytes())?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_base_dir() -> PathBuf {
+    match MCPMatePaths::new() {
+        Ok(paths) => paths.base_dir().to_path_buf(),
+        Err(_) => {
+            let home = env::var("HOME").unwrap_or_else(|_| String::from("/"));
+            PathBuf::from(home).join(".mcpmate")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_service_environment_preserves_base_entries() {
+        let env = merge_service_environment(vec![
+            ("MCPMATE_DATA_DIR".to_string(), "/tmp/mcpmate".to_string()),
+            ("MCPMATE_API_PORT".to_string(), "8080".to_string()),
+        ]);
+
+        assert!(
+            env.iter()
+                .any(|(key, value)| key == "MCPMATE_DATA_DIR" && value == "/tmp/mcpmate")
+        );
+        assert!(
+            env.iter()
+                .any(|(key, value)| key == "MCPMATE_API_PORT" && value == "8080")
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn service_environment_includes_path_on_macos() {
+        let env = service_environment_entries();
+        let path = env
+            .iter()
+            .find(|(key, _)| key == "PATH")
+            .map(|(_, value)| value.clone())
+            .expect("PATH entry");
+
+        assert!(path.contains(".mcpmate/bin"));
+        assert!(path.contains("/opt/homebrew/bin") || path.contains("/usr/local/bin"));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn service_environment_is_empty_off_macos() {
+        assert!(service_environment_entries().is_empty());
+    }
+}

--- a/desktop/src-tauri/src/runtime_env.rs
+++ b/desktop/src-tauri/src/runtime_env.rs
@@ -23,9 +23,14 @@ pub fn service_environment_entries() -> Vec<(String, String)> {
     desktop_runtime_environment().into_iter().collect()
 }
 
-pub fn merge_service_environment(mut base: Vec<(String, String)>) -> Vec<(String, String)> {
-    base.extend(service_environment_entries());
-    base
+pub fn merge_service_environment(base: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut merged: BTreeMap<String, String> = base.into_iter().collect();
+
+    for (key, value) in service_environment_entries() {
+        merged.insert(key, value);
+    }
+
+    merged.into_iter().collect()
 }
 
 fn desktop_runtime_environment() -> BTreeMap<String, String> {
@@ -53,20 +58,20 @@ fn desktop_runtime_environment() -> BTreeMap<String, String> {
 
 #[cfg(target_os = "macos")]
 fn ensure_desktop_runtime_path() -> Result<String> {
-    use std::os::unix::fs::PermissionsExt;
-
     let base_dir = resolve_base_dir();
     let bin_dir = base_dir.join("bin");
     fs::create_dir_all(&bin_dir)?;
 
-    let bunx_path = base_dir.join("runtimes").join("bun").join("bunx");
+    let bun_runtime_dir = base_dir.join("runtimes").join("bun");
+    let bunx_path = bun_runtime_dir.join("bunx");
 
     let npx_shim = bin_dir.join("npx");
     ensure_executable_shim(
         &npx_shim,
         &format!(
-            "#!/bin/sh\nset -e\nBUNX=\"{}\"\nif [ -x \"$BUNX\" ]; then exec \"$BUNX\" \"$@\"; fi\nif command -v npx >/dev/null 2>&1; then exec \"$(command -v npx)\" \"$@\"; fi\necho 'npx is unavailable (no bunx in ~/.mcpmate/runtimes and npx not found in PATH)' 1>&2\nexit 127\n",
-            bunx_path.display()
+            "#!/bin/sh\nset -e\nBUNX=\"{}\"\nif [ -x \"$BUNX\" ]; then exec \"$BUNX\" \"$@\"; fi\nif command -v npx >/dev/null 2>&1; then exec \"$(command -v npx)\" \"$@\"; fi\necho 'npx is unavailable (no bunx in {} and npx not found in PATH)' 1>&2\nexit 127\n",
+            bunx_path.display(),
+            bun_runtime_dir.display()
         ),
     )?;
 
@@ -145,6 +150,20 @@ mod tests {
         assert!(
             env.iter()
                 .any(|(key, value)| key == "MCPMATE_API_PORT" && value == "8080")
+        );
+    }
+
+    #[test]
+    fn merge_service_environment_deduplicates_base_keys() {
+        let env = merge_service_environment(vec![
+            ("MCPMATE_DATA_DIR".to_string(), "/tmp/mcpmate".to_string()),
+            ("PATH".to_string(), "/tmp/bin".to_string()),
+        ]);
+
+        assert_eq!(env.iter().filter(|(key, _)| key == "PATH").count(), 1);
+        assert!(
+            env.iter()
+                .any(|(key, value)| key == "MCPMATE_DATA_DIR" && value == "/tmp/mcpmate")
         );
     }
 


### PR DESCRIPTION
## Summary
- bundle the default MCP preset so first-run server seeding no longer depends on the current working directory
- align desktop Service mode with DesktopManaged runtime environment setup so managed stdio servers can refresh capabilities consistently
- document the bundled preset and localhost runtime path behavior in backend and desktop READMEs

## Validation
- cargo test import_from_mcp_config_content_imports_servers_without_file_path -- --nocapture
- cargo test runtime_env -- --nocapture
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings