### PR TITLE
fix(runtime): tighten server visibility plumbing

### DIFF
--- a/backend/src/api/handlers/server/crud.rs
+++ b/backend/src/api/handlers/server/crud.rs
@@ -190,7 +190,9 @@ pub async fn create_server(
     let existing_server = crate::config::server::get_server(&db.pool, &payload.name)
         .await
         .map_err(map_anyhow_error)?;
-    let reusable_pending_server = existing_server.as_ref().filter(|server| is_pending_import && server.pending_import);
+    let reusable_pending_server = existing_server
+        .as_ref()
+        .filter(|server| is_pending_import && server.pending_import);
     if existing_server.is_some() && reusable_pending_server.is_none() {
         return Err(ApiError::Conflict(format!(
             "Server with name '{}' already exists. Please choose a different name for your server.",
@@ -245,13 +247,9 @@ pub async fn create_server(
     // Persist default headers if provided
     if reusable_pending_server.is_some() {
         let empty_headers = std::collections::HashMap::new();
-        replace_server_headers(
-            &db.pool,
-            &server_id,
-            payload.headers.as_ref().unwrap_or(&empty_headers),
-        )
-        .await
-        .map_err(map_anyhow_error)?;
+        replace_server_headers(&db.pool, &server_id, payload.headers.as_ref().unwrap_or(&empty_headers))
+            .await
+            .map_err(map_anyhow_error)?;
     } else if let Some(headers) = &payload.headers {
         if !headers.is_empty() {
             upsert_server_headers(&db.pool, &server_id, headers)
@@ -286,7 +284,9 @@ pub async fn create_server(
     // Associate server with specified profiles if provided
     let initial_enabled = payload.enabled.unwrap_or(true);
 
-    if !server.pending_import && let Some(profile_ids) = payload.profile_ids.as_ref() {
+    if !server.pending_import
+        && let Some(profile_ids) = payload.profile_ids.as_ref()
+    {
         let mut unique_profiles = BTreeSet::new();
         for profile_id in profile_ids {
             if !unique_profiles.insert(profile_id) {

--- a/backend/src/api/handlers/system.rs
+++ b/backend/src/api/handlers/system.rs
@@ -462,7 +462,9 @@ fn get_uptime_seconds() -> u64 {
     now.saturating_sub(start_time)
 }
 
-pub async fn get_onboarding_policy(State(state): State<Arc<AppState>>) -> Result<Json<crate::api::models::client::OnboardingPolicyResponse>, axum::http::StatusCode> {
+pub async fn get_onboarding_policy(
+    State(state): State<Arc<AppState>>
+) -> Result<Json<crate::api::models::client::OnboardingPolicyResponse>, axum::http::StatusCode> {
     let service = crate::api::handlers::client::handlers::get_client_service(&state)?;
 
     let policy = service.get_onboarding_policy().await.map_err(|err| {
@@ -476,7 +478,7 @@ pub async fn get_onboarding_policy(State(state): State<Arc<AppState>>) -> Result
 }
 
 pub async fn get_first_contact_behavior(
-    State(state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>
 ) -> Result<Json<crate::api::models::client::FirstContactBehaviorResp>, axum::http::StatusCode> {
     let service = crate::api::handlers::client::handlers::get_client_service(&state)?;
 

--- a/backend/src/config/server/init.rs
+++ b/backend/src/config/server/init.rs
@@ -42,10 +42,7 @@ async fn cleanup_pending_import_servers(pool: &Pool<Sqlite>) -> Result<()> {
 
     let removed = result.rows_affected();
     if removed > 0 {
-        tracing::info!(
-            removed,
-            "Removed stale pending_import server records during startup"
-        );
+        tracing::info!(removed, "Removed stale pending_import server records during startup");
     }
 
     Ok(())
@@ -360,7 +357,11 @@ mod tests {
         pool
     }
 
-    fn build_server(id: &str, name: &str, pending_import: bool) -> Server {
+    fn build_server(
+        id: &str,
+        name: &str,
+        pending_import: bool,
+    ) -> Server {
         Server {
             id: Some(id.to_string()),
             name: name.to_string(),
@@ -392,12 +393,10 @@ mod tests {
             .await
             .expect("reinitialize tables and cleanup pending records");
 
-        let remaining_names = sqlx::query_scalar::<_, String>(
-            "SELECT name FROM server_config ORDER BY name ASC",
-        )
-        .fetch_all(&pool)
-        .await
-        .expect("list remaining servers");
+        let remaining_names = sqlx::query_scalar::<_, String>("SELECT name FROM server_config ORDER BY name ASC")
+            .fetch_all(&pool)
+            .await
+            .expect("list remaining servers");
 
         assert_eq!(remaining_names, vec!["visible-server".to_string()]);
     }

--- a/backend/src/core/profile/visibility.rs
+++ b/backend/src/core/profile/visibility.rs
@@ -1128,8 +1128,8 @@ mod tests {
         profile::{self, init::initialize_profile_tables},
         server::{self, init::initialize_server_tables},
     };
-    use sqlx::sqlite::SqlitePoolOptions;
     use serial_test::serial;
+    use sqlx::sqlite::SqlitePoolOptions;
     use tempfile::TempDir;
 
     async fn create_visibility_service() -> (TempDir, Arc<Database>, ProfileVisibilityService) {

--- a/backend/src/core/proxy/server/gateway.rs
+++ b/backend/src/core/proxy/server/gateway.rs
@@ -204,9 +204,10 @@ impl ProxyServer {
             .filter(|s| !s.trim().is_empty())
             .unwrap_or(client.client_id.as_str());
 
-        let state_opt = svc.fetch_state(&client.client_id).await.map_err(|e| {
-            rmcp::ErrorData::internal_error(format!("Failed to read client state: {e}"), None)
-        })?;
+        let state_opt = svc
+            .fetch_state(&client.client_id)
+            .await
+            .map_err(|e| rmcp::ErrorData::internal_error(format!("Failed to read client state: {e}"), None))?;
 
         if let Some(ref state) = state_opt {
             return match state.approval_status() {
@@ -312,7 +313,7 @@ impl ProxyServer {
                 session_id: Some(session_id.to_string()),
                 profile_id: binding.profile_id.clone(),
                 config_mode: binding.config_mode.clone(),
-            unify_workspace: binding.unify_workspace.clone(),
+                unify_workspace: binding.unify_workspace.clone(),
                 rules_fingerprint: binding.rules_fingerprint.clone(),
                 transport: crate::core::proxy::server::common::ClientTransport::StreamableHttp,
                 source: crate::core::proxy::server::common::ClientIdentitySource::SessionBinding,
@@ -521,8 +522,7 @@ impl ProxyServer {
         self.database = Some(db_arc.clone());
         crate::core::capability::naming::initialize(db_arc.pool.clone());
         self.profile_service = Some(Arc::new(crate::core::profile::ProfileService::new(db_arc.clone())));
-        let client_config_service =
-            Arc::new(ClientConfigService::bootstrap(Arc::new(db_arc.pool.clone())).await?);
+        let client_config_service = Arc::new(ClientConfigService::bootstrap(Arc::new(db_arc.pool.clone())).await?);
         self.client_config_service = Some(client_config_service.clone());
         self.builtin_services = Arc::new(BuiltinServiceRegistry::new().with_mcpmate_services(
             db_arc.clone(),

--- a/backend/src/core/transport/http.rs
+++ b/backend/src/core/transport/http.rs
@@ -47,10 +47,8 @@ async fn connect_http_internal(
     let (service, tools, capabilities) = match transport_type {
         TransportType::StreamableHttp => {
             let config = make_streamable_config(url, &server_config.headers);
-            let transport = StreamableHttpClientTransport::<reqwest::Client>::with_client(
-                reqwest::Client::new(),
-                config,
-            );
+            let transport =
+                StreamableHttpClientTransport::<reqwest::Client>::with_client(reqwest::Client::new(), config);
             build_service_tools(server_name, transport, service_timeout, tools_timeout).await?
         }
         TransportType::Stdio => {

--- a/desktop/src-tauri/src/source_config.rs
+++ b/desktop/src-tauri/src/source_config.rs
@@ -1,6 +1,6 @@
 use crate::runtime_ports::PersistedRuntimePorts;
 use anyhow::{Context, Result};
-use mcpmate::common::{constants::ports, MCPMatePaths};
+use mcpmate::common::{MCPMatePaths, constants::ports};
 use serde::{Deserialize, Serialize};
 use std::{fs, path::PathBuf};
 


### PR DESCRIPTION
## Summary
- align server CRUD and startup cleanup paths with the updated visibility and runtime checks
- keep gateway and HTTP transport behavior consistent with the refined server visibility flow
- carry the matching desktop source configuration adjustment needed by the localhost runtime selection path

## Validation
- backend: RUSTC_WRAPPER= cargo check -q
- desktop: RUSTC_WRAPPER= cargo check -q