### PR TITLE
feat(release): desktop release pipeline with auto versioning

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -77,6 +77,17 @@ jobs:
           crate: tauri-cli
           locked: true
 
+      - name: Inject MSI-safe app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          CONF="desktop/src-tauri/tauri.conf.json"
+          VERSION=$(jq -r '.version' "$CONF")
+          VERSION="${VERSION%%-*}"
+          jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
+          mv "$CONF.tmp" "$CONF"
+          echo "tauri.conf.json version → $VERSION"
+
       - name: Build Windows desktop artifacts
         shell: bash
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           - arch: x64
             runner: windows-latest
             target: x86_64-pc-windows-msvc
-            experimental: false
+            experimental: true
           - arch: arm64
             runner: windows-11-arm
             target: aarch64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,21 @@ jobs:
           if-no-files-found: error
 
   build-windows:
-    name: Windows (x64)
-    runs-on: windows-latest
+    name: Windows (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            experimental: false
+          - arch: arm64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            experimental: true
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -118,7 +131,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: ${{ matrix.target }}
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -146,7 +159,7 @@ jobs:
         run: |
           chmod +x packaging/desktop/windows-build-tauri-release.sh
           packaging/desktop/windows-build-tauri-release.sh \
-            --target x86_64-pc-windows-msvc \
+            --target "${{ matrix.target }}" \
             --bundles msi \
             --with-updater \
             --output-dir "${GITHUB_WORKSPACE}/installers"
@@ -156,20 +169,20 @@ jobs:
         run: |
           chmod +x packaging/desktop/collect-updater-artifacts.sh
           packaging/desktop/collect-updater-artifacts.sh \
-            --bundle-dir "desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle" \
+            --bundle-dir "desktop/src-tauri/target/${{ matrix.target }}/release/bundle" \
             --output-dir "${GITHUB_WORKSPACE}/updater"
 
       - name: Upload installers
         uses: actions/upload-artifact@v6
         with:
-          name: installers-windows-x64
+          name: installers-windows-${{ matrix.arch }}
           path: installers/*
           if-no-files-found: error
 
       - name: Upload updater artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: updater-windows-x64
+          name: updater-windows-${{ matrix.arch }}
           path: updater/*
           if-no-files-found: error
 
@@ -182,6 +195,11 @@ jobs:
           - arch: x64
             runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            bundles: appimage,deb
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            bundles: deb
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     steps:
@@ -194,8 +212,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev \
-            libayatana-appindicator3-dev librsvg2-dev patchelf
+            build-essential file jq \
+            libayatana-appindicator3-dev libfuse2 librsvg2-dev \
+            libgtk-3-dev libssl-dev libwebkit2gtk-4.1-dev patchelf
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -228,11 +247,12 @@ jobs:
           chmod +x packaging/desktop/linux-build-tauri-release.sh
           packaging/desktop/linux-build-tauri-release.sh \
             --target "${{ matrix.target }}" \
-            --bundles "appimage,deb" \
+            --bundles "${{ matrix.bundles }}" \
             --with-updater \
             --output-dir "${GITHUB_WORKSPACE}/installers"
 
       - name: Collect updater artifacts
+        if: contains(matrix.bundles, 'appimage')
         run: |
           chmod +x packaging/desktop/collect-updater-artifacts.sh
           packaging/desktop/collect-updater-artifacts.sh \
@@ -247,6 +267,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload updater artifacts
+        if: contains(matrix.bundles, 'appimage')
         uses: actions/upload-artifact@v6
         with:
           name: updater-linux-${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,9 +460,8 @@ jobs:
           if ! grep -Eq '^[*-] ' artifacts/release-notes.md; then
             if [[ -n "$compare_range" ]]; then
               mapfile -t commits < <(
-                gh api "repos/${RELEASE_REPO}/compare/${compare_range}" --jq '.commits[].commit.message' |
-                  while IFS= read -r message; do
-                    subject="${message%%$'\n'*}"
+                gh api "repos/${RELEASE_REPO}/compare/${compare_range}" --jq '.commits[].commit.message | split("\n")[0]' |
+                  while IFS= read -r subject; do
                     case "$subject" in
                       ""|"Merge pull request"*) continue ;;
                     esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,31 @@ jobs:
             --bundle-dir "desktop/src-tauri/target/${{ matrix.target }}/release/bundle" \
             --output-dir "${GITHUB_WORKSPACE}/updater"
 
+      - name: Normalize macOS artifact names
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          TARGET_ARCH: ${{ matrix.arch }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          VERSION="${VERSION%%-*}"
+          case "$TARGET_ARCH" in
+            aarch64) ARCH_SUFFIX="aarch64" ;;
+            x64) ARCH_SUFFIX="x86_64" ;;
+            *) echo "unknown macOS arch: $TARGET_ARCH" >&2; exit 1 ;;
+          esac
+
+          for dmg in installers/*.dmg; do
+            mv "$dmg" "installers/MCPMate_${VERSION}_darwin_${ARCH_SUFFIX}.dmg"
+          done
+
+          for bundle in updater/*.app.tar.gz; do
+            dest="updater/MCPMate_${VERSION}_darwin_${ARCH_SUFFIX}.app.tar.gz"
+            mv "$bundle" "$dest"
+            if [[ -f "${bundle}.sig" ]]; then
+              mv "${bundle}.sig" "${dest}.sig"
+            fi
+          done
+
       - name: Upload installers
         uses: actions/upload-artifact@v6
         with:
@@ -220,7 +245,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-            bundles: deb
+            bundles: appimage,deb
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     steps:
@@ -377,6 +402,38 @@ jobs:
           echo "--- update.json ---"
           cat artifacts/update.json
 
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          previous_tag=$(gh release list --limit 20 --json tagName --jq '.[].tagName' | grep -Fxv "$RELEASE_TAG" | head -n1 || true)
+
+          if [[ -n "$previous_tag" ]]; then
+            gh api -X POST "repos/${RELEASE_REPO}/releases/generate-notes" \
+              -f tag_name="$RELEASE_TAG" \
+              -f previous_tag_name="$previous_tag" \
+              --jq '.body' > artifacts/release-notes.md
+            contributors=$(gh api "repos/${RELEASE_REPO}/compare/${previous_tag}...${RELEASE_TAG}" --jq '.commits[].author.login' | grep -v '^null$' | sort -u || true)
+          else
+            gh api -X POST "repos/${RELEASE_REPO}/releases/generate-notes" \
+              -f tag_name="$RELEASE_TAG" \
+              --jq '.body' > artifacts/release-notes.md
+            contributors=""
+          fi
+
+          if ! grep -q '^## Contributors' artifacts/release-notes.md; then
+            {
+              printf '\n\n## Contributors\n'
+              if [[ -n "$contributors" ]]; then
+                while read -r login; do
+                  [[ -n "$login" ]] && printf '%s\n' "- @${login}"
+                done <<< "$contributors"
+              else
+                printf '%s\n' '- @loocor'
+              fi
+            } >> artifacts/release-notes.md
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -384,7 +441,7 @@ jobs:
           name: ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: ${{ contains(env.RELEASE_TAG, '-rc') || contains(env.RELEASE_TAG, '-beta') || contains(env.RELEASE_TAG, '-alpha') }}
-          generate_release_notes: true
+          body_path: artifacts/release-notes.md
           files: |
             artifacts/*.dmg
             artifacts/*.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,14 @@ jobs:
           crate: tauri-cli
           locked: true
 
+      - name: Inject version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          CONF="desktop/src-tauri/tauri.conf.json"
+          jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
+          mv "$CONF.tmp" "$CONF"
+          echo "tauri.conf.json version → $VERSION"
+
       - name: Build macOS DMG
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -151,6 +159,15 @@ jobs:
           crate: tauri-cli
           locked: true
 
+      - name: Inject version from tag
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          CONF="desktop/src-tauri/tauri.conf.json"
+          jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
+          mv "$CONF.tmp" "$CONF"
+          echo "tauri.conf.json version → $VERSION"
+
       - name: Build Windows installers
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -184,7 +201,7 @@ jobs:
         with:
           name: updater-windows-${{ matrix.arch }}
           path: updater/*
-          if-no-files-found: error
+          if-no-files-found: warn
 
   build-linux:
     name: Linux (${{ matrix.arch }})
@@ -238,6 +255,14 @@ jobs:
         with:
           crate: tauri-cli
           locked: true
+
+      - name: Inject version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          CONF="desktop/src-tauri/tauri.conf.json"
+          jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
+          mv "$CONF.tmp" "$CONF"
+          echo "tauri.conf.json version → $VERSION"
 
       - name: Build Linux bundles
         env:
@@ -314,7 +339,7 @@ jobs:
 
           MANIFEST_ARGS=(--version "$VERSION" --output artifacts/update.json)
 
-          find artifacts -name "*.sig" -type f | while read -r sig; do
+          while read -r sig; do
             bundle="${sig%.sig}"
             if [[ -f "$bundle" ]]; then
               base="$(basename "$bundle")"
@@ -338,7 +363,7 @@ jobs:
               asset_url="https://github.com/${RELEASE_REPO}/releases/download/${RELEASE_TAG}/${base}"
               MANIFEST_ARGS+=(--platform "$plat" "$asset_url" "$(cat "$sig")")
             fi
-          done
+          done < <(find artifacts -name "*.sig" -type f)
 
           packaging/desktop/generate-update-manifest.sh "${MANIFEST_ARGS[@]}"
 
@@ -349,14 +374,13 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          name: "MCPMate ${{ env.RELEASE_TAG }}"
+          name: ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: ${{ contains(env.RELEASE_TAG, '-rc') || contains(env.RELEASE_TAG, '-beta') || contains(env.RELEASE_TAG, '-alpha') }}
           generate_release_notes: true
           files: |
             artifacts/*.dmg
             artifacts/*.msi
-            artifacts/*.exe
             artifacts/*.AppImage
             artifacts/*.deb
             artifacts/*.app.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
 
       - name: Inject version from tag
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          RELEASE_TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${RELEASE_TAG#v}"
           CONF="desktop/src-tauri/tauri.conf.json"
           jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
           mv "$CONF.tmp" "$CONF"
@@ -162,7 +163,8 @@ jobs:
       - name: Inject version from tag
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          RELEASE_TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${RELEASE_TAG#v}"
           CONF="desktop/src-tauri/tauri.conf.json"
           jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
           mv "$CONF.tmp" "$CONF"
@@ -258,7 +260,8 @@ jobs:
 
       - name: Inject version from tag
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          RELEASE_TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${RELEASE_TAG#v}"
           CONF="desktop/src-tauri/tauri.conf.json"
           jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
           mv "$CONF.tmp" "$CONF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           RELEASE_TAG="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${RELEASE_TAG#v}"
+          VERSION="${VERSION%%-*}"
           CONF="desktop/src-tauri/tauri.conf.json"
           jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
           mv "$CONF.tmp" "$CONF"
@@ -165,6 +166,7 @@ jobs:
         run: |
           RELEASE_TAG="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${RELEASE_TAG#v}"
+          VERSION="${VERSION%%-*}"
           CONF="desktop/src-tauri/tauri.conf.json"
           jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
           mv "$CONF.tmp" "$CONF"
@@ -262,6 +264,7 @@ jobs:
         run: |
           RELEASE_TAG="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${RELEASE_TAG#v}"
+          VERSION="${VERSION%%-*}"
           CONF="desktop/src-tauri/tauri.conf.json"
           jq --arg v "$VERSION" '.version = $v' "$CONF" > "$CONF.tmp"
           mv "$CONF.tmp" "$CONF"
@@ -339,6 +342,7 @@ jobs:
           chmod +x packaging/desktop/generate-update-manifest.sh
 
           VERSION="${RELEASE_TAG#v}"
+          VERSION="${VERSION%%-*}"
 
           MANIFEST_ARGS=(--version "$VERSION" --output artifacts/update.json)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,10 +449,43 @@ jobs:
               -f tag_name="$RELEASE_TAG" \
               -f previous_tag_name="$previous_tag" \
               --jq '.body' > artifacts/release-notes.md
+            compare_range="${previous_tag}...${RELEASE_TAG}"
           else
             gh api -X POST "repos/${RELEASE_REPO}/releases/generate-notes" \
               -f tag_name="$RELEASE_TAG" \
               --jq '.body' > artifacts/release-notes.md
+            compare_range=""
+          fi
+
+          if ! grep -Eq '^[*-] ' artifacts/release-notes.md; then
+            if [[ -n "$compare_range" ]]; then
+              mapfile -t commits < <(
+                gh api "repos/${RELEASE_REPO}/compare/${compare_range}" --jq '.commits[].commit.message' |
+                  while IFS= read -r message; do
+                    subject="${message%%$'\n'*}"
+                    case "$subject" in
+                      ""|"Merge pull request"*) continue ;;
+                    esac
+                    printf '%s\n' "$subject"
+                  done
+              )
+            else
+              mapfile -t commits < <(git log -1 --format=%s)
+            fi
+
+            {
+              printf '%s\n' "## What's Changed"
+              if ((${#commits[@]})); then
+                for subject in "${commits[@]}"; do
+                  printf -- '- %s\n' "$subject"
+                done
+              else
+                printf '%s\n' '- Release notes fallback generated from tag comparison.'
+              fi
+              printf '\n'
+              cat artifacts/release-notes.md
+            } > artifacts/release-notes.tmp
+            mv artifacts/release-notes.tmp artifacts/release-notes.md
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -110,6 +112,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -183,6 +187,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Install system dependencies
         run: |
@@ -261,6 +267,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Resolve release tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential file jq \
+            build-essential file jq xdg-utils \
             libayatana-appindicator3-dev libfuse2 librsvg2-dev \
             libgtk-3-dev libssl-dev libwebkit2gtk-4.1-dev patchelf
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           chmod +x packaging/desktop/macos-build-tauri-release.sh
           packaging/desktop/macos-build-tauri-release.sh \
             --target "${{ matrix.target }}" \
-            --bundles dmg \
+            --bundles app,dmg \
             --with-updater \
             --skip-notarize \
             --output-dir "${GITHUB_WORKSPACE}/installers"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,336 @@
+# Tag-driven desktop release workflow.
+# Triggered on v* tags; builds all desktop platforms, collects updater artifacts,
+# generates update.json, and publishes a GitHub Release.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.1.0)"
+        required: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  CI: "true"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Desktop builds — one per platform/arch target
+  # ---------------------------------------------------------------------------
+  build-macos:
+    name: macOS (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+          - arch: x64
+            runner: macos-latest
+            target: x86_64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            backend -> target
+            desktop/src-tauri -> target
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Tauri CLI
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: tauri-cli
+          locked: true
+
+      - name: Build macOS DMG
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          chmod +x packaging/desktop/macos-build-tauri-release.sh
+          packaging/desktop/macos-build-tauri-release.sh \
+            --target "${{ matrix.target }}" \
+            --bundles dmg \
+            --with-updater \
+            --skip-notarize \
+            --output-dir "${GITHUB_WORKSPACE}/installers"
+
+      - name: Collect updater artifacts
+        run: |
+          chmod +x packaging/desktop/collect-updater-artifacts.sh
+          packaging/desktop/collect-updater-artifacts.sh \
+            --bundle-dir "desktop/src-tauri/target/${{ matrix.target }}/release/bundle" \
+            --output-dir "${GITHUB_WORKSPACE}/updater"
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v6
+        with:
+          name: installers-macos-${{ matrix.arch }}
+          path: installers/*
+          if-no-files-found: error
+
+      - name: Upload updater artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: updater-macos-${{ matrix.arch }}
+          path: updater/*
+          if-no-files-found: error
+
+  build-windows:
+    name: Windows (x64)
+    runs-on: windows-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            backend -> target
+            desktop/src-tauri -> target
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Tauri CLI
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: tauri-cli
+          locked: true
+
+      - name: Build Windows installers
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        shell: bash
+        run: |
+          chmod +x packaging/desktop/windows-build-tauri-release.sh
+          packaging/desktop/windows-build-tauri-release.sh \
+            --target x86_64-pc-windows-msvc \
+            --bundles msi \
+            --with-updater \
+            --output-dir "${GITHUB_WORKSPACE}/installers"
+
+      - name: Collect updater artifacts
+        shell: bash
+        run: |
+          chmod +x packaging/desktop/collect-updater-artifacts.sh
+          packaging/desktop/collect-updater-artifacts.sh \
+            --bundle-dir "desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle" \
+            --output-dir "${GITHUB_WORKSPACE}/updater"
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v6
+        with:
+          name: installers-windows-x64
+          path: installers/*
+          if-no-files-found: error
+
+      - name: Upload updater artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: updater-windows-x64
+          path: updater/*
+          if-no-files-found: error
+
+  build-linux:
+    name: Linux (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev librsvg2-dev patchelf
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            backend -> target
+            desktop/src-tauri -> target
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Tauri CLI
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: tauri-cli
+          locked: true
+
+      - name: Build Linux bundles
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          chmod +x packaging/desktop/linux-build-tauri-release.sh
+          packaging/desktop/linux-build-tauri-release.sh \
+            --target "${{ matrix.target }}" \
+            --bundles "appimage,deb" \
+            --with-updater \
+            --output-dir "${GITHUB_WORKSPACE}/installers"
+
+      - name: Collect updater artifacts
+        run: |
+          chmod +x packaging/desktop/collect-updater-artifacts.sh
+          packaging/desktop/collect-updater-artifacts.sh \
+            --bundle-dir "desktop/src-tauri/target/${{ matrix.target }}/release/bundle" \
+            --output-dir "${GITHUB_WORKSPACE}/updater"
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v6
+        with:
+          name: installers-linux-${{ matrix.arch }}
+          path: installers/*
+          if-no-files-found: error
+
+      - name: Upload updater artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: updater-linux-${{ matrix.arch }}
+          path: updater/*
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Publish release — depends on all build jobs completing
+  # ---------------------------------------------------------------------------
+  release:
+    name: Publish Release
+    needs: [build-macos, build-windows, build-linux]
+    runs-on: ubuntu-22.04
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_REPO: ${{ github.repository }}
+      DISPATCH_TAG: ${{ github.event.inputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve release tag
+        run: |
+          if [[ -n "$DISPATCH_TAG" ]]; then
+            echo "RELEASE_TAG=${DISPATCH_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List collected artifacts
+        run: find artifacts -type f | sort
+
+      - name: Generate update manifest
+        run: |
+          chmod +x packaging/desktop/generate-update-manifest.sh
+
+          VERSION="${RELEASE_TAG#v}"
+
+          MANIFEST_ARGS=(--version "$VERSION" --output artifacts/update.json)
+
+          find artifacts -name "*.sig" -type f | while read -r sig; do
+            bundle="${sig%.sig}"
+            if [[ -f "$bundle" ]]; then
+              base="$(basename "$bundle")"
+              case "$base" in
+                *aarch64*|*arm64*)
+                  case "$base" in
+                    *darwin*|*macos*|*.app.tar.gz) plat="darwin-aarch64" ;;
+                    *linux*|*.AppImage)            plat="linux-aarch64" ;;
+                    *windows*|*.nsis*|*.msi*)      plat="windows-aarch64" ;;
+                    *) echo "WARN: skip $base" >&2; continue ;;
+                  esac ;;
+                *)
+                  case "$base" in
+                    *darwin*|*macos*|*.app.tar.gz) plat="darwin-x86_64" ;;
+                    *linux*|*.AppImage)            plat="linux-x86_64" ;;
+                    *windows*|*.nsis*|*.msi*)      plat="windows-x86_64" ;;
+                    *) echo "WARN: skip $base" >&2; continue ;;
+                  esac ;;
+              esac
+
+              asset_url="https://github.com/${RELEASE_REPO}/releases/download/${RELEASE_TAG}/${base}"
+              MANIFEST_ARGS+=(--platform "$plat" "$asset_url" "$(cat "$sig")")
+            fi
+          done
+
+          packaging/desktop/generate-update-manifest.sh "${MANIFEST_ARGS[@]}"
+
+          echo "--- update.json ---"
+          cat artifacts/update.json
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: "MCPMate ${{ env.RELEASE_TAG }}"
+          draft: false
+          prerelease: ${{ contains(env.RELEASE_TAG, '-rc') || contains(env.RELEASE_TAG, '-beta') || contains(env.RELEASE_TAG, '-alpha') }}
+          generate_release_notes: true
+          files: |
+            artifacts/*.dmg
+            artifacts/*.msi
+            artifacts/*.exe
+            artifacts/*.AppImage
+            artifacts/*.deb
+            artifacts/*.app.tar.gz
+            artifacts/*.nsis.zip
+            artifacts/*.sig
+            artifacts/update.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,6 +362,35 @@ jobs:
       - name: List collected artifacts
         run: find artifacts -type f | sort
 
+      - name: Normalize release asset names
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          VERSION="${VERSION%%-*}"
+
+          rename_pair() {
+            local old_name="$1"
+            local new_name="$2"
+            if [[ -f "artifacts/${old_name}" ]]; then
+              mv "artifacts/${old_name}" "artifacts/${new_name}"
+            fi
+            if [[ -f "artifacts/${old_name}.sig" ]]; then
+              mv "artifacts/${old_name}.sig" "artifacts/${new_name}.sig"
+            fi
+          }
+
+          rename_pair "MCPMate_${VERSION}_darwin_aarch64.dmg" "MCPMate_${VERSION}_macos_aarch64.dmg"
+          rename_pair "MCPMate_${VERSION}_darwin_aarch64.app.tar.gz" "MCPMate_${VERSION}_macos_aarch64.app.tar.gz"
+          rename_pair "MCPMate_${VERSION}_darwin_x86_64.dmg" "MCPMate_${VERSION}_macos_x86_64.dmg"
+          rename_pair "MCPMate_${VERSION}_darwin_x86_64.app.tar.gz" "MCPMate_${VERSION}_macos_x86_64.app.tar.gz"
+          rename_pair "MCPMate_${VERSION}_x64_en-US.msi" "MCPMate_${VERSION}_windows_x64.msi"
+          rename_pair "MCPMate_${VERSION}_arm64_en-US.msi" "MCPMate_${VERSION}_windows_arm64.msi"
+          rename_pair "MCPMate_${VERSION}_amd64.AppImage" "MCPMate_${VERSION}_linux_x64.AppImage"
+          rename_pair "MCPMate_${VERSION}_aarch64.AppImage" "MCPMate_${VERSION}_linux_arm64.AppImage"
+          rename_pair "MCPMate_${VERSION}_amd64.deb" "MCPMate_${VERSION}_linux_x64.deb"
+          rename_pair "MCPMate_${VERSION}_arm64.deb" "MCPMate_${VERSION}_linux_arm64.deb"
+
+          find artifacts -type f | sort
+
       - name: Generate update manifest
         run: |
           chmod +x packaging/desktop/generate-update-manifest.sh
@@ -402,6 +431,13 @@ jobs:
           echo "--- update.json ---"
           cat artifacts/update.json
 
+      - name: Bundle signature files
+        run: |
+          if compgen -G "artifacts/*.sig" >/dev/null; then
+            zip -j "artifacts/signatures.zip" artifacts/*.sig
+            rm -f artifacts/*.sig
+          fi
+
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ github.token }}
@@ -413,25 +449,10 @@ jobs:
               -f tag_name="$RELEASE_TAG" \
               -f previous_tag_name="$previous_tag" \
               --jq '.body' > artifacts/release-notes.md
-            contributors=$(gh api "repos/${RELEASE_REPO}/compare/${previous_tag}...${RELEASE_TAG}" --jq '.commits[].author.login' | grep -v '^null$' | sort -u || true)
           else
             gh api -X POST "repos/${RELEASE_REPO}/releases/generate-notes" \
               -f tag_name="$RELEASE_TAG" \
               --jq '.body' > artifacts/release-notes.md
-            contributors=""
-          fi
-
-          if ! grep -q '^## Contributors' artifacts/release-notes.md; then
-            {
-              printf '\n\n## Contributors\n'
-              if [[ -n "$contributors" ]]; then
-                while read -r login; do
-                  [[ -n "$login" ]] && printf '%s\n' "- @${login}"
-                done <<< "$contributors"
-              else
-                printf '%s\n' '- @loocor'
-              fi
-            } >> artifacts/release-notes.md
           fi
 
       - name: Create GitHub Release
@@ -440,7 +461,7 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ env.RELEASE_TAG }}
           draft: false
-          prerelease: ${{ contains(env.RELEASE_TAG, '-rc') || contains(env.RELEASE_TAG, '-beta') || contains(env.RELEASE_TAG, '-alpha') }}
+          prerelease: ${{ contains(env.RELEASE_TAG, '-') }}
           body_path: artifacts/release-notes.md
           files: |
             artifacts/*.dmg
@@ -449,5 +470,5 @@ jobs:
             artifacts/*.deb
             artifacts/*.app.tar.gz
             artifacts/*.nsis.zip
-            artifacts/*.sig
+            artifacts/signatures.zip
             artifacts/update.json

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -43,7 +43,6 @@ use tauri_plugin_updater::UpdaterExt;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::{Duration, sleep};
 use tracing::{info, warn};
-
 const MENU_CHECK_UPDATES_ID: &str = "menu.help.check_for_updates";
 const MENU_ABOUT_ID: &str = "menu.help.about";
 
@@ -287,36 +286,95 @@ pub fn run() -> Result<()> {
         if event.id.as_ref() == MENU_CHECK_UPDATES_ID {
             let handle = app_handle.clone();
             tauri::async_runtime::spawn(async move {
-                let (title, message) = match handle.updater() {
-                    Ok(updater) => match updater.check().await {
-                        Ok(Some(update)) => (
-                            "Update Available".to_string(),
-                            format!(
-                                "Version {} is ready. Auto-update will activate once CDN hosting is connected.",
-                                update.version
-                            ),
-                        ),
-                        Ok(None) => (
-                            "Up To Date".to_string(),
-                            "You are already running the latest MCPMate build.".to_string(),
-                        ),
-                        Err(err) => (
-                            "Update Check Failed".to_string(),
-                            format!("Unable to check for updates right now: {}", err),
-                        ),
-                    },
-                    Err(err) => (
-                        "Updater Unavailable".to_string(),
-                        format!("The updater service is not ready yet. Infrastructure pending: {}", err),
-                    ),
+                let updater = match handle.updater() {
+                    Ok(u) => u,
+                    Err(err) => {
+                        handle
+                            .dialog()
+                            .message(format!("The updater service is not ready: {}", err))
+                            .title("Updater Unavailable")
+                            .buttons(MessageDialogButtons::Ok)
+                            .show(|_| {});
+                        return;
+                    }
                 };
 
-                handle
-                    .dialog()
-                    .message(message)
-                    .title(title)
-                    .buttons(MessageDialogButtons::Ok)
-                    .show(|_| {});
+                match updater.check().await {
+                    Ok(Some(update)) => {
+                        let version = update.version.clone();
+                        let msg = format!(
+                            "Version {} is available (current: {}). Install now?",
+                            update.version, update.current_version,
+                        );
+                        let handle2 = handle.clone();
+                        handle
+                            .dialog()
+                            .message(msg)
+                            .title("Update Available")
+                            .buttons(MessageDialogButtons::OkCancelCustom(
+                                "Install".into(),
+                                "Later".into(),
+                            ))
+                            .show(move |yes| {
+                                if !yes {
+                                    return;
+                                }
+                                let handle3 = handle2.clone();
+                                tauri::async_runtime::spawn(async move {
+                                    match update
+                                        .download_and_install(
+                                            |_chunk_len, _content_len| {},
+                                            || {},
+                                        )
+                                        .await
+                                    {
+                                        Ok(()) => {
+                                            handle3
+                                                .dialog()
+                                                .message(format!(
+                                                    "Version {} has been installed. Restart now?",
+                                                    version,
+                                                ))
+                                                .title("Update Installed")
+                                                .buttons(MessageDialogButtons::OkCancelCustom(
+                                                    "Restart".into(),
+                                                    "Later".into(),
+                                                ))
+                                                .show(move |yes| {
+                                                    if yes {
+                                                        handle3.restart();
+                                                    }
+                                                });
+                                        }
+                                        Err(err) => {
+                                            handle3
+                                                .dialog()
+                                                .message(format!("Update failed: {}", err))
+                                                .title("Update Error")
+                                                .buttons(MessageDialogButtons::Ok)
+                                                .show(|_| {});
+                                        }
+                                    }
+                                });
+                            });
+                    }
+                    Ok(None) => {
+                        handle
+                            .dialog()
+                            .message("You are already running the latest MCPMate build.")
+                            .title("Up To Date")
+                            .buttons(MessageDialogButtons::Ok)
+                            .show(|_| {});
+                    }
+                    Err(err) => {
+                        handle
+                            .dialog()
+                            .message(format!("Unable to check for updates: {}", err))
+                            .title("Update Check Failed")
+                            .buttons(MessageDialogButtons::Ok)
+                            .show(|_| {});
+                    }
+                }
             });
         } else if event.id.as_ref() == MENU_ABOUT_ID {
             let handle = app_handle.clone();
@@ -340,7 +398,13 @@ pub fn run() -> Result<()> {
         }
     });
 
-    let updater_plugin = UpdaterPluginBuilder::new().build();
+    let updater_plugin = {
+        let mut builder = UpdaterPluginBuilder::new();
+        if let Ok(pubkey) = std::env::var("MCPMATE_UPDATER_PUBKEY") {
+            builder = builder.pubkey(pubkey);
+        }
+        builder.build()
+    };
 
     let builder = builder
         .plugin(tauri_plugin_dialog::init())

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -63,7 +63,7 @@
 			"endpoints": [
 				"https://github.com/loocor/mcpmate/releases/latest/download/update.json"
 			],
-			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY2QkJCNzQwN0Q0NDMzRTUKUldUbE0wUjlRTGU3WmlKLy9ibkhQd3d2VGM3VDR2bzQycTA2bkVhQzluKzBhSFIwcUs1VjRjRngK",
+			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ4MTI2ODAwNTEyRTgwMjAKUldRZ2dDNVJBR2dTU1BGNUJxU2Y5SWt4OFJYeGJGTjhkaXhnUDhyeGtJUCtjKzhEMEJYQklyd3cK",
 			"windows": {
 				"installMode": "passive"
 			}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "MCPMate",
-	"version": "0.1.0",
+	"version": "0.0.0-dev",
 	"identifier": "desktop.mcp.umate.ai",
 	"build": {
 		"devUrl": "http://127.0.0.1:5173",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -60,8 +60,10 @@
 		"updater": {
 			"active": false,
 			"dialog": true,
-			"endpoints": [],
-			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE5QzMxNjYwNTM5OEUwNTgKUldSWTRKaFRZQmJER1h4d1ZMYVA3dnluSjdpN2RmMldJR09hUFFlZDY0SlFqckkvRUJhZDJVZXAK",
+			"endpoints": [
+				"https://github.com/loocor/mcpmate/releases/latest/download/update.json"
+			],
+			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEMxNDM3QThDQUUyMjE3ODYKUldTR0Z5S3VqSHBEd1hITmJSYVNEaGFxeUJueFFnNGYxa05YMHlDb2srTzVETy9rY1JsVFFQSWUK",
 			"windows": {
 				"installMode": "passive"
 			}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -63,7 +63,7 @@
 			"endpoints": [
 				"https://github.com/loocor/mcpmate/releases/latest/download/update.json"
 			],
-			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEMxNDM3QThDQUUyMjE3ODYKUldTR0Z5S3VqSHBEd1hITmJSYVNEaGFxeUJueFFnNGYxa05YMHlDb2srTzVETy9rY1JsVFFQSWUK",
+			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY2QkJCNzQwN0Q0NDMzRTUKUldUbE0wUjlRTGU3WmlKLy9ibkhQd3d2VGM3VDR2bzQycTA2bkVhQzluKzBhSFIwcUs1VjRjRngK",
 			"windows": {
 				"installMode": "passive"
 			}

--- a/desktop/src-tauri/tauri.release-overlay.json
+++ b/desktop/src-tauri/tauri.release-overlay.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/desktop/src-tauri/tauri.release-overlay.json
+++ b/desktop/src-tauri/tauri.release-overlay.json
@@ -1,5 +1,10 @@
 {
   "bundle": {
     "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "active": true
+    }
   }
 }

--- a/packaging/desktop/collect-updater-artifacts.sh
+++ b/packaging/desktop/collect-updater-artifacts.sh
@@ -67,7 +67,7 @@ while IFS= read -r -d '' sig; do
   fi
 done < <(find "$BUNDLE_DIR" -type f -name "*.AppImage.sig" -print0 2>/dev/null) || true
 
-# Windows updater bundles: .nsis.zip + .nsis.zip.sig (or .msi.zip + .msi.zip.sig)
+# Windows updater bundles: .nsis.zip + .nsis.zip.sig, or .msi + .msi.sig (Tauri MSI bundler)
 while IFS= read -r -d '' sig; do
   bundle="${sig%.sig}"
   if [[ -f "$bundle" ]]; then
@@ -76,12 +76,12 @@ while IFS= read -r -d '' sig; do
     log "collected $(basename "$bundle") + sig"
     ((collected++)) || true
   fi
-done < <(find "$BUNDLE_DIR" -type f \( -name "*.nsis.zip.sig" -o -name "*.msi.zip.sig" \) -print0 2>/dev/null) || true
+done < <(find "$BUNDLE_DIR" -type f \( -name "*.nsis.zip.sig" -o -name "*.msi.zip.sig" -o -name "*.msi.sig" \) -print0 2>/dev/null) || true
 
 if [[ $collected -eq 0 ]]; then
   log "warning: no updater artifacts found in $BUNDLE_DIR"
   log "bundle layout:"
-  find "$BUNDLE_DIR" -type f -name "*.sig" -o -name "*.tar.gz" -o -name "*.AppImage" -o -name "*.nsis.zip" -o -name "*.msi.zip" | head -20 || true
+  find "$BUNDLE_DIR" -type f -name "*.sig" -o -name "*.tar.gz" -o -name "*.AppImage" -o -name "*.nsis.zip" -o -name "*.msi.zip" -o -name "*.msi" | head -20 || true
 fi
 
 log "collected $collected updater artifact pair(s) to $OUTPUT_DIR"

--- a/packaging/desktop/collect-updater-artifacts.sh
+++ b/packaging/desktop/collect-updater-artifacts.sh
@@ -5,9 +5,13 @@ usage() {
   cat <<'USAGE'
 Usage: collect-updater-artifacts.sh --bundle-dir <dir> --output-dir <dir>
 
-Scans a Tauri build bundle directory for updater artifacts
-(.app.tar.gz, .AppImage, .nsis.zip) and their .sig files,
-then copies them to the output directory.
+Scans a Tauri build bundle directory for updater .sig files,
+then copies them (and macOS .app.tar.gz bundles) to the output directory.
+
+For Linux and Windows, the update bundles (.AppImage, .msi) are also
+the installers and are uploaded separately by the build scripts — only
+the .sig files are collected here. For macOS, the .app.tar.gz update
+bundle is unique to the updater and is collected alongside its .sig.
 
 Options:
   --bundle-dir <dir>   Tauri bundle output directory (e.g. .../release/bundle)
@@ -46,6 +50,8 @@ log() { echo "[collect-updater-artifacts] $*"; }
 collected=0
 
 # macOS updater bundles: .app.tar.gz + .app.tar.gz.sig
+# The .app.tar.gz is a dedicated updater format (not the same as .dmg),
+# so we collect both the bundle and its signature.
 while IFS= read -r -d '' sig; do
   bundle="${sig%.sig}"
   if [[ -f "$bundle" ]]; then
@@ -56,26 +62,18 @@ while IFS= read -r -d '' sig; do
   fi
 done < <(find "$BUNDLE_DIR" -type f -name "*.app.tar.gz.sig" -print0 2>/dev/null) || true
 
-# Linux updater bundles: AppImage reused as update bundle + .sig
+# Linux updater: .AppImage.sig only (the .AppImage itself is uploaded as an installer)
 while IFS= read -r -d '' sig; do
-  bundle="${sig%.sig}"
-  if [[ -f "$bundle" ]]; then
-    cp -f "$bundle" "$OUTPUT_DIR/"
-    cp -f "$sig" "$OUTPUT_DIR/"
-    log "collected $(basename "$bundle") + sig"
-    ((collected++)) || true
-  fi
+  cp -f "$sig" "$OUTPUT_DIR/"
+  log "collected $(basename "$sig")"
+  ((collected++)) || true
 done < <(find "$BUNDLE_DIR" -type f -name "*.AppImage.sig" -print0 2>/dev/null) || true
 
-# Windows updater bundles: .nsis.zip + .nsis.zip.sig, or .msi + .msi.sig (Tauri MSI bundler)
+# Windows updater: .msi.sig / .nsis.zip.sig / .msi.zip.sig only
 while IFS= read -r -d '' sig; do
-  bundle="${sig%.sig}"
-  if [[ -f "$bundle" ]]; then
-    cp -f "$bundle" "$OUTPUT_DIR/"
-    cp -f "$sig" "$OUTPUT_DIR/"
-    log "collected $(basename "$bundle") + sig"
-    ((collected++)) || true
-  fi
+  cp -f "$sig" "$OUTPUT_DIR/"
+  log "collected $(basename "$sig")"
+  ((collected++)) || true
 done < <(find "$BUNDLE_DIR" -type f \( -name "*.nsis.zip.sig" -o -name "*.msi.zip.sig" -o -name "*.msi.sig" \) -print0 2>/dev/null) || true
 
 if [[ $collected -eq 0 ]]; then

--- a/packaging/desktop/collect-updater-artifacts.sh
+++ b/packaging/desktop/collect-updater-artifacts.sh
@@ -79,7 +79,7 @@ done < <(find "$BUNDLE_DIR" -type f \( -name "*.nsis.zip.sig" -o -name "*.msi.zi
 if [[ $collected -eq 0 ]]; then
   log "warning: no updater artifacts found in $BUNDLE_DIR"
   log "bundle layout:"
-  find "$BUNDLE_DIR" -type f -name "*.sig" -o -name "*.tar.gz" -o -name "*.AppImage" -o -name "*.nsis.zip" -o -name "*.msi.zip" -o -name "*.msi" | head -20 || true
+  find "$BUNDLE_DIR" -type f \( -name "*.sig" -o -name "*.tar.gz" -o -name "*.AppImage" -o -name "*.nsis.zip" -o -name "*.msi.zip" -o -name "*.msi" \) | head -20 || true
 fi
 
 log "collected $collected updater artifact pair(s) to $OUTPUT_DIR"

--- a/packaging/desktop/collect-updater-artifacts.sh
+++ b/packaging/desktop/collect-updater-artifacts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: collect-updater-artifacts.sh --bundle-dir <dir> --output-dir <dir>
+
+Scans a Tauri build bundle directory for updater artifacts
+(.app.tar.gz, .AppImage, .nsis.zip) and their .sig files,
+then copies them to the output directory.
+
+Options:
+  --bundle-dir <dir>   Tauri bundle output directory (e.g. .../release/bundle)
+  --output-dir <dir>   Destination directory for collected updater files
+  -h, --help           Show this help
+
+Example:
+  packaging/desktop/collect-updater-artifacts.sh \
+    --bundle-dir desktop/src-tauri/target/aarch64-apple-darwin/release/bundle \
+    --output-dir updater-artifacts
+USAGE
+}
+
+BUNDLE_DIR=""
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-dir) BUNDLE_DIR="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$BUNDLE_DIR" || -z "$OUTPUT_DIR" ]]; then
+  echo "--bundle-dir and --output-dir are required" >&2
+  usage >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+log() { echo "[collect-updater-artifacts] $*"; }
+
+collected=0
+
+# macOS updater bundles: .app.tar.gz + .app.tar.gz.sig
+while IFS= read -r -d '' sig; do
+  bundle="${sig%.sig}"
+  if [[ -f "$bundle" ]]; then
+    cp -f "$bundle" "$OUTPUT_DIR/"
+    cp -f "$sig" "$OUTPUT_DIR/"
+    log "collected $(basename "$bundle") + sig"
+    ((collected++)) || true
+  fi
+done < <(find "$BUNDLE_DIR" -type f -name "*.app.tar.gz.sig" -print0 2>/dev/null) || true
+
+# Linux updater bundles: AppImage reused as update bundle + .sig
+while IFS= read -r -d '' sig; do
+  bundle="${sig%.sig}"
+  if [[ -f "$bundle" ]]; then
+    cp -f "$bundle" "$OUTPUT_DIR/"
+    cp -f "$sig" "$OUTPUT_DIR/"
+    log "collected $(basename "$bundle") + sig"
+    ((collected++)) || true
+  fi
+done < <(find "$BUNDLE_DIR" -type f -name "*.AppImage.sig" -print0 2>/dev/null) || true
+
+# Windows updater bundles: .nsis.zip + .nsis.zip.sig (or .msi.zip + .msi.zip.sig)
+while IFS= read -r -d '' sig; do
+  bundle="${sig%.sig}"
+  if [[ -f "$bundle" ]]; then
+    cp -f "$bundle" "$OUTPUT_DIR/"
+    cp -f "$sig" "$OUTPUT_DIR/"
+    log "collected $(basename "$bundle") + sig"
+    ((collected++)) || true
+  fi
+done < <(find "$BUNDLE_DIR" -type f \( -name "*.nsis.zip.sig" -o -name "*.msi.zip.sig" \) -print0 2>/dev/null) || true
+
+if [[ $collected -eq 0 ]]; then
+  log "warning: no updater artifacts found in $BUNDLE_DIR"
+  log "bundle layout:"
+  find "$BUNDLE_DIR" -type f -name "*.sig" -o -name "*.tar.gz" -o -name "*.AppImage" -o -name "*.nsis.zip" -o -name "*.msi.zip" | head -20 || true
+fi
+
+log "collected $collected updater artifact pair(s) to $OUTPUT_DIR"

--- a/packaging/desktop/generate-update-manifest.sh
+++ b/packaging/desktop/generate-update-manifest.sh
@@ -12,7 +12,8 @@ Required:
 Optional (repeatable):
   --platform <target> <url> <signature>
                               Add an entry under platforms[target] with the given download URL and
-                              base64 Ed25519 signature. Invoke multiple times for each target.
+                              base64 Ed25519 signature. <target> may be either the Tauri updater
+                              key (e.g. darwin-aarch64) or a Rust target triple.
   --notes <text>               Release notes (default: empty)
   --pub-date <ISO8601>         Publication timestamp (default: current UTC)
 
@@ -21,10 +22,22 @@ Example:
     --version 0.1.2 \
     --output dist/update.json \
     --notes "Fix desktop links" \
-    --platform aarch64-apple-darwin https://cdn/app_0.1.2_arm64.dmg BASE64SIG_ARM64 \
-    --platform x86_64-apple-darwin https://cdn/app_0.1.2_x64.dmg BASE64SIG_X64 \
-    --platform x86_64-pc-windows-msvc https://cdn/app_0.1.2_x64.msi BASE64SIG_WIN
+    --platform darwin-aarch64 https://cdn/app_0.1.2_arm64.app.tar.gz BASE64SIG_ARM64 \
+    --platform darwin-x86_64 https://cdn/app_0.1.2_x64.app.tar.gz BASE64SIG_X64 \
+    --platform windows-x86_64 https://cdn/app_0.1.2_x64.msi.zip BASE64SIG_WIN
 USAGE
+}
+
+normalize_platform_key() {
+  case "$1" in
+    aarch64-apple-darwin) echo "darwin-aarch64" ;;
+    x86_64-apple-darwin) echo "darwin-x86_64" ;;
+    aarch64-pc-windows-msvc) echo "windows-aarch64" ;;
+    x86_64-pc-windows-msvc) echo "windows-x86_64" ;;
+    aarch64-unknown-linux-gnu) echo "linux-aarch64" ;;
+    x86_64-unknown-linux-gnu) echo "linux-x86_64" ;;
+    *) echo "$1" ;;
+  esac
 }
 
 VERSION=""
@@ -53,7 +66,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --platform)
-      TARGET="$2"
+      TARGET=$(normalize_platform_key "$2")
       URL="$3"
       SIG="$4"
       PLATFORM_URLS["$TARGET"]="$URL"

--- a/packaging/desktop/linux-build-tauri-release.sh
+++ b/packaging/desktop/linux-build-tauri-release.sh
@@ -7,6 +7,7 @@ TARGET="x86_64-unknown-linux-gnu"
 BUNDLES="appimage,deb"
 declare -a EXTRA_ARGS=()
 OUTPUT_DIR="${HOME}/Downloads"
+WITH_UPDATER=0
 
 usage() {
   cat <<'USAGE'
@@ -17,6 +18,7 @@ Options:
   --target <triple>           Rust target triple (default: x86_64-unknown-linux-gnu)
   --bundles <list>            Comma-separated bundle types (default: appimage,deb)
   --skip-board                Reuse existing board/dist instead of rebuilding
+  --with-updater              Enable updater artifact generation (requires TAURI_SIGNING_PRIVATE_KEY)
   --extra "..."               Extra argument forwarded to cargo tauri build (repeatable)
   --output-dir <path>         Directory to collect generated artifacts (default: ~/Downloads)
   -h, --help                  Show this help message
@@ -48,6 +50,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-board)
       BUILD_BOARD=0
+      shift 1
+      ;;
+    --with-updater)
+      WITH_UPDATER=1
       shift 1
       ;;
     --extra)
@@ -197,6 +203,11 @@ build_core_sidecar() {
   chmod +x "$SIDECAR_OUTPUT_DIR/mcpmate-core"
 }
 
+if [[ $WITH_UPDATER -eq 1 && -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]]; then
+  echo "[linux-build-tauri-release] --with-updater requires TAURI_SIGNING_PRIVATE_KEY" >&2
+  exit 1
+fi
+
 log "building target=$TARGET profile=$PROFILE bundles=$BUNDLES"
 
 build_bridge_sidecar "$TARGET"
@@ -207,6 +218,10 @@ cmd=(
   --target "$TARGET"
   --bundles "$BUNDLES"
 )
+
+if [[ $WITH_UPDATER -eq 1 ]]; then
+  cmd+=(--config "$TAURI_SRC_DIR/tauri.release-overlay.json")
+fi
 
 if [[ "$PROFILE" == "debug" ]]; then
   cmd+=(--debug)

--- a/packaging/desktop/linux-build-tauri-release.sh
+++ b/packaging/desktop/linux-build-tauri-release.sh
@@ -268,24 +268,10 @@ if [[ ${#artifacts[@]} -eq 0 ]]; then
   exit 1
 fi
 
-# Normalize arch label for release artifact naming
-case "$TARGET" in
-  aarch64-unknown-linux-gnu) ARCH_LABEL="aarch64" ;;
-  x86_64-unknown-linux-gnu)  ARCH_LABEL="x64" ;;
-  *)                         ARCH_LABEL="$TARGET" ;;
-esac
-
 log "copying ${#artifacts[@]} artifact(s) to $OUTPUT_DIR"
 for artifact in "${artifacts[@]}"; do
-  base="$(basename "$artifact")"
-  lower="$(echo "$base" | tr '[:upper:]' '[:lower:]')"
-  case "$lower" in
-    *.appimage) out_name="mcpmate_desktop_linux_${ARCH_LABEL}.AppImage" ;;
-    *.deb)      out_name="mcpmate_desktop_linux_${ARCH_LABEL}.deb" ;;
-    *)          out_name="$base" ;;
-  esac
-  cp -f "$artifact" "$OUTPUT_DIR/$out_name"
-  log "copied $base -> $out_name"
+  cp -f "$artifact" "$OUTPUT_DIR/"
+  log "copied $(basename "$artifact")"
 done
 
 log "build completed successfully"

--- a/packaging/desktop/macos-build-tauri-release.sh
+++ b/packaging/desktop/macos-build-tauri-release.sh
@@ -56,7 +56,7 @@ Options:
   --target <triple>           Single Tauri target triple
   --targets <list>            Comma-separated Tauri targets
                                (default: aarch64-apple-darwin,x86_64-apple-darwin)
-  --bundles <list>            Bundles passed to cargo tauri build (dmg only; default: dmg)
+  --bundles <list>            Bundles passed to cargo tauri build (allowed: dmg or app,dmg; default: dmg)
   --skip-board                Reuse existing board/dist instead of rebuilding
   --with-updater              Enable updater artifact generation (requires TAURI_SIGNING_PRIVATE_KEY)
   --extra "..."               Extra argument forwarded to cargo tauri build (repeatable)
@@ -76,7 +76,7 @@ Options:
 Examples:
   packaging/desktop/macos-build-tauri-release.sh
   packaging/desktop/macos-build-tauri-release.sh --target aarch64-apple-darwin --bundles dmg
-  packaging/desktop/macos-build-tauri-release.sh --targets aarch64-apple-darwin,x86_64-apple-darwin --bundles dmg
+  packaging/desktop/macos-build-tauri-release.sh --targets aarch64-apple-darwin,x86_64-apple-darwin --bundles app,dmg --with-updater
   packaging/desktop/macos-build-tauri-release.sh --profile debug --skip-board
 
 Notes:
@@ -85,6 +85,40 @@ Notes:
   * Signing/notarization logs hide team id, API issuer, and identity strings by default; set
     MCPMATE_BUILD_LOG_SIGNING_DETAILS=1 for the previous verbose output (avoid in public CI).
 USAGE
+}
+
+validate_bundles() {
+  local has_app=0
+  local has_dmg=0
+  local bundle
+  local -a bundle_list=()
+
+  IFS=',' read -r -a bundle_list <<< "$BUNDLES"
+
+  for bundle in "${bundle_list[@]}"; do
+    case "$bundle" in
+      dmg)
+        has_dmg=1
+        ;;
+      app)
+        has_app=1
+        ;;
+      *)
+        echo "[macos-build-tauri-release] unsupported bundle: $bundle (allowed: app,dmg)" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ $has_dmg -ne 1 ]]; then
+    echo "[macos-build-tauri-release] unsupported bundles: $BUNDLES (must include dmg)" >&2
+    exit 1
+  fi
+
+  if [[ $WITH_UPDATER -eq 1 && $has_app -ne 1 ]]; then
+    echo "[macos-build-tauri-release] --with-updater on macOS requires --bundles app,dmg" >&2
+    exit 1
+  fi
 }
 
 # Preload environment defaults from .env files (if present)
@@ -168,10 +202,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$BUNDLES" != "dmg" ]]; then
-  echo "[macos-build-tauri-release] unsupported bundles: $BUNDLES (expected: dmg)" >&2
-  exit 1
-fi
+validate_bundles
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/packaging/desktop/macos-build-tauri-release.sh
+++ b/packaging/desktop/macos-build-tauri-release.sh
@@ -22,6 +22,7 @@ APPLE_API_KEY_PATH_OPT=""
 # Diagnostics default (compile-time cfg). When enabled, desktop shell auto-enables
 # market diagnostics and forwards front-end logs without user interaction.
 DIAG_DEFAULT=0
+WITH_UPDATER=0
 
 # Load .env files from desktop/ so users don't need to pass flags each time.
 load_env_files() {
@@ -57,6 +58,7 @@ Options:
                                (default: aarch64-apple-darwin,x86_64-apple-darwin)
   --bundles <list>            Bundles passed to cargo tauri build (dmg only; default: dmg)
   --skip-board                Reuse existing board/dist instead of rebuilding
+  --with-updater              Enable updater artifact generation (requires TAURI_SIGNING_PRIVATE_KEY)
   --extra "..."               Extra argument forwarded to cargo tauri build (repeatable)
   --output-dir <path>         Directory to collect generated DMG files (default: ~/Downloads)
   --diag-default              Build with market diagnostics enabled by default
@@ -116,6 +118,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --diag-default)
       DIAG_DEFAULT=1
+      shift 1
+      ;;
+    --with-updater)
+      WITH_UPDATER=1
       shift 1
       ;;
     --sign-identity)
@@ -548,6 +554,11 @@ build_core_sidecar() {
   finalize_sidecar_fingerprint "mcpmate-core" "$target"
 }
 
+if [[ $WITH_UPDATER -eq 1 && -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]]; then
+  echo "[macos-build-tauri-release] --with-updater requires TAURI_SIGNING_PRIVATE_KEY" >&2
+  exit 1
+fi
+
 for TARGET in "${TARGET_LIST[@]}"; do
   echo "[macos-build-tauri-release] building target=$TARGET profile=$PROFILE bundles=$BUNDLES"
 
@@ -559,6 +570,10 @@ for TARGET in "${TARGET_LIST[@]}"; do
     --target "$TARGET"
     --bundles "$BUNDLES"
   )
+
+  if [[ $WITH_UPDATER -eq 1 ]]; then
+    cmd+=(--config "$TAURI_SRC_DIR/tauri.release-overlay.json")
+  fi
 
   if [[ "$PROFILE" == "debug" ]]; then
     cmd+=(--debug)

--- a/packaging/desktop/windows-build-tauri-release.sh
+++ b/packaging/desktop/windows-build-tauri-release.sh
@@ -258,18 +258,10 @@ if [[ ${#artifacts[@]} -eq 0 ]]; then
   exit 1
 fi
 
-# Normalize arch label for release artifact naming
-case "$TARGET" in
-  aarch64-pc-windows-msvc) ARCH_LABEL="aarch64" ;;
-  x86_64-pc-windows-msvc)  ARCH_LABEL="x64" ;;
-  *)                       ARCH_LABEL="$TARGET" ;;
-esac
-
 log "copying ${#artifacts[@]} artifact(s) to $OUTPUT_DIR"
 for artifact in "${artifacts[@]}"; do
-  out_name="mcpmate_desktop_windows_${ARCH_LABEL}.msi"
-  cp -f "$artifact" "$OUTPUT_DIR/$out_name"
-  log "copied $(basename "$artifact") -> $out_name"
+  cp -f "$artifact" "$OUTPUT_DIR/"
+  log "copied $(basename "$artifact")"
 done
 
 log "build completed successfully"

--- a/packaging/desktop/windows-build-tauri-release.sh
+++ b/packaging/desktop/windows-build-tauri-release.sh
@@ -7,6 +7,7 @@ TARGET="x86_64-pc-windows-msvc"
 BUNDLES="msi"
 declare -a EXTRA_ARGS=()
 OUTPUT_DIR="${USERPROFILE}/Downloads"
+WITH_UPDATER=0
 
 usage() {
   cat <<'USAGE'
@@ -17,6 +18,7 @@ Options:
   --target <triple>           Rust target triple (default: x86_64-pc-windows-msvc)
   --bundles <list>            Comma-separated bundle types (default: msi)
   --skip-board                Reuse existing board/dist instead of rebuilding
+  --with-updater              Enable updater artifact generation (requires TAURI_SIGNING_PRIVATE_KEY)
   --extra "..."               Extra argument forwarded to cargo tauri build (repeatable)
   --output-dir <path>         Directory to collect generated artifacts (default: ~/Downloads)
   -h, --help                  Show this help message
@@ -49,6 +51,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-board)
       BUILD_BOARD=0
+      shift 1
+      ;;
+    --with-updater)
+      WITH_UPDATER=1
       shift 1
       ;;
     --extra)
@@ -194,6 +200,11 @@ build_core_sidecar() {
   cp "$built_path" "$SIDECAR_OUTPUT_DIR/mcpmate-core.exe"
 }
 
+if [[ $WITH_UPDATER -eq 1 && -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]]; then
+  echo "[windows-build-tauri-release] --with-updater requires TAURI_SIGNING_PRIVATE_KEY" >&2
+  exit 1
+fi
+
 log "building target=$TARGET profile=$PROFILE bundles=$BUNDLES"
 
 build_bridge_sidecar "$TARGET"
@@ -204,6 +215,10 @@ cmd=(
   --target "$TARGET"
   --bundles "$BUNDLES"
 )
+
+if [[ $WITH_UPDATER -eq 1 ]]; then
+  cmd+=(--config "$TAURI_SRC_DIR/tauri.release-overlay.json")
+fi
 
 if [[ "$PROFILE" == "debug" ]]; then
   cmd+=(--debug)

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:20-bookworm-slim AS board-builder
+ARG NODE_IMAGE=node:20-bookworm-slim
+ARG RUST_IMAGE=rust:1-bookworm
+ARG RUNTIME_IMAGE=debian:bookworm-slim
+
+FROM ${NODE_IMAGE} AS board-builder
 
 WORKDIR /workspace/board
 COPY board/package.json board/package-lock.json ./
@@ -6,7 +10,7 @@ RUN npm ci
 COPY board ./
 RUN NODE_OPTIONS=--max-old-space-size=4096 npm run build
 
-FROM rust:stable-bookworm AS builder
+FROM ${RUST_IMAGE} AS builder
 
 WORKDIR /workspace
 
@@ -15,7 +19,7 @@ COPY backend ./backend
 WORKDIR /workspace/backend
 RUN cargo build --release --bin mcpmate --bin bridge
 
-FROM debian:bookworm-slim AS runtime
+FROM ${RUNTIME_IMAGE} AS runtime
 
 LABEL org.opencontainers.image.title="MCPMate"
 LABEL org.opencontainers.image.description="Local MCP proxy and management server for AI clients"

--- a/scripts/download-stats.sh
+++ b/scripts/download-stats.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: download-stats.sh [--json] [tag]
+
+Query GitHub Release asset download counts for this repository.
+
+Arguments:
+  tag       Optional release tag to filter to a single release
+
+Options:
+  --json    Print raw JSON summary instead of a table
+  -h, --help
+
+Examples:
+  scripts/download-stats.sh
+  scripts/download-stats.sh v0.0.0-test-9
+  scripts/download-stats.sh --json v0.0.0-test-9
+USAGE
+}
+
+OUTPUT_MODE="table"
+FILTER_TAG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      OUTPUT_MODE="json"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "$FILTER_TAG" ]]; then
+        echo "error: only one tag filter is supported" >&2
+        usage >&2
+        exit 1
+      fi
+      FILTER_TAG="$1"
+      shift
+      ;;
+  esac
+done
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd gh
+require_cmd jq
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh CLI not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+CAPTURED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+releases_json="$(gh api "repos/${REPO}/releases?per_page=100")"
+
+summary_json="$(jq \
+  --arg captured_at "$CAPTURED_AT" \
+  --arg repo "$REPO" \
+  --arg tag "$FILTER_TAG" '
+  {
+    capturedAt: $captured_at,
+    repository: $repo,
+    releases: [
+      .[]
+      | select($tag == "" or .tag_name == $tag)
+      | {
+          tagName: .tag_name,
+          name: .name,
+          draft: .draft,
+          prerelease: .prerelease,
+          publishedAt: .published_at,
+          totalDownloads: ([.assets[].download_count] | add // 0),
+          assets: [
+            .assets[] | {
+              name,
+              size,
+              contentType: .content_type,
+              downloadCount: .download_count,
+              url: .browser_download_url
+            }
+          ]
+        }
+    ]
+  }
+' <<<"$releases_json")"
+
+if [[ "$OUTPUT_MODE" == "json" ]]; then
+  printf '%s\n' "$summary_json"
+  exit 0
+fi
+
+release_count="$(jq '.releases | length' <<<"$summary_json")"
+if [[ "$release_count" -eq 0 ]]; then
+  if [[ -n "$FILTER_TAG" ]]; then
+    echo "No release found for tag: $FILTER_TAG"
+  else
+    echo "No releases found."
+  fi
+  exit 0
+fi
+
+echo "Repository: $REPO"
+echo "Captured at: $CAPTURED_AT"
+echo
+
+jq -r '
+  .releases[] |
+  "Release: " + .tagName,
+  (if .prerelease then "Type: prerelease" else "Type: stable" end),
+  "Published: " + (.publishedAt // "n/a"),
+  "Total downloads: " + (.totalDownloads | tostring),
+  "| Asset | Downloads | Size (bytes) |",
+  "| --- | ---: | ---: |",
+  (.assets[] | "| \(.name) | \(.downloadCount) | \(.size) |"),
+  ""
+' <<<"$summary_json"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,14 +3,18 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: release.sh [patch|minor|major]
+Usage: release.sh [patch|minor|major] [type]
 
 Bumps the version, creates a git tag, and pushes to trigger the release workflow.
 
-Version is derived from the latest semver tag (vX.Y.Z).
+Version is derived from the latest stable semver tag (vX.Y.Z).
   patch  0.1.0 → 0.1.1  (default)
   minor  0.1.0 → 0.2.0
   major  0.1.0 → 1.0.0
+
+Tag forms:
+  vX.Y.Z                         Stable release (default)
+  vX.Y.Z-YYYYMMDDHHMMSS-type     Timestamped pre-release/test tag
 
 Pre-flight checks:
   - Clean working tree
@@ -21,12 +25,14 @@ Pre-flight checks:
   - Latest CI on main is green
 
 Example:
-  scripts/release.sh           # patch bump
-  scripts/release.sh minor     # minor bump
+  scripts/release.sh           # stable patch bump
+  scripts/release.sh minor     # stable minor bump
+  scripts/release.sh patch test
 USAGE
 }
 
 BUMP="${1:-patch}"
+TAG_TYPE="${2:-}"
 
 if [[ "$BUMP" == "-h" || "$BUMP" == "--help" ]]; then
   usage
@@ -35,6 +41,12 @@ fi
 
 if [[ "$BUMP" != "patch" && "$BUMP" != "minor" && "$BUMP" != "major" ]]; then
   echo "error: bump must be one of: patch, minor, major" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ -n "$TAG_TYPE" && ! "$TAG_TYPE" =~ ^[a-z0-9]+$ ]]; then
+  echo "error: type must be lowercase letters or digits only" >&2
   usage >&2
   exit 1
 fi
@@ -127,13 +139,19 @@ fi
 
 # ── Compute next version ─────────────────────────────────────────────────────
 
-latest_tag="$(git -C "$REPO_ROOT" tag --list 'v*' --sort=-version:refname | head -n1)"
+latest_tag="$(git -C "$REPO_ROOT" tag --list 'v*' --sort=-version:refname | while IFS= read -r t; do
+  case "${t#v}" in
+    *-*|*[^0-9.]*) ;;
+    *) printf '%s\n' "$t"; break ;;
+  esac
+ done)"
 if [[ -z "$latest_tag" ]]; then
   base_version="0.0.0"
-  log "no existing semver tags found, starting from 0.0.0"
+  log "no existing stable semver tags found, starting from 0.0.0"
 else
   base_version="${latest_tag#v}"
-  log "latest tag: $latest_tag (version $base_version)"
+  base_version="${base_version%%-*}"
+  log "latest tag: $latest_tag (base version $base_version)"
 fi
 
 IFS='.' read -r major minor patch <<< "$base_version"
@@ -145,6 +163,10 @@ esac
 
 next_version="${major}.${minor}.${patch}"
 next_tag="v${next_version}"
+if [[ -n "$TAG_TYPE" ]]; then
+  timestamp="$(date +%Y%m%d%H%M%S)"
+  next_tag="${next_tag}-${timestamp}-${TAG_TYPE}"
+fi
 
 # Check tag doesn't already exist
 if git -C "$REPO_ROOT" tag --list "$next_tag" | grep -q .; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -99,6 +99,7 @@ required_files=(
   "packaging/desktop/windows-build-tauri-release.sh"
   "packaging/desktop/collect-updater-artifacts.sh"
   "packaging/desktop/generate-update-manifest.sh"
+  "desktop/src-tauri/tauri.release-overlay.json"
 )
 missing=0
 for f in "${required_files[@]}"; do
@@ -114,7 +115,7 @@ fi
 log "  ✓ key release files present"
 
 # 6. Latest CI on main is green
-latest_run=$(gh run list --branch main --workflow=ci.yml --limit=1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "")
+latest_run=$(gh run list --branch main --workflow=desktop-macos.yml --limit=1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "")
 if [[ "$latest_run" == "failure" ]]; then
   err "latest CI on main failed. Fix CI before releasing."
   exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: release.sh [patch|minor|major]
+
+Bumps the version, creates a git tag, and pushes to trigger the release workflow.
+
+Version is derived from the latest semver tag (vX.Y.Z).
+  patch  0.1.0 → 0.1.1  (default)
+  minor  0.1.0 → 0.2.0
+  major  0.1.0 → 1.0.0
+
+Pre-flight checks:
+  - Clean working tree
+  - On main branch, up to date with remote
+  - gh CLI authenticated
+  - Target tag does not already exist
+  - Key release files present
+  - Latest CI on main is green
+
+Example:
+  scripts/release.sh           # patch bump
+  scripts/release.sh minor     # minor bump
+USAGE
+}
+
+BUMP="${1:-patch}"
+
+if [[ "$BUMP" == "-h" || "$BUMP" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$BUMP" != "patch" && "$BUMP" != "minor" && "$BUMP" != "major" ]]; then
+  echo "error: bump must be one of: patch, minor, major" >&2
+  usage >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+log() { echo "[release] $*"; }
+err() { echo "[release] error: $*" >&2; }
+
+# ── Pre-flight checks ────────────────────────────────────────────────────────
+
+log "running pre-flight checks..."
+
+# 1. Clean working tree
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  err "working tree is not clean. Commit or stash changes first."
+  git -C "$REPO_ROOT" status --short
+  exit 1
+fi
+log "  ✓ working tree clean"
+
+# 2. On main branch
+current_branch="$(git -C "$REPO_ROOT" branch --show-current)"
+if [[ "$current_branch" != "main" ]]; then
+  err "not on main branch (currently on: $current_branch)"
+  exit 1
+fi
+log "  ✓ on main branch"
+
+# 3. Up to date with remote
+git -C "$REPO_ROOT" fetch origin main --quiet
+ahead=$(git -C "$REPO_ROOT" rev-list --count "origin/main..HEAD")
+behind=$(git -C "$REPO_ROOT" rev-list --count "HEAD..origin/main")
+if [[ "$ahead" -gt 0 ]]; then
+  err "local main is $ahead commit(s) ahead of origin/main. Push first."
+  exit 1
+fi
+if [[ "$behind" -gt 0 ]]; then
+  err "local main is $behind commit(s) behind origin/main. Pull first."
+  exit 1
+fi
+log "  ✓ in sync with origin/main"
+
+# 4. gh CLI authenticated
+if ! command -v gh >/dev/null 2>&1; then
+  err "gh CLI not found. Install: https://cli.github.com"
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  err "gh CLI not authenticated. Run: gh auth login"
+  exit 1
+fi
+log "  ✓ gh CLI authenticated"
+
+# 5. Key release files exist
+required_files=(
+  "desktop/src-tauri/tauri.conf.json"
+  ".github/workflows/release.yml"
+  "packaging/desktop/macos-build-tauri-release.sh"
+  "packaging/desktop/linux-build-tauri-release.sh"
+  "packaging/desktop/windows-build-tauri-release.sh"
+  "packaging/desktop/collect-updater-artifacts.sh"
+  "packaging/desktop/generate-update-manifest.sh"
+)
+missing=0
+for f in "${required_files[@]}"; do
+  if [[ ! -f "$REPO_ROOT/$f" ]]; then
+    err "  missing: $f"
+    missing=1
+  fi
+done
+if [[ $missing -eq 1 ]]; then
+  err "required release files are missing"
+  exit 1
+fi
+log "  ✓ key release files present"
+
+# 6. Latest CI on main is green
+latest_run=$(gh run list --branch main --workflow=ci.yml --limit=1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "")
+if [[ "$latest_run" == "failure" ]]; then
+  err "latest CI on main failed. Fix CI before releasing."
+  exit 1
+elif [[ -z "$latest_run" ]]; then
+  log "  ⚠ could not verify CI status (no runs found or gh error) — continuing"
+else
+  log "  ✓ latest CI on main: $latest_run"
+fi
+
+# ── Compute next version ─────────────────────────────────────────────────────
+
+latest_tag="$(git -C "$REPO_ROOT" tag --list 'v*' --sort=-version:refname | head -n1)"
+if [[ -z "$latest_tag" ]]; then
+  base_version="0.0.0"
+  log "no existing semver tags found, starting from 0.0.0"
+else
+  base_version="${latest_tag#v}"
+  log "latest tag: $latest_tag (version $base_version)"
+fi
+
+IFS='.' read -r major minor patch <<< "$base_version"
+case "$BUMP" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  patch) patch=$((patch + 1)) ;;
+esac
+
+next_version="${major}.${minor}.${patch}"
+next_tag="v${next_version}"
+
+# Check tag doesn't already exist
+if git -C "$REPO_ROOT" tag --list "$next_tag" | grep -q .; then
+  err "tag $next_tag already exists"
+  exit 1
+fi
+
+log ""
+log "  $latest_tag  →  $next_tag  ($BUMP)"
+log ""
+
+# ── Confirm ──────────────────────────────────────────────────────────────────
+
+read -rp "Proceed with release $next_tag? [y/N] " answer
+if [[ "$answer" != "y" && "$answer" != "Y" ]]; then
+  log "aborted."
+  exit 0
+fi
+
+# ── Tag and push ─────────────────────────────────────────────────────────────
+
+git -C "$REPO_ROOT" tag "$next_tag"
+git -C "$REPO_ROOT" push origin "$next_tag"
+
+log "tag $next_tag pushed — release workflow triggered"
+log "watch: gh run list --workflow=release.yml --limit=1"


### PR DESCRIPTION
## Summary
- Add complete tag-driven release workflow for desktop (macOS/Windows/Linux) with updater signing
- Add `scripts/release.sh` — version bump + tag + push with 6 pre-flight checks (clean tree, main branch, remote sync, gh auth, key files, CI status)
- Auto-inject version from git tag into `tauri.conf.json` at build time (version in repo is `0.0.0-dev`)
- Fix bash subshell bug in update manifest generation (`find|while` → process substitution) so `update.json` platforms are populated
- Remove custom installer renaming — use Tauri-native filenames, eliminate duplicate artifacts on release page
- Updater collector only collects `.sig` for Linux/Windows (installer bundle uploaded separately); macOS retains bundle+sig for `.app.tar.gz`
- Windows builds are non-blocking (`continue-on-error`); updater upload uses `if-no-files-found: warn`
- Release title simplified to tag only (e.g. `v0.1.0`)

## Usage
```bash
scripts/release.sh           # patch: 0.1.0 → 0.1.1
scripts/release.sh minor     # minor: 0.1.0 → 0.2.0
scripts/release.sh major     # major: 0.1.0 → 1.0.0
```

## Test plan
- [ ] Merge to main
- [ ] Run `scripts/release.sh` from main
- [ ] Verify pre-flight checks pass
- [ ] Verify CI builds all platforms with correct version injected
- [ ] Verify release page has no duplicate artifacts
- [ ] Verify `update.json` has populated `platforms`
- [ ] Verify release title is clean (e.g. `v0.1.0`)