### PR TITLE
fix(clients): tighten runtime target validation

### DIFF
--- a/backend/src/api/handlers/client/approval.rs
+++ b/backend/src/api/handlers/client/approval.rs
@@ -13,13 +13,10 @@ pub async fn approve_client(
 ) -> Result<Json<ApprovalResponse>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let (status, managed) = service
-        .approve_client(&request.identifier)
-        .await
-        .map_err(|err| {
-            tracing::error!("Failed to approve client {}: {}", request.identifier, err);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let (status, managed) = service.approve_client(&request.identifier).await.map_err(|err| {
+        tracing::error!("Failed to approve client {}: {}", request.identifier, err);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     crate::audit::interceptor::emit_event(
         app_state.audit_service.as_ref(),
@@ -45,13 +42,10 @@ pub async fn reject_client(
 ) -> Result<Json<ApprovalResponse>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let (status, managed) = service
-        .reject_client(&request.identifier)
-        .await
-        .map_err(|err| {
-            tracing::error!("Failed to reject client {}: {}", request.identifier, err);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let (status, managed) = service.reject_client(&request.identifier).await.map_err(|err| {
+        tracing::error!("Failed to reject client {}: {}", request.identifier, err);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     crate::audit::interceptor::emit_event(
         app_state.audit_service.as_ref(),
@@ -77,13 +71,10 @@ pub async fn suspend_client(
 ) -> Result<Json<ApprovalResponse>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let (status, managed) = service
-        .suspend_client(&request.identifier)
-        .await
-        .map_err(|err| {
-            tracing::error!("Failed to suspend client {}: {}", request.identifier, err);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let (status, managed) = service.suspend_client(&request.identifier).await.map_err(|err| {
+        tracing::error!("Failed to suspend client {}: {}", request.identifier, err);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     crate::audit::interceptor::emit_event(
         app_state.audit_service.as_ref(),

--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -32,7 +32,10 @@ use toml;
 
 type ClientSettingsErrorResponse = (StatusCode, Json<crate::api::models::client::ClientSettingsUpdateResp>);
 
-fn client_settings_error(status: StatusCode, message: impl Into<String>) -> ClientSettingsErrorResponse {
+fn client_settings_error(
+    status: StatusCode,
+    message: impl Into<String>,
+) -> ClientSettingsErrorResponse {
     (
         status,
         Json(crate::api::models::client::ClientSettingsUpdateResp::error_simple(
@@ -328,7 +331,7 @@ pub async fn config_apply(
                 })?;
         }
     }
-    
+
     let template = service.get_client_template(&request.identifier).await.map_err(|err| {
         tracing::error!(
             client = %request.identifier,
@@ -337,7 +340,7 @@ pub async fn config_apply(
         );
         StatusCode::NOT_FOUND
     })?;
-    
+
     let options = build_render_options(&request);
     let outcome = service.apply_with_deferred(options).await.map_err(|err| {
         let status = match err {
@@ -426,7 +429,7 @@ pub async fn config_restore(
     Json(request): Json<ClientConfigRestoreReq>,
 ) -> Result<Json<ClientBackupActionResp>, StatusCode> {
     let service = get_client_service(&app_state)?;
-    
+
     if let Ok(Some(state)) = service.fetch_state(&request.identifier).await {
         if state.is_pending_unknown() {
             tracing::warn!(
@@ -449,7 +452,7 @@ pub async fn config_restore(
             tracing::error!(client = %request.identifier, error = %err, "Failed to activate client state before restore");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
-    
+
     let result = service
         .restore_backup(&request.identifier, &request.backup)
         .await
@@ -661,8 +664,8 @@ pub async fn update_settings(
     State(app_state): State<Arc<AppState>>,
     Json(request): Json<crate::api::models::client::ClientSettingsUpdateReq>,
 ) -> Result<Json<crate::api::models::client::ClientSettingsUpdateResp>, ClientSettingsErrorResponse> {
-    let service = get_client_service(&app_state)
-        .map_err(|status| client_settings_error(status, "Client service unavailable"))?;
+    let service =
+        get_client_service(&app_state).map_err(|status| client_settings_error(status, "Client service unavailable"))?;
 
     tracing::info!(
         client = %request.identifier,
@@ -1141,20 +1144,27 @@ fn parse_config_value(
     }
 }
 
-fn parse_runtime_config_value(content: &str, config_path: Option<&str>) -> Value {
+fn parse_runtime_config_value(
+    content: &str,
+    config_path: Option<&str>,
+) -> Value {
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return Value::Null;
     }
 
     match infer_template_format_from_path(config_path) {
-        Some(TemplateFormat::Json) => serde_json::from_str(trimmed).unwrap_or_else(|_| Value::String(content.to_string())),
+        Some(TemplateFormat::Json) => {
+            serde_json::from_str(trimmed).unwrap_or_else(|_| Value::String(content.to_string()))
+        }
         Some(TemplateFormat::Json5) => json5::from_str(trimmed).unwrap_or_else(|_| Value::String(content.to_string())),
         Some(TemplateFormat::Toml) => toml::from_str::<toml::Value>(trimmed)
             .ok()
             .and_then(|value| serde_json::to_value(value).ok())
             .unwrap_or_else(|| Value::String(content.to_string())),
-        Some(TemplateFormat::Yaml) => serde_yaml::from_str(trimmed).unwrap_or_else(|_| Value::String(content.to_string())),
+        Some(TemplateFormat::Yaml) => {
+            serde_yaml::from_str(trimmed).unwrap_or_else(|_| Value::String(content.to_string()))
+        }
         None => Value::String(content.to_string()),
     }
 }
@@ -1175,8 +1185,7 @@ fn infer_template_format_from_path(config_path: Option<&str>) -> Option<Template
 }
 
 fn infer_config_type_from_path(config_path: Option<&str>) -> Option<crate::api::models::client::ClientConfigType> {
-    infer_template_format_from_path(config_path)
-        .map(|_| crate::api::models::client::ClientConfigType::Standard)
+    infer_template_format_from_path(config_path).map(|_| crate::api::models::client::ClientConfigType::Standard)
 }
 
 async fn read_runtime_config(
@@ -1318,9 +1327,8 @@ mod tests {
         ClientConfigService::seed_client_runtime_rows(&db_pool, template_source.as_ref())
             .await
             .expect("seed runtime rows");
-        let runtime_source: Arc<dyn ClientConfigSource> = Arc::new(
-            DbTemplateSource::new(Arc::new(db_pool.clone())).expect("runtime source"),
-        );
+        let runtime_source: Arc<dyn ClientConfigSource> =
+            Arc::new(DbTemplateSource::new(Arc::new(db_pool.clone())).expect("runtime source"));
         let client_service = Arc::new(
             ClientConfigService::with_source(Arc::new(db_pool.clone()), runtime_source)
                 .await
@@ -1499,7 +1507,10 @@ mod tests {
         let data = response.data.expect("response data");
         assert_eq!(data.display_name, "Custom Runtime");
         assert_eq!(data.connection_mode.as_deref(), Some("local_config_detected"));
-        assert_eq!(data.supported_transports, vec!["streamable_http".to_string(), "stdio".to_string()]);
+        assert_eq!(
+            data.supported_transports,
+            vec!["streamable_http".to_string(), "stdio".to_string()]
+        );
         assert_eq!(data.description.as_deref(), Some("Custom runtime client"));
 
         let state = context
@@ -1527,12 +1538,20 @@ mod tests {
         assert_eq!(runtime_template.identifier, "custom.runtime.payload");
         assert_eq!(runtime_template.display_name.as_deref(), Some("Custom Runtime"));
         assert_eq!(runtime_template.version.as_deref(), Some("1.2.3"));
-        assert_eq!(runtime_template.config_mapping.container_keys, vec!["mcpServers".to_string()]);
+        assert_eq!(
+            runtime_template.config_mapping.container_keys,
+            vec!["mcpServers".to_string()]
+        );
         assert_eq!(
             runtime_template.config_mapping.managed_source.as_deref(),
             Some("runtime_active_client")
         );
-        assert!(runtime_template.config_mapping.format_rules.contains_key("streamable_http"));
+        assert!(
+            runtime_template
+                .config_mapping
+                .format_rules
+                .contains_key("streamable_http")
+        );
         assert!(runtime_template.config_mapping.format_rules.contains_key("stdio"));
         assert_eq!(
             metadata_string(&runtime_template, "homepage_url").as_deref(),
@@ -1636,9 +1655,7 @@ mod tests {
     async fn update_settings_clears_config_path_when_switching_to_manual() {
         let context = create_test_context().await;
         let config_path = context._temp_dir.path().join("client-manual-clear.json");
-        tokio::fs::write(&config_path, "{}")
-            .await
-            .expect("seed config file");
+        tokio::fs::write(&config_path, "{}").await.expect("seed config file");
 
         let Json(initial_response) = update_settings(
             State(context.app_state.clone()),
@@ -1750,9 +1767,7 @@ mod tests {
     async fn update_settings_accepts_directory_target_for_kv_client() {
         let context = create_test_context().await;
         let kv_dir = context._temp_dir.path().join("cherry-kv");
-        tokio::fs::create_dir_all(&kv_dir)
-            .await
-            .expect("create kv directory");
+        tokio::fs::create_dir_all(&kv_dir).await.expect("create kv directory");
 
         let Json(response) = update_settings(
             State(context.app_state.clone()),
@@ -1912,7 +1927,10 @@ mod tests {
         assert!(details_response.success);
         let details = details_response.data.expect("details data");
         assert!(details.config_exists);
-        assert_eq!(details.template.managed_source.as_deref(), Some("runtime_active_client"));
+        assert_eq!(
+            details.template.managed_source.as_deref(),
+            Some("runtime_active_client")
+        );
         assert_eq!(details.content["mcpServers"]["MCPMate"]["type"], "streamable_http");
     }
 

--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -1712,6 +1712,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_settings_infers_manual_when_config_path_is_explicitly_cleared() {
+        let context = create_test_context().await;
+        let config_path = context._temp_dir.path().join("client-manual-empty-string.json");
+        tokio::fs::write(&config_path, "{}")
+            .await
+            .expect("seed config file");
+
+        let Json(initial_response) = update_settings(
+            State(context.app_state.clone()),
+            Json(crate::api::models::client::ClientSettingsUpdateReq {
+                identifier: "custom.runtime.empty-clear".to_string(),
+                config_mode: Some("hosted".to_string()),
+                transport: Some("streamable_http".to_string()),
+                client_version: None,
+                display_name: Some("Empty Clear Runtime".to_string()),
+                connection_mode: Some("local_config_detected".to_string()),
+                config_path: Some(config_path.to_string_lossy().to_string()),
+                supported_transports: Some(vec!["streamable_http".to_string()]),
+                description: None,
+                homepage_url: None,
+                docs_url: None,
+                support_url: None,
+                logo_url: None,
+            }),
+        )
+        .await
+        .expect("initial update succeeds");
+        assert!(initial_response.success);
+
+        let Json(clear_response) = update_settings(
+            State(context.app_state.clone()),
+            Json(crate::api::models::client::ClientSettingsUpdateReq {
+                identifier: "custom.runtime.empty-clear".to_string(),
+                config_mode: Some("hosted".to_string()),
+                transport: Some("streamable_http".to_string()),
+                client_version: None,
+                display_name: Some("Empty Clear Runtime".to_string()),
+                connection_mode: None,
+                config_path: Some("   ".to_string()),
+                supported_transports: Some(vec!["streamable_http".to_string()]),
+                description: None,
+                homepage_url: None,
+                docs_url: None,
+                support_url: None,
+                logo_url: None,
+            }),
+        )
+        .await
+        .expect("explicit empty config path update succeeds");
+        assert!(clear_response.success);
+
+        let state = context
+            .client_service
+            .fetch_state("custom.runtime.empty-clear")
+            .await
+            .expect("fetch state")
+            .expect("state exists");
+        assert_eq!(state.connection_mode().as_str(), "manual");
+        assert_eq!(state.config_path(), None);
+    }
+
+    #[tokio::test]
     async fn config_details_and_apply_reject_stale_missing_config_target() {
         let context = create_test_context().await;
 

--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -1856,6 +1856,50 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
+    async fn update_settings_rejects_non_writable_directory_target() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let context = create_test_context().await;
+        let kv_dir = context._temp_dir.path().join("read-only-kv");
+        tokio::fs::create_dir_all(&kv_dir).await.expect("create kv directory");
+
+        let original_permissions = std::fs::metadata(&kv_dir)
+            .expect("directory metadata")
+            .permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_mode(0o555);
+        std::fs::set_permissions(&kv_dir, read_only_permissions).expect("set read-only permissions");
+
+        let result = update_settings(
+            State(context.app_state.clone()),
+            Json(crate::api::models::client::ClientSettingsUpdateReq {
+                identifier: "cherry_studio".to_string(),
+                config_mode: Some("hosted".to_string()),
+                transport: Some("streamable_http".to_string()),
+                client_version: None,
+                display_name: Some("Cherry Studio".to_string()),
+                connection_mode: Some("local_config_detected".to_string()),
+                config_path: Some(kv_dir.to_string_lossy().to_string()),
+                supported_transports: Some(vec!["streamable_http".to_string()]),
+                description: None,
+                homepage_url: None,
+                docs_url: None,
+                support_url: None,
+                logo_url: None,
+            }),
+        )
+        .await;
+
+        std::fs::set_permissions(&kv_dir, original_permissions).expect("restore permissions");
+
+        let (status, Json(response)) = result.expect_err("read-only directory target should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let error = response.error.expect("error payload");
+        assert!(error.message.contains("not writable"));
+    }
+
+    #[tokio::test]
     async fn update_settings_preserves_suspended_governance_state() {
         let context = create_test_context().await;
         let config_path = context._temp_dir.path().join("suspended-client.json");

--- a/backend/src/api/models/client.rs
+++ b/backend/src/api/models/client.rs
@@ -846,7 +846,9 @@ pub struct OnboardingPolicyResponse {
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(description = "First contact behavior update request")]
 pub struct FirstContactBehaviorRequest {
-    #[schemars(description = "Behavior: deny, review, or allow (legacy pending_review / allow_then_review accepted as review)")]
+    #[schemars(
+        description = "Behavior: deny, review, or allow (legacy pending_review / allow_then_review accepted as review)"
+    )]
     pub behavior: String,
 }
 

--- a/backend/src/clients/service/core.rs
+++ b/backend/src/clients/service/core.rs
@@ -7,13 +7,13 @@ use crate::clients::models::{
     ClientTemplate, ConfigMapping, ConfigMode, DetectionMethod, DetectionRule, FormatRule, ManagedEndpointConfig,
     MergeStrategy, ServerTemplateInput, StorageConfig, StorageKind, TemplateFormat,
 };
-use crate::clients::source::{ClientConfigSource, DbTemplateSource};
 #[cfg(test)]
 use crate::clients::source::FileTemplateSource;
+use crate::clients::source::{ClientConfigSource, DbTemplateSource};
 use crate::system::paths::{PathService, get_path_service};
 use chrono::{DateTime, Utc};
-use serde_json::json;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::path::Path;
@@ -36,14 +36,18 @@ fn parse_embedded_template(
         .ok_or_else(|| ConfigError::TemplateParseError(format!("Unsupported embedded template: {}", file_name)))?;
 
     let mut template: ClientTemplate = match ext.as_str() {
-        "json" => serde_json::from_str(contents)
-            .map_err(|err| ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err)))?,
-        "json5" => json5::from_str(contents)
-            .map_err(|err| ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err)))?,
-        "yaml" | "yml" => serde_yaml::from_str(contents)
-            .map_err(|err| ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err)))?,
-        "toml" => toml::from_str(contents)
-            .map_err(|err| ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err)))?,
+        "json" => serde_json::from_str(contents).map_err(|err| {
+            ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err))
+        })?,
+        "json5" => json5::from_str(contents).map_err(|err| {
+            ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err))
+        })?,
+        "yaml" | "yml" => serde_yaml::from_str(contents).map_err(|err| {
+            ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err))
+        })?,
+        "toml" => toml::from_str(contents).map_err(|err| {
+            ConfigError::TemplateParseError(format!("Failed to parse embedded template {}: {}", file_name, err))
+        })?,
         _ => {
             return Err(ConfigError::TemplateParseError(format!(
                 "Unsupported embedded template extension {} ({})",
@@ -158,10 +162,7 @@ impl ClientStateRow {
 
     #[allow(dead_code)]
     pub(super) fn is_approved(&self) -> bool {
-        matches!(
-            self.approval_status.as_deref(),
-            Some("approved") | None
-        )
+        matches!(self.approval_status.as_deref(), Some("approved") | None)
     }
 
     pub fn approval_status(&self) -> &str {
@@ -197,9 +198,7 @@ impl ClientStateRow {
     }
 
     pub fn config_path(&self) -> Option<&str> {
-        self.config_path
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
+        self.config_path.as_deref().filter(|value| !value.trim().is_empty())
     }
 
     pub fn governed_by_default_policy(&self) -> bool {
@@ -222,8 +221,7 @@ impl ClientStateRow {
 
     #[allow(dead_code)]
     pub fn is_pending_unknown(&self) -> bool {
-        self.approval_status.as_deref() == Some("pending")
-            && self.record_kind() == ClientRecordKind::ObservedUnknown
+        self.approval_status.as_deref() == Some("pending") && self.record_kind() == ClientRecordKind::ObservedUnknown
     }
 
     pub fn template_id(&self) -> Option<&str> {
@@ -423,10 +421,7 @@ impl ClientConfigService {
         let resolved_path = std::path::PathBuf::from(&config_path);
         let metadata = tokio::fs::metadata(&resolved_path).await.map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
-                ConfigError::DataAccessError(format!(
-                    "Client config target does not exist: {}",
-                    config_path
-                ))
+                ConfigError::DataAccessError(format!("Client config target does not exist: {}", config_path))
             } else {
                 ConfigError::FileOperationError(format!(
                     "Failed to inspect client config target {}: {}",
@@ -441,11 +436,15 @@ impl ClientConfigService {
                 .write(true)
                 .open(&resolved_path)
                 .await
-                .map_err(|_| ConfigError::PathNotWritable { path: resolved_path.clone() })?;
+                .map_err(|_| ConfigError::PathNotWritable {
+                    path: resolved_path.clone(),
+                })?;
         } else if metadata.is_dir() {
             let _ = tokio::fs::read_dir(&resolved_path)
                 .await
-                .map_err(|_| ConfigError::PathNotWritable { path: resolved_path.clone() })?;
+                .map_err(|_| ConfigError::PathNotWritable {
+                    path: resolved_path.clone(),
+                })?;
         } else {
             return Err(ConfigError::DataAccessError(format!(
                 "Client config target is neither a file nor a directory: {}",
@@ -477,8 +476,9 @@ impl ClientConfigService {
         templates: &[ClientTemplate],
     ) -> crate::clients::error::ConfigResult<()> {
         for template in templates {
-            let payload_json = serde_json::to_string(&template)
-                .map_err(|err| ConfigError::TemplateParseError(format!("Failed to serialize runtime template payload: {}", err)))?;
+            let payload_json = serde_json::to_string(&template).map_err(|err| {
+                ConfigError::TemplateParseError(format!("Failed to serialize runtime template payload: {}", err))
+            })?;
             sqlx::query(
                 r#"
                 INSERT INTO client_template_runtime (identifier, payload_json)
@@ -772,9 +772,7 @@ impl ClientConfigService {
         Ok(())
     }
 
-    pub(crate) fn extract_runtime_config_path_from_template(
-        template: &ClientTemplate,
-    ) -> Option<String> {
+    pub(crate) fn extract_runtime_config_path_from_template(template: &ClientTemplate) -> Option<String> {
         let platform = PathService::get_current_platform();
         let rules = template.platform_rules(platform)?;
         let rule = rules.first()?;

--- a/backend/src/clients/service/core.rs
+++ b/backend/src/clients/service/core.rs
@@ -18,6 +18,7 @@ use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs::OpenOptions;
 
 // Generated at build time from the repository's config/client directory
@@ -440,11 +441,7 @@ impl ClientConfigService {
                     path: resolved_path.clone(),
                 })?;
         } else if metadata.is_dir() {
-            let _ = tokio::fs::read_dir(&resolved_path)
-                .await
-                .map_err(|_| ConfigError::PathNotWritable {
-                    path: resolved_path.clone(),
-                })?;
+            Self::validate_directory_target_writable(&resolved_path).await?;
         } else {
             return Err(ConfigError::DataAccessError(format!(
                 "Client config target is neither a file nor a directory: {}",
@@ -453,6 +450,37 @@ impl ClientConfigService {
         }
 
         Ok(Some(config_path))
+    }
+
+    pub(super) async fn validate_directory_target_writable(
+        directory_path: &std::path::Path,
+    ) -> ConfigResult<()> {
+        let probe_name = format!(
+            ".mcpmate-write-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0)
+        );
+        let probe_path = directory_path.join(probe_name);
+
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&probe_path)
+            .await
+            .map_err(|_| ConfigError::PathNotWritable {
+                path: directory_path.to_path_buf(),
+            })?;
+
+        tokio::fs::remove_file(&probe_path)
+            .await
+            .map_err(|_| ConfigError::PathNotWritable {
+                path: directory_path.to_path_buf(),
+            })?;
+
+        Ok(())
     }
 
     pub async fn has_verified_local_config_target(

--- a/backend/src/clients/service/list.rs
+++ b/backend/src/clients/service/list.rs
@@ -53,10 +53,7 @@ impl ClientConfigService {
         }
 
         for (identifier, detected) in detected_map {
-            let display_name = detected
-                .display_name
-                .as_deref()
-                .unwrap_or(&identifier);
+            let display_name = detected.display_name.as_deref().unwrap_or(&identifier);
 
             match self
                 .ensure_passive_observed_row(&identifier, display_name, detected.config_path.as_deref())
@@ -124,9 +121,7 @@ mod tests {
         initialize_profile_tables(pool.as_ref())
             .await
             .expect("init profile tables");
-        initialize_client_table(pool.as_ref())
-            .await
-            .expect("init client table");
+        initialize_client_table(pool.as_ref()).await.expect("init client table");
         initialize_system_settings_table(pool.as_ref())
             .await
             .expect("init system settings table");

--- a/backend/src/clients/service/settings.rs
+++ b/backend/src/clients/service/settings.rs
@@ -40,8 +40,7 @@ impl ClientConfigService {
             Some("local_config_detected") => {
                 let raw_path = normalized_path.ok_or_else(|| {
                     ConfigError::DataAccessError(
-                        "Clients with a local config target must provide a valid MCP config file path."
-                            .to_string(),
+                        "Clients with a local config target must provide a valid MCP config file path.".to_string(),
                     )
                 })?;
                 self.validate_existing_config_target(raw_path).await?;
@@ -49,8 +48,7 @@ impl ClientConfigService {
             Some("manual") | Some("remote_http") => {
                 if normalized_path.is_some() {
                     return Err(ConfigError::DataAccessError(
-                        "Only clients with a local config target may store a config file path."
-                            .to_string(),
+                        "Only clients with a local config target may store a config file path.".to_string(),
                     ));
                 }
             }
@@ -73,15 +71,9 @@ impl ClientConfigService {
             .map_err(|err| ConfigError::PathResolutionError(err.to_string()))?;
         let metadata = tokio::fs::metadata(&resolved_path).await.map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
-                ConfigError::DataAccessError(format!(
-                    "Configured MCP file does not exist: {}",
-                    raw_path
-                ))
+                ConfigError::DataAccessError(format!("Configured MCP file does not exist: {}", raw_path))
             } else {
-                ConfigError::FileOperationError(format!(
-                    "Failed to inspect configured MCP file {}: {}",
-                    raw_path, err
-                ))
+                ConfigError::FileOperationError(format!("Failed to inspect configured MCP file {}: {}", raw_path, err))
             }
         })?;
 
@@ -91,9 +83,7 @@ impl ClientConfigService {
                 .write(true)
                 .open(&resolved_path)
                 .await
-                .map_err(|_| ConfigError::PathNotWritable {
-                    path: resolved_path,
-                })?;
+                .map_err(|_| ConfigError::PathNotWritable { path: resolved_path })?;
         } else if metadata.is_dir() {
             let _ = tokio::fs::read_dir(&resolved_path)
                 .await
@@ -212,11 +202,8 @@ impl ClientConfigService {
             })
         });
 
-        self.validate_runtime_target_input(
-            resolved_connection_mode.as_deref(),
-            normalized_config_path.as_deref(),
-        )
-        .await?;
+        self.validate_runtime_target_input(resolved_connection_mode.as_deref(), normalized_config_path.as_deref())
+            .await?;
 
         let approval_status = existing_state
             .as_ref()
@@ -272,8 +259,7 @@ impl ClientConfigService {
                     .supported_transports
                     .unwrap_or(existing_metadata.supported_transports),
             };
-            self.update_runtime_client_metadata(identifier, &next_metadata)
-                .await?;
+            self.update_runtime_client_metadata(identifier, &next_metadata).await?;
         }
 
         if should_persist_runtime_template {

--- a/backend/src/clients/service/settings.rs
+++ b/backend/src/clients/service/settings.rs
@@ -40,7 +40,7 @@ impl ClientConfigService {
             Some("local_config_detected") => {
                 let raw_path = normalized_path.ok_or_else(|| {
                     ConfigError::DataAccessError(
-                        "Clients with a local config target must provide a valid MCP config file path.".to_string(),
+                        "Clients with a local config target must provide a valid MCP config path.".to_string(),
                     )
                 })?;
                 self.validate_existing_config_target(raw_path).await?;
@@ -48,7 +48,7 @@ impl ClientConfigService {
             Some("manual") | Some("remote_http") => {
                 if normalized_path.is_some() {
                     return Err(ConfigError::DataAccessError(
-                        "Only clients with a local config target may store a config file path.".to_string(),
+                        "Only clients with a local config target may store a config path.".to_string(),
                     ));
                 }
             }
@@ -71,9 +71,9 @@ impl ClientConfigService {
             .map_err(|err| ConfigError::PathResolutionError(err.to_string()))?;
         let metadata = tokio::fs::metadata(&resolved_path).await.map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
-                ConfigError::DataAccessError(format!("Configured MCP file does not exist: {}", raw_path))
+                ConfigError::DataAccessError(format!("Configured MCP path does not exist: {}", raw_path))
             } else {
-                ConfigError::FileOperationError(format!("Failed to inspect configured MCP file {}: {}", raw_path, err))
+                ConfigError::FileOperationError(format!("Failed to inspect configured MCP path {}: {}", raw_path, err))
             }
         })?;
 
@@ -85,9 +85,7 @@ impl ClientConfigService {
                 .await
                 .map_err(|_| ConfigError::PathNotWritable { path: resolved_path })?;
         } else if metadata.is_dir() {
-            let _ = tokio::fs::read_dir(&resolved_path)
-                .await
-                .map_err(|_| ConfigError::PathNotWritable { path: resolved_path })?;
+            Self::validate_directory_target_writable(&resolved_path).await?;
         } else {
             return Err(ConfigError::DataAccessError(format!(
                 "Configured MCP path is neither a file nor a directory: {}",

--- a/backend/src/clients/service/settings.rs
+++ b/backend/src/clients/service/settings.rs
@@ -185,21 +185,15 @@ impl ClientConfigService {
             .should_persist_runtime_active_template(identifier, existing_state.as_ref())
             .await?;
 
-        let normalized_config_path = update
-            .config_path
-            .as_deref()
-            .map(str::trim)
+        let raw_config_path = update.config_path.as_deref().map(str::trim);
+        let normalized_config_path = raw_config_path
             .filter(|value| !value.is_empty())
             .map(str::to_string);
 
-        let resolved_connection_mode = update.connection_mode.clone().or_else(|| {
-            normalized_config_path.as_ref().map(|path| {
-                if path.trim().is_empty() {
-                    "manual".to_string()
-                } else {
-                    "local_config_detected".to_string()
-                }
-            })
+        let resolved_connection_mode = update.connection_mode.clone().or_else(|| match raw_config_path {
+            Some("") => Some("manual".to_string()),
+            Some(_) => Some("local_config_detected".to_string()),
+            None => None,
         });
 
         self.validate_runtime_target_input(resolved_connection_mode.as_deref(), normalized_config_path.as_deref())

--- a/backend/src/clients/service/state.rs
+++ b/backend/src/clients/service/state.rs
@@ -174,12 +174,11 @@ impl ClientConfigService {
     }
 
     pub async fn get_first_contact_behavior(&self) -> ConfigResult<FirstContactBehavior> {
-        let result: Option<(String,)> = sqlx::query_as(
-            "SELECT value FROM system_settings WHERE key = 'first_contact_behavior'",
-        )
-        .fetch_optional(&*self.db_pool)
-        .await
-        .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
+        let result: Option<(String,)> =
+            sqlx::query_as("SELECT value FROM system_settings WHERE key = 'first_contact_behavior'")
+                .fetch_optional(&*self.db_pool)
+                .await
+                .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
 
         match result {
             Some((value,)) => value
@@ -233,7 +232,10 @@ impl ClientConfigService {
         self.set_first_contact_behavior(behavior).await
     }
 
-    pub async fn approve_client(&self, identifier: &str) -> ConfigResult<(String, bool)> {
+    pub async fn approve_client(
+        &self,
+        identifier: &str,
+    ) -> ConfigResult<(String, bool)> {
         let name = self.resolve_client_name(identifier).await?;
         let row = self
             .ensure_active_state_row_with_name(identifier, &name, Some(true), Some("approved"))
@@ -258,7 +260,10 @@ impl ClientConfigService {
         Ok(("approved".to_string(), true))
     }
 
-    pub async fn reject_client(&self, identifier: &str) -> ConfigResult<(String, bool)> {
+    pub async fn reject_client(
+        &self,
+        identifier: &str,
+    ) -> ConfigResult<(String, bool)> {
         let name = self.resolve_client_name(identifier).await?;
         let row = self
             .ensure_active_state_row_with_name(identifier, &name, Some(false), Some("rejected"))
@@ -280,13 +285,17 @@ impl ClientConfigService {
         .await
         .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
 
-        let updated_row = self.fetch_state(identifier).await?
-            .ok_or_else(|| ConfigError::DataAccessError(format!("Failed to fetch client {} after rejection", identifier)))?;
+        let updated_row = self.fetch_state(identifier).await?.ok_or_else(|| {
+            ConfigError::DataAccessError(format!("Failed to fetch client {} after rejection", identifier))
+        })?;
 
         Ok((updated_row.approval_status().to_string(), updated_row.managed()))
     }
 
-    pub async fn suspend_client(&self, identifier: &str) -> ConfigResult<(String, bool)> {
+    pub async fn suspend_client(
+        &self,
+        identifier: &str,
+    ) -> ConfigResult<(String, bool)> {
         let name = self.resolve_client_name(identifier).await?;
         let row = self
             .ensure_active_state_row_with_name(identifier, &name, Some(false), Some("suspended"))
@@ -440,9 +449,11 @@ impl ClientConfigService {
             .as_ref()
             .and_then(|entry| entry.display_name.clone())
             .unwrap_or_else(|| name.to_string());
-        let config_path = observed_config_path
-            .map(str::to_string)
-            .or_else(|| template.as_ref().and_then(Self::extract_runtime_config_path_from_template));
+        let config_path = observed_config_path.map(str::to_string).or_else(|| {
+            template
+                .as_ref()
+                .and_then(Self::extract_runtime_config_path_from_template)
+        });
         let connection_mode = if config_path.is_some() {
             ClientConnectionMode::LocalConfigDetected.as_str()
         } else {
@@ -527,9 +538,7 @@ mod tests {
         initialize_profile_tables(pool.as_ref())
             .await
             .expect("init profile tables");
-        initialize_client_table(pool.as_ref())
-            .await
-            .expect("init client table");
+        initialize_client_table(pool.as_ref()).await.expect("init client table");
         initialize_system_settings_table(pool.as_ref())
             .await
             .expect("init system settings table");
@@ -626,10 +635,7 @@ mod tests {
     async fn default_policy_is_auto_manage() {
         let (_temp_dir, service) = create_test_service().await;
 
-        let policy = service
-            .get_onboarding_policy()
-            .await
-            .expect("get policy");
+        let policy = service.get_onboarding_policy().await.expect("get policy");
 
         assert_eq!(policy, OnboardingPolicy::AutoManage);
     }

--- a/backend/src/clients/source.rs
+++ b/backend/src/clients/source.rs
@@ -148,12 +148,10 @@ impl DbTemplateSource {
     }
 
     async fn load_templates(&self) -> ConfigResult<Vec<ClientTemplate>> {
-        let rows = sqlx::query_as::<_, (String, String)>(
-            &format!(
-                "SELECT identifier, payload_json FROM {} ORDER BY identifier",
-                tables::CLIENT_TEMPLATE_RUNTIME
-            ),
-        )
+        let rows = sqlx::query_as::<_, (String, String)>(&format!(
+            "SELECT identifier, payload_json FROM {} ORDER BY identifier",
+            tables::CLIENT_TEMPLATE_RUNTIME
+        ))
         .fetch_all(&*self.db_pool)
         .await
         .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
@@ -485,20 +483,19 @@ impl ClientConfigSource for DbTemplateSource {
         client_id: &str,
         _platform: &str,
     ) -> ConfigResult<Option<ClientTemplate>> {
-        let row = sqlx::query_scalar::<_, String>(
-            &format!(
-                "SELECT payload_json FROM {} WHERE identifier = ?",
-                tables::CLIENT_TEMPLATE_RUNTIME
-            ),
-        )
+        let row = sqlx::query_scalar::<_, String>(&format!(
+            "SELECT payload_json FROM {} WHERE identifier = ?",
+            tables::CLIENT_TEMPLATE_RUNTIME
+        ))
         .bind(client_id)
         .fetch_optional(&*self.db_pool)
         .await
         .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
 
         row.map(|payload_json| {
-            serde_json::from_str::<ClientTemplate>(&payload_json)
-                .map_err(|err| ConfigError::TemplateParseError(format!("Failed to parse runtime template payload: {}", err)))
+            serde_json::from_str::<ClientTemplate>(&payload_json).map_err(|err| {
+                ConfigError::TemplateParseError(format!("Failed to parse runtime template payload: {}", err))
+            })
         })
         .transpose()
     }
@@ -508,12 +505,10 @@ impl ClientConfigSource for DbTemplateSource {
         client_id: &str,
         _platform: &str,
     ) -> ConfigResult<Option<String>> {
-        let path = sqlx::query_scalar::<_, String>(
-            &format!(
-                "SELECT config_path FROM {} WHERE identifier = ? AND config_path IS NOT NULL AND TRIM(config_path) <> ''",
-                tables::CLIENT
-            ),
-        )
+        let path = sqlx::query_scalar::<_, String>(&format!(
+            "SELECT config_path FROM {} WHERE identifier = ? AND config_path IS NOT NULL AND TRIM(config_path) <> ''",
+            tables::CLIENT
+        ))
         .bind(client_id)
         .fetch_optional(&*self.db_pool)
         .await

--- a/backend/src/config/client/init.rs
+++ b/backend/src/config/client/init.rs
@@ -135,27 +135,9 @@ pub async fn initialize_client_table(pool: &Pool<Sqlite>) -> Result<()> {
         "TEXT NOT NULL DEFAULT 'approved' CHECK (approval_status IN ('pending', 'approved', 'suspended', 'rejected'))",
     )
     .await?;
-    ensure_column(
-        pool,
-        tables::CLIENT,
-        "template_id",
-        "TEXT",
-    )
-    .await?;
-    ensure_column(
-        pool,
-        tables::CLIENT,
-        "template_version",
-        "TEXT",
-    )
-    .await?;
-    ensure_column(
-        pool,
-        tables::CLIENT,
-        "approval_metadata",
-        "TEXT",
-    )
-    .await?;
+    ensure_column(pool, tables::CLIENT, "template_id", "TEXT").await?;
+    ensure_column(pool, tables::CLIENT, "template_version", "TEXT").await?;
+    ensure_column(pool, tables::CLIENT, "approval_metadata", "TEXT").await?;
 
     sqlx::query(&format!(
         r#"
@@ -525,8 +507,14 @@ pub async fn initialize_system_settings_table(pool: &Pool<Sqlite>) -> Result<()>
         .fetch_optional(pool)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to read onboarding_policy for first_contact_behavior migration: {}", e);
-            anyhow::anyhow!("Failed to read onboarding_policy for first_contact_behavior migration: {}", e)
+            tracing::error!(
+                "Failed to read onboarding_policy for first_contact_behavior migration: {}",
+                e
+            );
+            anyhow::anyhow!(
+                "Failed to read onboarding_policy for first_contact_behavior migration: {}",
+                e
+            )
         })?;
 
         let initial_behavior = match onboarding_policy.as_deref() {
@@ -559,8 +547,8 @@ pub async fn initialize_system_settings_table(pool: &Pool<Sqlite>) -> Result<()>
 #[cfg(test)]
 mod tests {
     use super::{
-        initialize_client_table, initialize_system_settings_table, resolve_default_client_config_mode,
-        set_default_client_config_mode, FIRST_CONTACT_BEHAVIOR_SETTING_KEY,
+        FIRST_CONTACT_BEHAVIOR_SETTING_KEY, initialize_client_table, initialize_system_settings_table,
+        resolve_default_client_config_mode, set_default_client_config_mode,
     };
     use sqlx::sqlite::SqlitePoolOptions;
 
@@ -636,13 +624,11 @@ mod tests {
             .await
             .expect("reinitialize system settings");
 
-        let behavior = sqlx::query_scalar::<_, String>(
-            "SELECT value FROM system_settings WHERE key = ?",
-        )
-        .bind(FIRST_CONTACT_BEHAVIOR_SETTING_KEY)
-        .fetch_one(&pool)
-        .await
-        .expect("fetch first_contact_behavior");
+        let behavior = sqlx::query_scalar::<_, String>("SELECT value FROM system_settings WHERE key = ?")
+            .bind(FIRST_CONTACT_BEHAVIOR_SETTING_KEY)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch first_contact_behavior");
 
         assert_eq!(behavior, "deny");
     }


### PR DESCRIPTION
## Summary
- persist and validate client runtime target settings through the active client settings flow
- tighten local config target handling across client service, source resolution, and API payloads
- keep the client runtime metadata/bootstrap path aligned with the updated governance model

## Validation
- cargo check