### PR TITLE
fix(client-import): expose skipped server reasons

### DIFF
--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -28,7 +28,6 @@ use crate::clients::{
     ClientConfigService, ClientDescriptor, ClientRenderOptions, ConfigError, ConfigMode, TemplateExecutionResult,
 };
 use crate::common::ClientCategory;
-use crate::config::server::import::SkipReason;
 use crate::core::proxy::server::ProxyServer;
 use axum::{
     extract::{Json, Query, State},
@@ -979,25 +978,7 @@ pub async fn config_import(
         })
         .collect();
 
-    let skipped_servers: Vec<SkippedServerData> = skipped
-        .into_iter()
-        .map(|s| SkippedServerData {
-            name: s.name,
-            reason: match &s.reason {
-                SkipReason::DuplicateName => "duplicate_name".to_string(),
-                SkipReason::DuplicateFingerprint => "duplicate_fingerprint".to_string(),
-                SkipReason::UrlQueryMismatch { .. } => "url_query_mismatch".to_string(),
-            },
-            existing_query: match &s.reason {
-                SkipReason::UrlQueryMismatch { existing_query, .. } => existing_query.clone(),
-                _ => None,
-            },
-            incoming_query: match &s.reason {
-                SkipReason::UrlQueryMismatch { incoming_query, .. } => incoming_query.clone(),
-                _ => None,
-            },
-        })
-        .collect();
+    let skipped_servers: Vec<SkippedServerData> = skipped.into_iter().map(SkippedServerData::from).collect();
 
     let skipped_count = skipped_servers.len() as u32;
 

--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -15,6 +15,7 @@ use crate::api::models::client::{
     ClientImportSummary, ClientImportedServer, ClientInfo, ClientTemplateMetadata, ClientTemplateStorageMetadata,
     ClientUnifyDirectExposureData,
 };
+use crate::api::models::server::SkippedServerData;
 use crate::api::routes::AppState;
 use crate::audit::{AuditAction, AuditEvent, AuditStatus};
 use crate::clients::models::{
@@ -27,6 +28,7 @@ use crate::clients::{
     ClientConfigService, ClientDescriptor, ClientRenderOptions, ConfigError, ConfigMode, TemplateExecutionResult,
 };
 use crate::common::ClientCategory;
+use crate::config::server::import::SkipReason;
 use crate::core::proxy::server::ProxyServer;
 use axum::{
     extract::{Json, Query, State},
@@ -977,12 +979,35 @@ pub async fn config_import(
         })
         .collect();
 
+    let skipped_servers: Vec<SkippedServerData> = skipped
+        .into_iter()
+        .map(|s| SkippedServerData {
+            name: s.name,
+            reason: match &s.reason {
+                SkipReason::DuplicateName => "duplicate_name".to_string(),
+                SkipReason::DuplicateFingerprint => "duplicate_fingerprint".to_string(),
+                SkipReason::UrlQueryMismatch { .. } => "url_query_mismatch".to_string(),
+            },
+            existing_query: match &s.reason {
+                SkipReason::UrlQueryMismatch { existing_query, .. } => existing_query.clone(),
+                _ => None,
+            },
+            incoming_query: match &s.reason {
+                SkipReason::UrlQueryMismatch { incoming_query, .. } => incoming_query.clone(),
+                _ => None,
+            },
+        })
+        .collect();
+
+    let skipped_count = skipped_servers.len() as u32;
+
     let summary = ClientImportSummary {
         attempted: true,
         imported_count: imported_servers.len() as u32,
-        skipped_count: skipped.len() as u32,
+        skipped_count,
         failed_count: failed.len() as u32,
         errors: if failed.is_empty() { None } else { Some(failed) },
+        skipped_servers,
     };
 
     let data = ClientConfigImportData {

--- a/backend/src/api/handlers/registry.rs
+++ b/backend/src/api/handlers/registry.rs
@@ -497,30 +497,8 @@ pub async fn install_server(
         skipped_servers: outcome
             .skipped
             .iter()
-            .map(|s| crate::api::models::server::SkippedServerData {
-                name: s.name.clone(),
-                reason: match s.reason {
-                    crate::config::server::import::SkipReason::DuplicateName => "duplicate_name".to_string(),
-                    crate::config::server::import::SkipReason::DuplicateFingerprint => {
-                        "duplicate_fingerprint".to_string()
-                    }
-                    crate::config::server::import::SkipReason::UrlQueryMismatch { .. } => {
-                        "url_query_mismatch".to_string()
-                    }
-                },
-                existing_query: match &s.reason {
-                    crate::config::server::import::SkipReason::UrlQueryMismatch { existing_query, .. } => {
-                        existing_query.clone()
-                    }
-                    _ => None,
-                },
-                incoming_query: match &s.reason {
-                    crate::config::server::import::SkipReason::UrlQueryMismatch { incoming_query, .. } => {
-                        incoming_query.clone()
-                    }
-                    _ => None,
-                },
-            })
+            .cloned()
+            .map(crate::api::models::server::SkippedServerData::from)
             .collect(),
         failed_count,
         failed_servers: outcome.failed.keys().cloned().collect(),

--- a/backend/src/api/handlers/server/crud.rs
+++ b/backend/src/api/handlers/server/crud.rs
@@ -14,8 +14,7 @@ use crate::{
     common::server::ServerType,
     config::server::capabilities::sync_via_connection_pool,
     config::server::{
-        ConflictPolicy, ImportOptions, ImportOutcome, SkipReason, SkippedServer, import::server_meta_from_payload,
-        import_batch,
+        ConflictPolicy, ImportOptions, ImportOutcome, SkippedServer, import::server_meta_from_payload, import_batch,
     },
     config::server::{replace_server_headers, upsert_server_headers},
     config::{
@@ -710,21 +709,7 @@ pub async fn import_servers(
 }
 
 fn skipped_server_to_api(source: SkippedServer) -> SkippedServerData {
-    let (reason, existing_query, incoming_query) = match source.reason {
-        SkipReason::DuplicateName => ("duplicate_name".to_string(), None, None),
-        SkipReason::DuplicateFingerprint => ("duplicate_fingerprint".to_string(), None, None),
-        SkipReason::UrlQueryMismatch {
-            existing_query,
-            incoming_query,
-        } => ("url_query_mismatch".to_string(), existing_query, incoming_query),
-    };
-
-    SkippedServerData {
-        name: source.name,
-        reason,
-        existing_query,
-        incoming_query,
-    }
+    SkippedServerData::from(source)
 }
 
 /// Disconnect server instances from connection pool

--- a/backend/src/api/models/client.rs
+++ b/backend/src/api/models/client.rs
@@ -408,6 +408,9 @@ pub struct ClientImportSummary {
     #[schemars(description = "Optional per-server error messages for failures")]
     #[serde(default)]
     pub errors: Option<std::collections::HashMap<String, String>>,
+    #[schemars(description = "Detailed reason for each skipped server")]
+    #[serde(default)]
+    pub skipped_servers: Vec<crate::api::models::server::SkippedServerData>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1062,3 +1065,4 @@ api_resp!(
     FirstContactBehaviorData,
     "First contact behavior API response"
 );
+

--- a/backend/src/api/models/server.rs
+++ b/backend/src/api/models/server.rs
@@ -2,6 +2,7 @@
 // Contains data models for MCP server endpoints
 
 use crate::common::server::ServerType;
+use crate::config::server::import::{SkipReason, SkippedServer};
 use crate::macros::resp::api_resp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -890,6 +891,26 @@ pub struct SkippedServerData {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Incoming query string (after filtering)")]
     pub incoming_query: Option<String>,
+}
+
+impl From<SkippedServer> for SkippedServerData {
+    fn from(source: SkippedServer) -> Self {
+        let (reason, existing_query, incoming_query) = match source.reason {
+            SkipReason::DuplicateName => ("duplicate_name".to_string(), None, None),
+            SkipReason::DuplicateFingerprint => ("duplicate_fingerprint".to_string(), None, None),
+            SkipReason::UrlQueryMismatch {
+                existing_query,
+                incoming_query,
+            } => ("url_query_mismatch".to_string(), existing_query, incoming_query),
+        };
+
+        Self {
+            name: source.name,
+            reason,
+            existing_query,
+            incoming_query,
+        }
+    }
 }
 
 // ==========================================

--- a/backend/src/config/server/fingerprint.rs
+++ b/backend/src/config/server/fingerprint.rs
@@ -47,15 +47,16 @@ pub struct UrlSignature {
     pub fingerprint: String,
     pub base: String,
     pub filtered_query: String,
+    pub display_filtered_query: String,
     pub raw_query: Option<String>,
 }
 
 impl UrlSignature {
     pub fn display_query(&self) -> Option<String> {
-        if !self.filtered_query.is_empty() {
-            Some(self.filtered_query.clone())
+        if self.display_filtered_query.is_empty() {
+            None
         } else {
-            self.raw_query.clone()
+            Some(self.display_filtered_query.clone())
         }
     }
 }
@@ -95,7 +96,7 @@ pub(crate) fn url_signature(raw: &str) -> UrlSignature {
 
         let base = format!("{}{}{}", host, port_part, path);
 
-        let (raw_query, filtered_query) = canonicalize_query(url.query());
+        let (raw_query, filtered_query, display_filtered_query) = canonicalize_query(url.query());
         let fingerprint = if filtered_query.is_empty() {
             base.clone()
         } else {
@@ -106,6 +107,7 @@ pub(crate) fn url_signature(raw: &str) -> UrlSignature {
             fingerprint,
             base,
             filtered_query,
+            display_filtered_query,
             raw_query,
         }
     } else {
@@ -113,6 +115,7 @@ pub(crate) fn url_signature(raw: &str) -> UrlSignature {
             fingerprint: raw.to_string(),
             base: raw.to_string(),
             filtered_query: String::new(),
+            display_filtered_query: String::new(),
             raw_query: None,
         }
     }
@@ -517,17 +520,46 @@ const QUERY_IGNORE_KEYS: &[&str] = &[
     "session",
 ];
 
-fn canonicalize_query(query: Option<&str>) -> (Option<String>, String) {
+const DISPLAY_QUERY_IGNORE_KEYS: &[&str] = &[
+    "token",
+    "access_token",
+    "auth",
+    "auth_token",
+    "signature",
+    "sig",
+    "timestamp",
+    "ts",
+    "nonce",
+    "api_key",
+    "apikey",
+    "session",
+    "secret",
+    "client_secret",
+    "password",
+    "passwd",
+    "private_key",
+    "refresh_token",
+    "id_token",
+    "key",
+];
+
+fn canonicalize_query(query: Option<&str>) -> (Option<String>, String, String) {
     if let Some(q) = query {
         let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(q.as_bytes()).into_owned().collect();
         if pairs.is_empty() {
-            return (None, String::new());
+            return (None, String::new(), String::new());
         }
         pairs.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
 
         let filtered_pairs: Vec<(String, String)> = pairs
             .iter()
             .filter(|(k, _)| !should_ignore_query_key(k))
+            .cloned()
+            .collect();
+
+        let display_filtered_pairs: Vec<(String, String)> = filtered_pairs
+            .iter()
+            .filter(|(k, _)| !should_ignore_display_query_key(k))
             .cloned()
             .collect();
 
@@ -549,14 +581,30 @@ fn canonicalize_query(query: Option<&str>) -> (Option<String>, String) {
                 .join("&")
         };
 
-        (raw_query, filtered_query)
+        let display_filtered_query = if display_filtered_pairs.is_empty() {
+            String::new()
+        } else {
+            display_filtered_pairs
+                .into_iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join("&")
+        };
+
+        (raw_query, filtered_query, display_filtered_query)
     } else {
-        (None, String::new())
+        (None, String::new(), String::new())
     }
 }
 
 fn should_ignore_query_key(key: &str) -> bool {
     QUERY_IGNORE_KEYS.iter().any(|ignore| key.eq_ignore_ascii_case(ignore))
+}
+
+fn should_ignore_display_query_key(key: &str) -> bool {
+    DISPLAY_QUERY_IGNORE_KEYS
+        .iter()
+        .any(|ignore| key.eq_ignore_ascii_case(ignore))
 }
 
 fn extract_node_package_spec(
@@ -710,6 +758,31 @@ mod tests {
         assert_eq!(sig.filtered_query, "workspace=alpha");
         assert_eq!(sig.fingerprint, "example.com/data?workspace=alpha");
         assert_eq!(sig.display_query(), Some("workspace=alpha".to_string()));
+    }
+
+    #[test]
+    fn url_signature_hides_queries_when_only_sensitive_params_remain() {
+        let sig = url_signature("https://example.com/data?api_key=ABC123&token=XYZ");
+        assert_eq!(sig.filtered_query, "");
+        assert_eq!(sig.display_query(), None);
+    }
+
+    #[test]
+    fn url_signature_hides_display_only_sensitive_params_without_changing_fingerprint() {
+        let sig = url_signature("https://example.com/data?client_secret=ABC123&password=XYZ&workspace=alpha");
+        assert_eq!(sig.filtered_query, "client_secret=ABC123&password=XYZ&workspace=alpha");
+        assert_eq!(
+            sig.fingerprint,
+            "example.com/data?client_secret=ABC123&password=XYZ&workspace=alpha"
+        );
+        assert_eq!(sig.display_query(), Some("workspace=alpha".to_string()));
+    }
+
+    #[test]
+    fn url_signature_hides_display_when_only_display_sensitive_params_remain() {
+        let sig = url_signature("https://example.com/data?client_secret=ABC123&password=XYZ");
+        assert_eq!(sig.filtered_query, "client_secret=ABC123&password=XYZ");
+        assert_eq!(sig.display_query(), None);
     }
 
     #[test]

--- a/board/src/components/server-import-drawer.tsx
+++ b/board/src/components/server-import-drawer.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { extractImportStats, serversApi } from "../lib/api";
 import { notifyError, notifyInfo, notifySuccess } from "../lib/notify";
 import { formatNameList, summarizeSkipped } from "../lib/server-import-utils";
@@ -69,6 +70,7 @@ export function ServerImportDrawer({
 	const [text, setText] = useState<string>(sample());
 	const [preview, setPreview] = useState<PreviewResult | null>(null);
 	const [importing, setImporting] = useState(false);
+	const { t } = useTranslation();
 
 	useEffect(() => {
 		if (!open) {
@@ -176,8 +178,8 @@ export function ServerImportDrawer({
 			if (didSucceed) {
 				const { importedCount, skippedCount, skippedServers, skippedDetails } =
 					stats;
-				const skippedSummary = summarizeSkipped(skippedDetails);
-				const fallbackList = formatNameList(skippedServers);
+				const skippedSummary = summarizeSkipped(skippedDetails, t);
+				const fallbackList = formatNameList(skippedServers, t);
 				const skippedDescription = skippedSummary
 					? skippedSummary
 					: skippedCount > 0

--- a/board/src/hooks/use-server-install-pipeline.ts
+++ b/board/src/hooks/use-server-install-pipeline.ts
@@ -40,7 +40,7 @@ interface PreviewState {
 export function useServerInstallPipeline(
 	opts: UseServerInstallPipelineOptions = {},
 ) {
-	const { t } = useTranslation("servers");
+	const { t, i18n } = useTranslation("servers");
 	const [isDrawerOpen, setDrawerOpen] = useState(false);
 	const [drafts, setDrafts] = useState<ServerInstallDraft[]>([]);
 	const [source, setSource] = useState<InstallSource | null>(null);
@@ -216,7 +216,8 @@ export function useServerInstallPipeline(
 	);
 
 	const performDryRun = useCallback(async () => {
-		if (!drafts.length) return;
+		void i18n.language;
+			if (!drafts.length) return;
 		try {
 			setDryRunLoading(true);
 			setDryRunError(null);
@@ -233,8 +234,8 @@ export function useServerInstallPipeline(
 			const stats = extractImportStats(result);
 			setDryRunStats(stats);
 
-			const skipSummary = summarizeSkipped(stats.skippedDetails);
-			const skipFallback = formatNameList(stats.skippedServers);
+			const skipSummary = summarizeSkipped(stats.skippedDetails, t);
+			const skipFallback = formatNameList(stats.skippedServers, t);
 			if (stats.skippedCount > 0) {
 				const baseKey =
 					stats.skippedCount === 1
@@ -256,7 +257,7 @@ export function useServerInstallPipeline(
 
 			// Check if dry-run indicates any issues
 			if (stats.failedCount > 0) {
-				const failedNames = formatNameList(stats.failedServers);
+				const failedNames = formatNameList(stats.failedServers, t);
 				setDryRunError(
 					t("wizard.result.failedSummary", {
 						count: stats.failedCount,
@@ -283,10 +284,11 @@ export function useServerInstallPipeline(
 		} finally {
 			setDryRunLoading(false);
 		}
-	}, [drafts, buildImportPayload, targetProfileId]);
+	}, [drafts, buildImportPayload, targetProfileId, t, i18n.language]);
 
 	const confirmImport = useCallback(async () => {
-		if (!drafts.length) return false;
+		void i18n.language;
+			if (!drafts.length) return false;
 		try {
 			setImporting(true);
 			setCurrentStep("result");
@@ -306,8 +308,8 @@ export function useServerInstallPipeline(
 				const stats = extractImportStats(result);
 				const { importedCount, skippedCount, skippedServers, skippedDetails } =
 					stats;
-				const skippedSummary = summarizeSkipped(skippedDetails);
-				const fallbackList = formatNameList(skippedServers);
+				const skippedSummary = summarizeSkipped(skippedDetails, t);
+				const fallbackList = formatNameList(skippedServers, t);
 				const skippedDescription = skippedSummary
 					? skippedSummary
 					: skippedCount > 0
@@ -346,7 +348,7 @@ export function useServerInstallPipeline(
 		} finally {
 			setImporting(false);
 		}
-	}, [drafts, buildImportPayload, opts, targetProfileId]);
+	}, [drafts, buildImportPayload, opts, targetProfileId, t, i18n.language]);
 
 	const state = useMemo(
 		() => ({

--- a/board/src/lib/i18n/common.ts
+++ b/board/src/lib/i18n/common.ts
@@ -34,6 +34,21 @@ export const commonTranslations = {
 			recent: "Most Recently Hidden",
 			name: "Name (A-Z)",
 		},
+		serverImport: {
+			nameList: {
+				more: "+{{count}} more",
+			},
+			queryLabels: {
+				existing: "Existing query",
+				incoming: "Incoming query",
+			},
+			skippedReasons: {
+				duplicateName: "Duplicate name",
+				duplicateFingerprint: "Duplicate fingerprint",
+				urlQueryMismatch: "URL query mismatch",
+				unknown: "Unknown reason",
+			},
+		},
 		pagination: {
 			first: "First",
 			previous: "Previous",
@@ -42,15 +57,12 @@ export const commonTranslations = {
 			perPage: "Per page",
 			page: "Page {{page}}",
 			showing: "Showing {{start}}-{{end}} items",
-			/** When the backend reports total item count */
 			showingOfTotal: "Showing {{start}}-{{end}} of {{total}} items",
 			showingEmpty: "No items on this page",
-			/** Left summary when total count is known (no per-page range) */
 			totalItems: "Total {{total}} items",
 			summary: "{{start}}–{{end}} · {{page}}",
 			summaryTitle: "Items {{start}}–{{end}}, page {{page}}",
 			pageWord: "Page",
-			/** Shown between page number and “of total” (empty in English) */
 			pageSuffix: "",
 			ofTotal: "of {{total}}",
 			goToPage: "Go to page",
@@ -90,6 +102,21 @@ export const commonTranslations = {
 		sort: {
 			recent: "最近隐藏时间",
 			name: "名称 (A-Z)",
+		},
+		serverImport: {
+			nameList: {
+				more: "另有 {{count}} 项",
+			},
+			queryLabels: {
+				existing: "现有查询参数",
+				incoming: "传入查询参数",
+			},
+			skippedReasons: {
+				duplicateName: "名称重复",
+				duplicateFingerprint: "指纹重复",
+				urlQueryMismatch: "URL 查询参数不匹配",
+				unknown: "未知原因",
+			},
 		},
 		pagination: {
 			first: "首页",
@@ -144,6 +171,21 @@ export const commonTranslations = {
 		sort: {
 			recent: "最近非表示",
 			name: "名前 (A-Z)",
+		},
+		serverImport: {
+			nameList: {
+				more: "他 {{count}} 件",
+			},
+			queryLabels: {
+				existing: "既存のクエリ",
+				incoming: "入力クエリ",
+			},
+			skippedReasons: {
+				duplicateName: "名前の重複",
+				duplicateFingerprint: "フィンガープリントの重複",
+				urlQueryMismatch: "URL クエリ不一致",
+				unknown: "不明な理由",
+			},
 		},
 		pagination: {
 			first: "最初",

--- a/board/src/lib/server-import-utils.ts
+++ b/board/src/lib/server-import-utils.ts
@@ -1,31 +1,111 @@
+import type { TFunction } from "i18next";
+
 import type { SkippedServer } from "./types";
 
-export const formatNameList = (names: string[], limit = 3): string => {
-	if (!names.length) return "";
-	if (names.length <= limit) return names.join(", ");
-	const head = names.slice(0, limit).join(", ");
-	return `${head}, +${names.length - limit} more`;
+export type SkippedQueryField = "existing" | "incoming";
+
+const SKIPPED_REASON_LABELS: Record<
+  string,
+  { key: string; defaultValue: string }
+> = {
+  duplicate_name: {
+    key: "serverImport.skippedReasons.duplicateName",
+    defaultValue: "Duplicate name",
+  },
+  duplicate_fingerprint: {
+    key: "serverImport.skippedReasons.duplicateFingerprint",
+    defaultValue: "Duplicate fingerprint",
+  },
+  url_query_mismatch: {
+    key: "serverImport.skippedReasons.urlQueryMismatch",
+    defaultValue: "URL query mismatch",
+  },
 };
 
-const describeSkip = (detail: SkippedServer): string => {
-	const label = detail.reason.replace(/_/g, " ");
-	const parts: string[] = [label];
-	if (detail.incoming_query || detail.existing_query) {
-		const queryParts: string[] = [];
-		if (detail.incoming_query) {
-			queryParts.push(`incoming=${detail.incoming_query}`);
-		}
-		if (detail.existing_query) {
-			queryParts.push(`existing=${detail.existing_query}`);
-		}
-		if (queryParts.length) {
-			parts.push(queryParts.join(", "));
-		}
-	}
-	return `${detail.name} (${parts.join("; ")})`;
+const SKIPPED_QUERY_FIELD_LABELS: Record<
+  SkippedQueryField,
+  { key: string; defaultValue: string }
+> = {
+  existing: {
+    key: "serverImport.queryLabels.existing",
+    defaultValue: "Existing query",
+  },
+  incoming: {
+    key: "serverImport.queryLabels.incoming",
+    defaultValue: "Incoming query",
+  },
 };
 
-export const summarizeSkipped = (details: SkippedServer[]): string => {
-	if (!details.length) return "";
-	return details.map(describeSkip).join("; ");
+const translateCommon = (
+  t: TFunction,
+  key: string,
+  defaultValue: string,
+  options?: Record<string, string | number>,
+) => t(key, { ns: "translation", defaultValue, ...options });
+
+export const getSkippedReasonLabel = (reason: string, t: TFunction) => {
+  const spec = SKIPPED_REASON_LABELS[reason];
+  if (!spec) {
+    return translateCommon(
+      t,
+      "serverImport.skippedReasons.unknown",
+      "Unknown reason",
+    );
+  }
+  return translateCommon(t, spec.key, spec.defaultValue);
+};
+
+export const getSkippedQueryFieldLabel = (
+  field: SkippedQueryField,
+  t: TFunction,
+) => {
+  const spec = SKIPPED_QUERY_FIELD_LABELS[field];
+  return translateCommon(t, spec.key, spec.defaultValue);
+};
+
+export const formatNameList = (
+  names: string[],
+  t: TFunction,
+  limit = 3,
+): string => {
+  if (!names.length) return "";
+  if (names.length <= limit) return names.join(", ");
+  const head = names.slice(0, limit).join(", ");
+  const suffix = translateCommon(
+    t,
+    "serverImport.nameList.more",
+    "+{{count}} more",
+    { count: names.length - limit },
+  );
+  return `${head}, ${suffix}`;
+};
+
+const describeSkip = (detail: SkippedServer, t: TFunction): string => {
+  const label = getSkippedReasonLabel(detail.reason, t);
+  const parts: string[] = [label];
+  if (detail.incoming_query || detail.existing_query) {
+    const queryParts: string[] = [];
+    if (detail.incoming_query) {
+      queryParts.push(
+        `${getSkippedQueryFieldLabel("incoming", t)}=${detail.incoming_query}`,
+      );
+    }
+    if (detail.existing_query) {
+      queryParts.push(
+        `${getSkippedQueryFieldLabel("existing", t)}=${detail.existing_query}`,
+      );
+    }
+    if (queryParts.length) {
+      parts.push(queryParts.join(", "));
+    }
+  }
+  return `${detail.name} (${parts.join("; ")})`;
+};
+
+export const summarizeSkipped = (
+  details: SkippedServer[],
+  t: TFunction,
+): string => {
+  if (!details.length) return "";
+  return details.map((detail) => describeSkip(detail, t)).join("; ");
 };

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -1087,6 +1087,7 @@ export interface ClientImportSummary {
   skipped_count: number;
   failed_count: number;
   errors?: Record<string, string> | null;
+  skipped_servers?: SkippedServer[] | null;
 }
 
 export interface ClientConfigImportItem {

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -1,23 +1,23 @@
 import {
-	useMutation,
-	useQueries,
-	useQuery,
-	useQueryClient,
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
 } from "@tanstack/react-query";
 import {
-	Check,
-	Download,
-	HardDrive,
-	Info,
-	Link2,
-	MoreVertical,
-	Pencil,
-	RefreshCw,
-	RotateCcw,
-	ShieldCheck,
-	ShieldX,
-	Trash2,
-	Unlink,
+  Check,
+  Download,
+  HardDrive,
+  Info,
+  Link2,
+  MoreVertical,
+  Pencil,
+  RefreshCw,
+  RotateCcw,
+  ShieldCheck,
+  ShieldX,
+  Trash2,
+  Unlink,
 } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,12 +25,12 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { AuditLogsPanel } from "../../components/audit-logs-panel";
 import { CachedAvatar } from "../../components/cached-avatar";
 import {
-	CapsuleStripeList,
-	CapsuleStripeListItem,
+  CapsuleStripeList,
+  CapsuleStripeListItem,
 } from "../../components/capsule-stripe-list";
 import {
-	CapsuleStripeLeadCircle,
-	CapsuleStripeRowBody,
+  CapsuleStripeLeadCircle,
+  CapsuleStripeRowBody,
 } from "../../components/capsule-stripe-row";
 import { ClientFormDrawer } from "../../components/client-form-drawer";
 import { ConfirmDialog } from "../../components/confirm-dialog";
@@ -41,3430 +41,3772 @@ import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { ButtonGroup, ButtonGroupText } from "../../components/ui/button-group";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from "../../components/ui/card";
 import {
-	Drawer,
-	DrawerContent,
-	DrawerDescription,
-	DrawerFooter,
-	DrawerHeader,
-	DrawerTitle,
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
 } from "../../components/ui/drawer";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Segment } from "../../components/ui/segment";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "../../components/ui/select";
 import {
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
 } from "../../components/ui/tabs";
-import { auditApi, clientsApi, configSuitsApi, serversApi } from "../../lib/api";
+import {
+  auditApi,
+  clientsApi,
+  configSuitsApi,
+  serversApi,
+} from "../../lib/api";
 import { mapDashboardSettingsToClientBackupPolicy } from "../../lib/client-backup-policy";
 import {
-	applyClientConfigWithResolvedSelection,
-	buildClientApplySelectedConfig,
-	resolveClientConfigSyncErrorMessage,
+  applyClientConfigWithResolvedSelection,
+  buildClientApplySelectedConfig,
+  resolveClientConfigSyncErrorMessage,
 } from "../../lib/client-config-sync";
 import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
+import {
+  getSkippedQueryFieldLabel,
+  getSkippedReasonLabel,
+} from "../../lib/server-import-utils";
 import { notifyError, notifyInfo, notifySuccess } from "../../lib/notify";
 import { useAppStore } from "../../lib/store";
 import type {
-	ClientBackupEntry,
-	ClientBackupPolicySetReq,
-	ClientCapabilityConfigData,
-	ClientCapabilityConfigReq,
-	ClientCapabilitySourceSelection,
-	ClientConfigImportData,
-	ClientConfigMode,
-	ClientConfigUpdateData,
-	ClientInfo,
-	ConfigSuit,
-	ServerSummary,
-	TransportRuleData,
-	UnifyDirectCapabilityIds,
+  ClientBackupEntry,
+  ClientBackupPolicySetReq,
+  ClientCapabilityConfigData,
+  ClientCapabilityConfigReq,
+  ClientCapabilitySourceSelection,
+  ClientConfigImportData,
+  ClientConfigMode,
+  ClientConfigUpdateData,
+  ClientInfo,
+  ConfigSuit,
+  ServerSummary,
+  TransportRuleData,
+  UnifyDirectCapabilityIds,
 } from "../../lib/types";
 import { formatBackupTime } from "../../lib/utils";
 import { ConfigurationProfileTokenChart } from "./components/configuration-profile-token-chart";
 
 type UnifyRouteMode = "broker_only" | "server_level" | "capability_level";
-type DirectExposureRouteMode = Extract<UnifyRouteMode, "server_level" | "capability_level">;
+type DirectExposureRouteMode = Extract<
+  UnifyRouteMode,
+  "server_level" | "capability_level"
+>;
 
 const governanceClientsApi = clientsApi as typeof clientsApi & {
-	suspendRecord: (payload: { identifier: string }) => Promise<unknown>;
+  suspendRecord: (payload: { identifier: string }) => Promise<unknown>;
 };
 
 const arrangeProfilesWithDefaultFirst = (items: ConfigSuit[] = []) => {
-	if (!items.length) {
-		return [] as ConfigSuit[];
-	}
-	const byName = (a: ConfigSuit, b: ConfigSuit) =>
-		a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-	const defaults = items.filter((profile) => profile.is_default).sort(byName);
-	const others = items.filter((profile) => !profile.is_default).sort(byName);
-	return [...defaults, ...others];
+  if (!items.length) {
+    return [] as ConfigSuit[];
+  }
+  const byName = (a: ConfigSuit, b: ConfigSuit) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  const defaults = items.filter((profile) => profile.is_default).sort(byName);
+  const others = items.filter((profile) => !profile.is_default).sort(byName);
+  return [...defaults, ...others];
 };
 
-const SUPPORTED_TRANSPORT_OPTIONS = ["streamable_http", "sse", "stdio"] as const;
+const SUPPORTED_TRANSPORT_OPTIONS = [
+  "streamable_http",
+  "sse",
+  "stdio",
+] as const;
 type SupportedTransportOption = (typeof SUPPORTED_TRANSPORT_OPTIONS)[number];
 
-function isSupportedTransportOption(value: string): value is SupportedTransportOption {
-	return SUPPORTED_TRANSPORT_OPTIONS.includes(value as SupportedTransportOption);
+function isSupportedTransportOption(
+  value: string,
+): value is SupportedTransportOption {
+  return SUPPORTED_TRANSPORT_OPTIONS.includes(
+    value as SupportedTransportOption,
+  );
 }
 
 function resolveSelectedTransport(
-	transports: Record<string, TransportRuleData> | null | undefined,
+  transports: Record<string, TransportRuleData> | null | undefined,
 ): "auto" | SupportedTransportOption {
-	for (const transport of SUPPORTED_TRANSPORT_OPTIONS) {
-		if (transports?.[transport]?.selected === true) {
-			return transport;
-		}
-	}
-	return "auto";
+  for (const transport of SUPPORTED_TRANSPORT_OPTIONS) {
+    if (transports?.[transport]?.selected === true) {
+      return transport;
+    }
+  }
+  return "auto";
 }
 
 function withSelectedTransport(
-	transports: Record<string, TransportRuleData> | null | undefined,
-	selected: string,
+  transports: Record<string, TransportRuleData> | null | undefined,
+  selected: string,
 ): Record<string, TransportRuleData> {
-	return Object.fromEntries(
-		Object.entries(transports ?? {}).map(([transport, rule]) => [
-			transport,
-			{
-				...rule,
-				selected: selected !== "auto" && transport === selected ? true : undefined,
-			},
-		]),
-	);
+  return Object.fromEntries(
+    Object.entries(transports ?? {}).map(([transport, rule]) => [
+      transport,
+      {
+        ...rule,
+        selected:
+          selected !== "auto" && transport === selected ? true : undefined,
+      },
+    ]),
+  );
 }
 
 function normalizeCapabilityIds(ids: string[] = []): string[] {
-	return Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean))).sort();
+  return Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean))).sort();
 }
 
 function getUnifyServerSurfaces<T extends { server_id: string }>(
-	selectedSurfaces: T[],
-	serverId: string,
+  selectedSurfaces: T[],
+  serverId: string,
 ): T[] {
-	return selectedSurfaces.filter((entry) => entry.server_id === serverId);
+  return selectedSurfaces.filter((entry) => entry.server_id === serverId);
 }
 
-function normalizeDirectCapabilityIds(ids?: UnifyDirectCapabilityIds): UnifyDirectCapabilityIds {
-	return {
-		tool_ids: normalizeCapabilityIds(ids?.tool_ids),
-		prompt_ids: normalizeCapabilityIds(ids?.prompt_ids),
-		resource_ids: normalizeCapabilityIds(ids?.resource_ids),
-		template_ids: normalizeCapabilityIds(ids?.template_ids),
-	};
+function normalizeDirectCapabilityIds(
+  ids?: UnifyDirectCapabilityIds,
+): UnifyDirectCapabilityIds {
+  return {
+    tool_ids: normalizeCapabilityIds(ids?.tool_ids),
+    prompt_ids: normalizeCapabilityIds(ids?.prompt_ids),
+    resource_ids: normalizeCapabilityIds(ids?.resource_ids),
+    template_ids: normalizeCapabilityIds(ids?.template_ids),
+  };
 }
 
 function resolveNextCapabilityIds(
-	currentIds: string[] = [],
-	hasSelectedForServer: boolean,
-	serverCapabilityIds: string[],
+  currentIds: string[] = [],
+  hasSelectedForServer: boolean,
+  serverCapabilityIds: string[],
 ): string[] {
-	const serverCapabilityIdSet = new Set(serverCapabilityIds);
-	const otherIds = currentIds.filter((id) => !serverCapabilityIdSet.has(id));
+  const serverCapabilityIdSet = new Set(serverCapabilityIds);
+  const otherIds = currentIds.filter((id) => !serverCapabilityIdSet.has(id));
 
-	if (hasSelectedForServer) {
-		return otherIds;
-	}
+  if (hasSelectedForServer) {
+    return otherIds;
+  }
 
-	return normalizeCapabilityIds([...otherIds, ...serverCapabilityIds]);
+  return normalizeCapabilityIds([...otherIds, ...serverCapabilityIds]);
 }
 
-function getCapabilityId(item: Record<string, unknown>, keys: string[]): string | null {
-	for (const key of keys) {
-		const value = item[key];
-		if (typeof value === "string" && value.trim()) {
-			return value;
-		}
-	}
-	return null;
+function getCapabilityId(
+  item: Record<string, unknown>,
+  keys: string[],
+): string | null {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function isUnifyServerMixedRouting(
-	routeMode: UnifyRouteMode,
-	toolSurfaceCount: number,
-	toolsCount: number | undefined,
+  routeMode: UnifyRouteMode,
+  toolSurfaceCount: number,
+  toolsCount: number | undefined,
 ): boolean {
-	if (routeMode !== "capability_level" || toolSurfaceCount === 0) {
-		return false;
-	}
+  if (routeMode !== "capability_level" || toolSurfaceCount === 0) {
+    return false;
+  }
 
-	if (!toolsCount) {
-		return true;
-	}
+  if (!toolsCount) {
+    return true;
+  }
 
-	return toolSurfaceCount < toolsCount;
+  return toolSurfaceCount < toolsCount;
 }
 
 function getClientDirectCapabilitiesPath(
-	identifier: string | undefined,
-	serverId: string,
+  identifier: string | undefined,
+  serverId: string,
 ): string | null {
-	if (!identifier) {
-		return null;
-	}
+  if (!identifier) {
+    return null;
+  }
 
-	return `/clients/${identifier}/direct/${serverId}`;
+  return `/clients/${identifier}/direct/${serverId}`;
 }
 
-function toggleSelectedServerIds(currentIds: string[], serverId: string): string[] {
-	if (currentIds.includes(serverId)) {
-		return currentIds.filter((id) => id !== serverId);
-	}
+function toggleSelectedServerIds(
+  currentIds: string[],
+  serverId: string,
+): string[] {
+  if (currentIds.includes(serverId)) {
+    return currentIds.filter((id) => id !== serverId);
+  }
 
-	return [...currentIds, serverId];
+  return [...currentIds, serverId];
 }
 
 function buildCapabilityConfigPayloadBase(
-	identifier: string,
-	currentConfig: ClientCapabilityConfigData,
+  identifier: string,
+  currentConfig: ClientCapabilityConfigData,
 ): Omit<ClientCapabilityConfigReq, "unify_direct_exposure"> {
-	return {
-		identifier,
-		capability_source: currentConfig.capability_source,
-		selected_profile_ids: currentConfig.selected_profile_ids,
-	};
+  return {
+    identifier,
+    capability_source: currentConfig.capability_source,
+    selected_profile_ids: currentConfig.selected_profile_ids,
+  };
 }
 
 function buildUnifyDirectExposurePayload(
-	routeMode: UnifyRouteMode,
-	serverIds: string[],
-	capabilityIds: UnifyDirectCapabilityIds,
+  routeMode: UnifyRouteMode,
+  serverIds: string[],
+  capabilityIds: UnifyDirectCapabilityIds,
 ): NonNullable<ClientCapabilityConfigReq["unify_direct_exposure"]> {
-	return {
-		route_mode: routeMode,
-		server_ids: routeMode === "server_level" ? serverIds : [],
-		capability_ids: routeMode === "capability_level" ? normalizeDirectCapabilityIds(capabilityIds) : {},
-	};
+  return {
+    route_mode: routeMode,
+    server_ids: routeMode === "server_level" ? serverIds : [],
+    capability_ids:
+      routeMode === "capability_level"
+        ? normalizeDirectCapabilityIds(capabilityIds)
+        : {},
+  };
 }
 
 function buildServerLevelExposureUpdate(
-	identifier: string,
-	currentConfig: ClientCapabilityConfigData,
-	serverId: string,
+  identifier: string,
+  currentConfig: ClientCapabilityConfigData,
+  serverId: string,
 ): ClientCapabilityConfigReq {
-	const currentServerIds = currentConfig.unify_direct_exposure?.server_ids ?? [];
+  const currentServerIds =
+    currentConfig.unify_direct_exposure?.server_ids ?? [];
 
-	return {
-		...buildCapabilityConfigPayloadBase(identifier, currentConfig),
-		unify_direct_exposure: buildUnifyDirectExposurePayload(
-			"server_level",
-			toggleSelectedServerIds(currentServerIds, serverId),
-			{},
-		),
-	};
+  return {
+    ...buildCapabilityConfigPayloadBase(identifier, currentConfig),
+    unify_direct_exposure: buildUnifyDirectExposurePayload(
+      "server_level",
+      toggleSelectedServerIds(currentServerIds, serverId),
+      {},
+    ),
+  };
 }
 
 function buildCapabilityLevelExposureUpdate(
-	identifier: string,
-	currentConfig: ClientCapabilityConfigData,
-	nextCapabilityIds: UnifyDirectCapabilityIds,
+  identifier: string,
+  currentConfig: ClientCapabilityConfigData,
+  nextCapabilityIds: UnifyDirectCapabilityIds,
 ): ClientCapabilityConfigReq {
-	return {
-		...buildCapabilityConfigPayloadBase(identifier, currentConfig),
-		unify_direct_exposure: buildUnifyDirectExposurePayload("capability_level", [], nextCapabilityIds),
-	};
+  return {
+    ...buildCapabilityConfigPayloadBase(identifier, currentConfig),
+    unify_direct_exposure: buildUnifyDirectExposurePayload(
+      "capability_level",
+      [],
+      nextCapabilityIds,
+    ),
+  };
 }
 
 function getTransportOptionLabel(
-	transport: string,
-	t: ReturnType<typeof useTranslation>["t"],
+  transport: string,
+  t: ReturnType<typeof useTranslation>["t"],
 ): string {
-	switch (transport) {
-		case "streamable_http":
-			return t("detail.configuration.transportOptions.streamableHttpLegacy", {
-				defaultValue: "Streamable HTTP",
-			});
-		case "sse":
-			return t("detail.configuration.transportOptions.sseLegacy", {
-				defaultValue: "SSE (Legacy)",
-			});
-		case "stdio":
-			return t("detail.configuration.transportOptions.stdio", {
-				defaultValue: "STDIO",
-			});
-		default:
-			return transport.toUpperCase();
-	}
+  switch (transport) {
+    case "streamable_http":
+      return t("detail.configuration.transportOptions.streamableHttpLegacy", {
+        defaultValue: "Streamable HTTP",
+      });
+    case "sse":
+      return t("detail.configuration.transportOptions.sseLegacy", {
+        defaultValue: "SSE (Legacy)",
+      });
+    case "stdio":
+      return t("detail.configuration.transportOptions.stdio", {
+        defaultValue: "STDIO",
+      });
+    default:
+      return transport.toUpperCase();
+  }
 }
 
 function resolveConfigModeForWritableState(
-	requestedMode: ClientConfigMode,
-	isWritableConfig: boolean,
+  requestedMode: ClientConfigMode,
+  isWritableConfig: boolean,
 ): ClientConfigMode {
-	if (requestedMode === "transparent" && !isWritableConfig) {
-		return "hosted";
-	}
+  if (requestedMode === "transparent" && !isWritableConfig) {
+    return "hosted";
+  }
 
-	return requestedMode;
+  return requestedMode;
 }
 
 function isDeniedApprovalStatus(status?: string | null): boolean {
-	return status === "suspended";
+  return status === "suspended";
 }
 
 function extractServers(obj: unknown): string[] {
-	if (!obj || typeof obj !== "object") return [];
-	const objRecord = obj as Record<string, unknown>;
-	const collected = new Set<string>();
-	const addFromValue = (value: unknown) => {
-		if (!value) return;
-		if (Array.isArray(value)) {
-			for (const entry of value) {
-				if (typeof entry === "string") {
-					collected.add(entry);
-				} else if (
-					entry &&
-					typeof entry === "object" &&
-					"name" in entry &&
-					typeof (entry as { name?: unknown }).name === "string"
-				) {
-					collected.add((entry as { name: string }).name);
-				}
-			}
-			return;
-		}
-		if (typeof value === "object") {
-			for (const key of Object.keys(value as Record<string, unknown>)) {
-				collected.add(key);
-			}
-		}
-	};
+  if (!obj || typeof obj !== "object") return [];
+  const objRecord = obj as Record<string, unknown>;
+  const collected = new Set<string>();
+  const addFromValue = (value: unknown) => {
+    if (!value) return;
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (typeof entry === "string") {
+          collected.add(entry);
+        } else if (
+          entry &&
+          typeof entry === "object" &&
+          "name" in entry &&
+          typeof (entry as { name?: unknown }).name === "string"
+        ) {
+          collected.add((entry as { name: string }).name);
+        }
+      }
+      return;
+    }
+    if (typeof value === "object") {
+      for (const key of Object.keys(value as Record<string, unknown>)) {
+        collected.add(key);
+      }
+    }
+  };
 
-	addFromValue(objRecord.mcpServers);
-	addFromValue(objRecord.mcp_servers);
-	addFromValue(objRecord.servers);
-	addFromValue(objRecord.context_servers);
-	addFromValue(objRecord.contextServers);
-	addFromValue(objRecord.agent_servers);
+  addFromValue(objRecord.mcpServers);
+  addFromValue(objRecord.mcp_servers);
+  addFromValue(objRecord.servers);
+  addFromValue(objRecord.context_servers);
+  addFromValue(objRecord.contextServers);
+  addFromValue(objRecord.agent_servers);
 
-	if (
-		objRecord.mcp &&
-		typeof objRecord.mcp === "object" &&
-		(objRecord.mcp as Record<string, unknown>).servers
-	) {
-		addFromValue((objRecord.mcp as Record<string, unknown>).servers);
-	}
+  if (
+    objRecord.mcp &&
+    typeof objRecord.mcp === "object" &&
+    (objRecord.mcp as Record<string, unknown>).servers
+  ) {
+    addFromValue((objRecord.mcp as Record<string, unknown>).servers);
+  }
 
-	return Array.from(collected);
+  return Array.from(collected);
 }
 
 export function ClientDetailPage() {
-	const { identifier } = useParams<{ identifier: string }>();
-	const qc = useQueryClient();
-	const navigate = useNavigate();
-	usePageTranslations("clients");
-	const { t, i18n } = useTranslation("clients");
-	const showClientLiveLogs = useAppStore(
-		(state) => state.dashboardSettings.showClientLiveLogs,
-	);
-	const dashboardSettings = useAppStore((state) => state.dashboardSettings);
-	const clientDefaultMode = useAppStore(
-		(state) => state.dashboardSettings.clientDefaultMode,
-	);
-	const [displayName, setDisplayName] = useState("");
-	const [selectedBackups, setSelectedBackups] = useState<string[]>([]);
-	const [isClientFormOpen, setIsClientFormOpen] = useState(false);
-	const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
-	const [attachmentActionConfirm, setAttachmentActionConfirm] = useState<"detach" | "attach" | null>(null);
-
-	const { data: clientsData } = useQuery({
-		queryKey: ["clients"],
-		queryFn: () => clientsApi.list(false),
-		retry: 1,
-	});
-
-	const currentClient = useMemo(
-		() => clientsData?.client?.find((client) => client.identifier === identifier),
-		[clientsData?.client, identifier],
-	);
-	const supportsBackupOperations =
-		Boolean(currentClient) &&
-		currentClient?.writable_config !== false &&
-		currentClient?.template?.managed_source !== "runtime_active_client";
-	const detailTabs = useMemo(
-		() =>
-			!supportsBackupOperations
-				? ["overview", "configuration"]
-				: ["overview", "configuration", "backups"],
-		[supportsBackupOperations],
-	);
-	const { activeTab: tabValue, setActiveTab: setTabValue } = useUrlTab({
-		paramName: "tab",
-		defaultTab: "overview",
-		validTabs: detailTabs,
-	});
-	const [selectedProfiles, setSelectedProfiles] = useState<string[]>([]);
-
-	const limitId = useId();
-	const [mode, setMode] = useState<ClientConfigMode>("hosted");
-	const [transport, setTransport] = useState<string>("auto");
-	const [unifyRouteMode, setUnifyRouteMode] = useState<UnifyRouteMode>("broker_only");
-	const [unifySelectedServers, setUnifySelectedServers] = useState<string[]>([]);
-	const [unifyCapabilityIds, setUnifyCapabilityIds] = useState<UnifyDirectCapabilityIds>({});
-	const [hasUnifyDraftChanges, setHasUnifyDraftChanges] = useState(false);
-
-	useEffect(() => {
-		if (!currentClient) {
-			return;
-		}
-		const isWritableConfig = currentClient.writable_config !== false;
-		setDisplayName(currentClient.display_name || "");
-		if (typeof currentClient.config_mode === "string") {
-			const configMode = currentClient.config_mode;
-			if (configMode === "unify") {
-				setMode("unify");
-			} else if (configMode === "transparent") {
-				setMode(resolveConfigModeForWritableState("transparent", isWritableConfig));
-			} else {
-				setMode("hosted");
-			}
-		} else {
-			setMode(resolveConfigModeForWritableState(clientDefaultMode, isWritableConfig));
-		}
-		setTransport(resolveSelectedTransport(currentClient.transports));
-	}, [clientDefaultMode, currentClient]);
-
-	useEffect(() => {
-		if (currentClient?.writable_config === false && tabValue === "backups") {
-			setTabValue("configuration");
-		}
-	}, [currentClient?.writable_config, setTabValue, tabValue]);
-
-	const [selectedConfig, setSelectedConfig] =
-		useState<ClientCapabilitySourceSelection>("default");
-	const [policyOpen, setPolicyOpen] = useState(false);
-	const [importPreviewOpen, setImportPreviewOpen] = useState(false);
-	const [importPreviewData, setImportPreviewData] =
-		useState<ClientConfigImportData | null>(null);
-
-	const {
-		data: configDetails,
-		isLoading: loadingConfig,
-		refetch: refetchDetails,
-	} = useQuery({
-		queryKey: ["client-config", identifier],
-		queryFn: () => clientsApi.configDetails(identifier || "", false),
-		enabled: !!identifier,
-	});
-
-	const { data: capabilityConfig } = useQuery({
-		queryKey: ["client-capability-config", identifier],
-		queryFn: () => clientsApi.getCapabilityConfig(identifier || ""),
-		enabled: !!identifier,
-	});
-
-	const {
-		data: backupsData,
-		isLoading: loadingBackups,
-		refetch: refetchBackups,
-	} = useQuery({
-		queryKey: ["client-backups", identifier],
-		queryFn: () => clientsApi.listBackups(identifier || undefined),
-		enabled: Boolean(identifier && supportsBackupOperations),
-	});
-
-	// Fetch eligible servers for Unify direct exposure
-	const { data: serversListData } = useQuery({
-		queryKey: ["servers", "unify-candidates"],
-		queryFn: () => serversApi.getAll(),
-		staleTime: 0,
-		gcTime: 0,
-		refetchOnMount: "always",
-		refetchOnWindowFocus: "always",
-		refetchOnReconnect: "always",
-		retry: 1,
-	});
-	const eligibleServers = useMemo(() => {
-		return serversListData?.servers?.filter((s) => s.unify_direct_exposure_eligible) || [];
-	}, [serversListData]);
-
-	const refreshClientCapabilityState = useCallback(async () => {
-		await Promise.allSettled([
-			qc.invalidateQueries({ queryKey: ["client-capability-config", identifier] }),
-			qc.invalidateQueries({ queryKey: ["client-config", identifier] }),
-			qc.invalidateQueries({ queryKey: ["clients"] }),
-		]);
-	}, [identifier, qc]);
-
-	const { data: profilesData, isLoading: loadingProfiles } = useQuery({
-		queryKey: ["profiles"],
-		queryFn: () => configSuitsApi.getAll(),
-		retry: 1,
-	});
-
-	const visibleBackups = useMemo(() => {
-		const backups: ClientBackupEntry[] = backupsData?.backups || [];
-		return backups.filter((backup) => backup.identifier === identifier);
-	}, [backupsData?.backups, identifier]);
-
-	// Process profiles data
-	const activeProfiles = useMemo(() => {
-		const profiles: ConfigSuit[] = profilesData?.suits || [];
-		return arrangeProfilesWithDefaultFirst(
-			profiles.filter((profile) => profile.is_active),
-		);
-	}, [profilesData?.suits]);
-	const sharedProfiles = useMemo(() => {
-		const profiles: ConfigSuit[] = profilesData?.suits || [];
-		return arrangeProfilesWithDefaultFirst(
-			profiles.filter((profile) => profile.suit_type === "shared"),
-		);
-	}, [profilesData?.suits]);
-
-	const effectiveCapabilityConfig = useMemo<ClientCapabilityConfigData | null>(() => {
-		if (capabilityConfig) {
-			return capabilityConfig;
-		}
-		if (!identifier) {
-			return null;
-		}
-		return {
-			identifier,
-			capability_source: configDetails?.capability_source || "activated",
-			selected_profile_ids: configDetails?.selected_profile_ids || [],
-			custom_profile_id: configDetails?.custom_profile_id ?? null,
-			custom_profile_missing: configDetails?.custom_profile_missing ?? false,
-		};
-	}, [
-		capabilityConfig,
-		configDetails?.capability_source,
-		configDetails?.custom_profile_id,
-		configDetails?.custom_profile_missing,
-		configDetails?.selected_profile_ids,
-		identifier,
-	]);
-
-	const customProfileMissing =
-		effectiveCapabilityConfig?.custom_profile_missing ??
-		configDetails?.custom_profile_missing ??
-		false;
-
-	const customProfileId =
-		customProfileMissing
-			? null
-			: effectiveCapabilityConfig?.custom_profile_id ?? configDetails?.custom_profile_id ?? null;
-
-	useEffect(() => {
-		setHasUnifyDraftChanges(false);
-	}, [identifier]);
-
-	useEffect(() => {
-		if (!effectiveCapabilityConfig) {
-			return;
-		}
-		if (hasUnifyDraftChanges) {
-			return;
-		}
-		switch (effectiveCapabilityConfig.capability_source) {
-			case "profiles":
-				setSelectedConfig("profile");
-				setSelectedProfiles(effectiveCapabilityConfig.selected_profile_ids || []);
-				break;
-			case "custom":
-				setSelectedConfig("custom");
-				setSelectedProfiles([]);
-				break;
-			case "activated":
-			default:
-				setSelectedConfig("default");
-				setSelectedProfiles([]);
-				break;
-		}
-		if (effectiveCapabilityConfig.unify_direct_exposure) {
-			const exposure = effectiveCapabilityConfig.unify_direct_exposure;
-			setUnifyRouteMode(exposure.route_mode || "broker_only");
-			setUnifySelectedServers(exposure.server_ids ?? []);
-			setUnifyCapabilityIds(normalizeDirectCapabilityIds(exposure.capability_ids));
-		} else {
-			setUnifyRouteMode("broker_only");
-			setUnifySelectedServers([]);
-			setUnifyCapabilityIds({});
-		}
-	}, [effectiveCapabilityConfig, hasUnifyDraftChanges]);
-
-	const capabilityProfileIds = useMemo(() => {
-		const ids = new Set<string>();
-		for (const profile of [...activeProfiles, ...sharedProfiles]) {
-			ids.add(profile.id);
-		}
-		if (customProfileId) {
-			ids.add(customProfileId);
-		}
-		return Array.from(ids);
-	}, [activeProfiles, customProfileId, sharedProfiles]);
-
-	// Fetch capabilities for profiles
-	const profileCapabilitiesQueries = useQueries({
-		queries: capabilityProfileIds.map((profileId) => ({
-			queryKey: ["profile-capabilities", profileId],
-			queryFn: async () => {
-				const [serversRes, toolsRes, resourcesRes, promptsRes, templatesRes] =
-					await Promise.all([
-						configSuitsApi.getServers(profileId),
-						configSuitsApi.getTools(profileId),
-						configSuitsApi.getResources(profileId),
-						configSuitsApi.getPrompts(profileId),
-						configSuitsApi.getResourceTemplates(profileId),
-					]);
-
-				const enabledByComponentId = new Map<string, boolean>();
-				for (const s of serversRes?.servers ?? []) {
-					enabledByComponentId.set(s.id, Boolean(s.enabled));
-				}
-				for (const tool of toolsRes?.tools ?? []) {
-					enabledByComponentId.set(tool.id, Boolean(tool.enabled));
-				}
-				for (const r of resourcesRes?.resources ?? []) {
-					enabledByComponentId.set(r.id, Boolean(r.enabled));
-				}
-				for (const p of promptsRes?.prompts ?? []) {
-					enabledByComponentId.set(p.id, Boolean(p.enabled));
-				}
-				for (const tmpl of templatesRes?.templates ?? []) {
-					enabledByComponentId.set(tmpl.id, Boolean(tmpl.enabled));
-				}
-
-				return {
-					profileId,
-					enabledByComponentId,
-					servers: {
-						total: serversRes?.servers?.length || 0,
-						enabled:
-							serversRes?.servers?.filter(
-								(s: { enabled?: boolean }) => s.enabled,
-							).length || 0,
-					},
-					tools: {
-						total: toolsRes?.tools?.length || 0,
-						enabled:
-							toolsRes?.tools?.filter((tool: { enabled?: boolean }) => tool.enabled)
-								.length || 0,
-					},
-					resources: {
-						total: resourcesRes?.resources?.length || 0,
-						enabled:
-							resourcesRes?.resources?.filter(
-								(r: { enabled?: boolean }) => r.enabled,
-							).length || 0,
-					},
-					prompts: {
-						total: promptsRes?.prompts?.length || 0,
-						enabled:
-							promptsRes?.prompts?.filter(
-								(p: { enabled?: boolean }) => p.enabled,
-							).length || 0,
-					},
-				};
-			},
-			enabled: capabilityProfileIds.length > 0,
-			retry: 1,
-		})),
-	});
-
-	// Create capabilities map
-	const profileCapabilities = useMemo(() => {
-		const map = new Map();
-		profileCapabilitiesQueries.forEach((query) => {
-			const data = query.data ?? undefined;
-			if (data) {
-				map.set(data.profileId, data);
-			}
-		});
-		return map;
-	}, [profileCapabilitiesQueries]);
-
-	const customProfileCapabilities = customProfileId
-		? profileCapabilities.get(customProfileId)
-		: undefined;
-	const managedTransportSupported = Object.keys(configDetails?.transports ?? {}).length > 0;
-	const canWriteClientConfig = configDetails?.writable_config !== false;
-	const isPendingApproval = configDetails?.approval_status === "pending";
-	const isSuspendedClient = isDeniedApprovalStatus(configDetails?.approval_status);
-	const isAttachmentApplicable =
-		configDetails?.attachment_state === "attached" ||
-		configDetails?.attachment_state === "detached";
-	const isAttachedClient = isAttachmentApplicable && configDetails?.attachment_state === "attached";
-	const showLocalConfigMetadata = isAttachmentApplicable && Boolean(configDetails?.config_path);
-	const overviewActionButtonClass =
-		"gap-2 rounded-none first:rounded-l-md last:rounded-r-md";
-	const canSaveManagementSettings = !isPendingApproval;
-	const canApplyTransparentConfig =
-		canSaveManagementSettings &&
-		canWriteClientConfig &&
-		!isDeniedApprovalStatus(configDetails?.approval_status);
-	const canSyncManagedConfig =
-		canWriteClientConfig &&
-		canSaveManagementSettings &&
-		!isDeniedApprovalStatus(configDetails?.approval_status) &&
-		managedTransportSupported;
-	const shouldRequireLocalConfigWrite = mode === "transparent";
-
-	const supportedTransportOptions = useMemo(() => {
-		const supported = Object.keys(configDetails?.transports ?? {});
-		if (supported.length < 2) {
-			return [] as string[];
-		}
-
-		const allowed = new Set(supported);
-		return SUPPORTED_TRANSPORT_OPTIONS.filter((transportOption) =>
-			allowed.has(transportOption),
-		);
-	}, [configDetails?.transports]);
-
-	const unifyRouteModeSegmentOptions = useMemo(
-		() => {
-			return [
-				{
-					value: "broker_only",
-					label: t("detail.configuration.sections.source.unifyRouteModes.broker_only", {
-						defaultValue: "Broker Only",
-					}),
-				},
-				{
-					value: "server_level",
-					label: t("detail.configuration.sections.source.unifyRouteModes.server_level", {
-						defaultValue: "Server Level",
-					}),
-				},
-				{
-					value: "capability_level",
-					label: t("detail.configuration.sections.source.unifyRouteModes.capability_level", {
-						defaultValue: "Capability Level",
-					}),
-				},
-			];
-		},
-		[t, i18n.language],
-	);
-
-	const configurationSourceSegmentOptions = useMemo(
-		() => {
-			const statusOrUndefined = (raw: string) => {
-				const trimmed = raw.trim();
-				return trimmed.length > 0 ? trimmed : undefined;
-			};
-			return [
-				{
-					value: "default",
-					label: t("detail.configuration.sections.source.options.default", {
-						defaultValue: "Active",
-					}),
-					status: statusOrUndefined(
-						t("detail.configuration.sections.source.statusLabel.default", {
-							defaultValue: "",
-						}),
-					),
-				},
-				{
-					value: "profile",
-					label: t("detail.configuration.sections.source.options.profile", {
-						defaultValue: "Profiles",
-					}),
-					status: statusOrUndefined(
-						t("detail.configuration.sections.source.statusLabel.profile", {
-							defaultValue: "",
-						}),
-					),
-				},
-				{
-					value: "custom",
-					label: t("detail.configuration.sections.source.options.custom", {
-						defaultValue: "Customize",
-					}),
-					status: statusOrUndefined(
-						t("detail.configuration.sections.source.statusLabel.custom", {
-							defaultValue: "",
-						}),
-					),
-				},
-			];
-		},
-		[t, i18n.language],
-	);
-
-	const detailDescription = configDetails?.description ?? "";
-	const detailHomepageUrl = configDetails?.homepage_url ?? "";
-	const detailDocsUrl = configDetails?.docs_url ?? "";
-	const detailSupportUrl = configDetails?.support_url ?? "";
-	const renderOverviewActionButtons = () => {
-		if (!configDetails) return null;
-		return (
-			<ButtonGroup className="ml-auto flex-shrink-0 flex-nowrap self-start">
-				<Button
-					variant="outline"
-					size="sm"
-					onClick={() => refreshDetectMutation.mutate()}
-					disabled={refreshDetectMutation.isPending}
-					className={overviewActionButtonClass}
-				>
-					<RefreshCw
-						className={`h-4 w-4 ${refreshDetectMutation.isPending ? "animate-spin" : ""}`}
-					/>
-					{t("detail.overview.buttons.refresh", {
-						defaultValue: "Refresh",
-					})}
-				</Button>
-				<Button
-					variant="outline"
-					size="sm"
-					onClick={() => setIsClientFormOpen(true)}
-					className={overviewActionButtonClass}
-				>
-					<Pencil className="h-4 w-4" />
-					{t("detail.overview.buttons.edit", {
-						defaultValue: "Edit",
-					})}
-				</Button>
-			</ButtonGroup>
-		);
-	};
-	const managementModeSegmentOptions = useMemo(
-		() => {
-			return [
-				{
-					value: "unify",
-					label: t("detail.configuration.sections.mode.options.unify", {
-						defaultValue: "Unify",
-					}),
-				},
-				{
-					value: "hosted",
-					label: t("detail.configuration.sections.mode.options.hosted", {
-						defaultValue: "Hosted",
-					}),
-				},
-				{
-					value: "transparent",
-					label: t("detail.configuration.sections.mode.options.transparent", {
-						defaultValue: "Transparent",
-					}),
-					disabled: configDetails?.writable_config === false,
-					tooltip:
-						configDetails?.writable_config === false
-							? t("detail.configuration.sections.mode.transparentDisabledReason", {
-								defaultValue: "Transparent requires a writable local config path.",
-							})
-							: undefined,
-				},
-			];
-		},
-		[configDetails?.writable_config, t, i18n.language],
-	);
-	const [logFilter, setLogFilter] = useState("");
-	const [logPageSize, setLogPageSize] = useState<number>(10);
-	const [logPageCursors, setLogPageCursors] = useState<string[]>([]);
-	const [logCurrentPageIndex, setLogCurrentPageIndex] = useState(0);
-	const [isLogPaginationActionLoading, setIsLogPaginationActionLoading] =
-		useState(false);
-	const logCurrentCursor = logPageCursors[logCurrentPageIndex];
-
-	const logsQuery = useQuery({
-		queryKey: [
-			"client-audit-logs",
-			identifier,
-			logCurrentCursor,
-			logPageSize,
-			showClientLiveLogs,
-		],
-		queryFn: () =>
-			auditApi.list({
-				limit: logPageSize,
-				cursor: logCurrentCursor,
-				client_id: identifier,
-			}),
-		enabled: Boolean(identifier && showClientLiveLogs),
-		refetchOnWindowFocus: false,
-		retry: false,
-	});
-
-	useEffect(() => {
-		setLogPageCursors([]);
-		setLogCurrentPageIndex(0);
-	}, [identifier, logPageSize]);
-
-	const filteredLogs = useMemo(() => {
-		const logs = logsQuery.data?.events ?? [];
-		const term = logFilter.trim().toLowerCase();
-		if (!term) {
-			return logs;
-		}
-		return logs.filter((event) => {
-			const haystacks = [
-				event.action,
-				event.category,
-				event.status,
-				event.target,
-				event.route,
-				event.error_message,
-				event.detail,
-				event.mcp_method,
-				event.request_id,
-			]
-				.filter(Boolean)
-				.map((value) => String(value).toLowerCase());
-			return haystacks.some((value) => value.includes(term));
-		});
-	}, [logsQuery.data?.events, logFilter]);
-
-	const handleLogsNextPage = () => {
-		if (!logsQuery.data?.next_cursor) {
-			return;
-		}
-		const nextCursor = logsQuery.data.next_cursor;
-		setLogPageCursors((prev) => {
-			const next = [...prev];
-			next[logCurrentPageIndex + 1] = nextCursor;
-			return next;
-		});
-		setLogCurrentPageIndex((prev) => prev + 1);
-	};
-
-	const handleLogsPrevPage = () => {
-		if (logCurrentPageIndex > 0) {
-			setLogCurrentPageIndex((prev) => prev - 1);
-		}
-	};
-
-	const handleLogsFirstPage = () => {
-		setLogCurrentPageIndex(0);
-	};
-
-	const handleLogsLastPage = async () => {
-		if (!logsQuery.data?.next_cursor || !identifier) {
-			return;
-		}
-		setIsLogPaginationActionLoading(true);
-		try {
-			let nextCursor: string | undefined = logsQuery.data.next_cursor;
-			let targetPageIndex = logCurrentPageIndex;
-			const nextPageCursors = [...logPageCursors];
-			while (nextCursor) {
-				targetPageIndex += 1;
-				nextPageCursors[targetPageIndex] = nextCursor;
-				const page = await auditApi.list({
-					limit: logPageSize,
-					cursor: nextCursor,
-					client_id: identifier,
-				});
-				if (!page) {
-					break;
-				}
-				nextCursor = page.next_cursor ?? undefined;
-			}
-			setLogPageCursors(nextPageCursors);
-			setLogCurrentPageIndex(targetPageIndex);
-		} finally {
-			setIsLogPaginationActionLoading(false);
-		}
-	};
-
-	const buildCapabilityConfigPayload = (): ClientCapabilityConfigReq => {
-		if (!identifier) {
-			throw new Error("No identifier provided");
-		}
-
-		const payload: ClientCapabilityConfigReq = {
-			identifier,
-			capability_source: "activated",
-			selected_profile_ids: [],
-		};
-
-		if (mode === "unify") {
-			payload.capability_source = "activated";
-			payload.selected_profile_ids = [];
-			payload.unify_direct_exposure = buildUnifyDirectExposurePayload(
-				unifyRouteMode,
-				unifySelectedServers,
-				unifyCapabilityIds,
-			);
-		} else {
-			payload.unify_direct_exposure = effectiveCapabilityConfig?.unify_direct_exposure || null;
-			if (selectedConfig === "profile") {
-				const profileIds = selectedProfiles.length > 0
-					? selectedProfiles
-					: [sharedProfiles.find((p) => p.is_default)?.id].filter(Boolean) as string[];
-
-				if (profileIds.length === 0) {
-					throw new Error(
-						t("detail.configuration.errors.profileRequired", {
-							defaultValue:
-								"Select at least one shared profile before applying this capability source.",
-						}),
-					);
-				}
-				payload.capability_source = "profiles";
-				payload.selected_profile_ids = profileIds;
-			} else if (selectedConfig === "custom") {
-				payload.capability_source = "custom";
-				payload.selected_profile_ids = [];
-			} else {
-				payload.capability_source = "activated";
-				payload.selected_profile_ids = [];
-			}
-		}
-
-		return payload;
-	};
-
-	const directExposureServerMutation = useMutation<
-		ClientCapabilityConfigData | null,
-		unknown,
-		{ server: ServerSummary; routeMode: DirectExposureRouteMode }
-	>({
-		mutationFn: async ({ server, routeMode }) => {
-			if (!identifier) {
-				throw new Error("No identifier provided");
-			}
-
-			const currentConfig =
-				(await clientsApi.getCapabilityConfig(identifier)) ?? effectiveCapabilityConfig;
-			if (!currentConfig) {
-				throw new Error(
-					t("detail.configuration.errors.capabilityConfigMissing", {
-						defaultValue:
-							"Capability configuration update returned no data. Please try again.",
-					}),
-				);
-			}
-
-			if (routeMode === "server_level") {
-				return clientsApi.updateCapabilityConfig(
-					buildServerLevelExposureUpdate(identifier, currentConfig, server.id),
-				);
-			}
-
-			const [toolsResponse, promptsResponse, resourcesResponse, templatesResponse] =
-				await Promise.all([
-					serversApi.listTools(server.id).catch(() => ({ items: [] })),
-					serversApi.listPrompts(server.id).catch(() => ({ items: [] })),
-					serversApi.listResources(server.id).catch(() => ({ items: [] })),
-					serversApi.listResourceTemplates(server.id).catch(() => ({ items: [] })),
-				]);
-
-			const currentUnifyExposure = currentConfig.unify_direct_exposure ?? {
-				route_mode: "capability_level" as const,
-				server_ids: [],
-				capability_ids: {},
-			};
-
-			const currentCapabilityIds = normalizeDirectCapabilityIds(currentUnifyExposure.capability_ids);
-
-			const rawTools = Array.isArray(toolsResponse.items)
-				? (toolsResponse.items as Array<Record<string, unknown>>)
-				: [];
-			const rawPrompts = Array.isArray(promptsResponse.items)
-				? (promptsResponse.items as Array<Record<string, unknown>>)
-				: [];
-			const rawResources = Array.isArray(resourcesResponse.items)
-				? (resourcesResponse.items as Array<Record<string, unknown>>)
-				: [];
-			const rawTemplates = Array.isArray(templatesResponse.items)
-				? (templatesResponse.items as Array<Record<string, unknown>>)
-				: [];
-
-			const serverToolIds = rawTools
-				.map((tool) => getCapabilityId(tool, ["unique_name"]))
-				.filter((id): id is string => Boolean(id));
-			const serverPromptIds = rawPrompts
-				.map((prompt) => getCapabilityId(prompt, ["unique_name"]))
-				.filter((id): id is string => Boolean(id));
-			const serverResourceIds = rawResources
-				.map((resource) => getCapabilityId(resource, ["unique_uri"]))
-				.filter((id): id is string => Boolean(id));
-			const serverTemplateIds = rawTemplates
-				.map((template) => getCapabilityId(template, ["unique_uri_template", "unique_name"]))
-				.filter((id): id is string => Boolean(id));
-			const serverCapabilityIdSet = new Set([
-				...serverToolIds,
-				...serverPromptIds,
-				...serverResourceIds,
-				...serverTemplateIds,
-			]);
-			const hasAnySelectedForServer = [
-				...(currentCapabilityIds.tool_ids ?? []),
-				...(currentCapabilityIds.prompt_ids ?? []),
-				...(currentCapabilityIds.resource_ids ?? []),
-				...(currentCapabilityIds.template_ids ?? []),
-			].some((id) => serverCapabilityIdSet.has(id));
-
-			const nextCapabilityIds: UnifyDirectCapabilityIds = {
-				tool_ids: resolveNextCapabilityIds(currentCapabilityIds.tool_ids, hasAnySelectedForServer, serverToolIds),
-				prompt_ids: resolveNextCapabilityIds(currentCapabilityIds.prompt_ids, hasAnySelectedForServer, serverPromptIds),
-				resource_ids: resolveNextCapabilityIds(currentCapabilityIds.resource_ids, hasAnySelectedForServer, serverResourceIds),
-				template_ids: resolveNextCapabilityIds(currentCapabilityIds.template_ids, hasAnySelectedForServer, serverTemplateIds),
-			};
-
-			return clientsApi.updateCapabilityConfig(
-				buildCapabilityLevelExposureUpdate(identifier, currentConfig, nextCapabilityIds),
-			);
-		},
-		onSuccess: async (data, { routeMode }) => {
-			if (routeMode === "server_level") {
-				setUnifySelectedServers(data?.unify_direct_exposure?.server_ids ?? []);
-				setHasUnifyDraftChanges(false);
-			}
-			await refreshClientCapabilityState();
-		},
-		onError: (error) =>
-			notifyError(
-				t("detail.directExposure.notifications.saveFailedTitle", {
-					defaultValue: "Unable to update direct capabilities",
-				}),
-				String(error),
-			),
-	});
-
-	const renderProfileCapabilitySummary = (
-		capabilities: NonNullable<ReturnType<typeof profileCapabilities.get>>,
-	) => {
-		const capabilityItems = [
-			{
-				key: "servers",
-				label: t("detail.configuration.labels.servers", {
-					defaultValue: "Servers",
-				}),
-				counts: capabilities.servers,
-			},
-			{
-				key: "tools",
-				label: t("detail.configuration.labels.tools", {
-					defaultValue: "Tools",
-				}),
-				counts: capabilities.tools,
-			},
-			{
-				key: "resources",
-				label: t("detail.configuration.labels.resources", {
-					defaultValue: "Resources",
-				}),
-				counts: capabilities.resources,
-			},
-			{
-				key: "prompts",
-				label: t("detail.configuration.labels.prompts", {
-					defaultValue: "Prompts",
-				}),
-				counts: capabilities.prompts,
-			},
-		];
-
-		return (
-			<div className="mt-1 flex gap-4 text-xs text-slate-500">
-				{capabilityItems.map((item) => (
-					<span key={item.key}>
-						{item.label}: {item.counts.enabled}/{item.counts.total}
-					</span>
-				))}
-			</div>
-		);
-	};
-
-	const renderUnifyEligibleServerCapabilitySummary = (
-		server: ServerSummary,
-		routeMode: DirectExposureRouteMode,
-		exposedToolCount: number,
-	) => {
-		const cap = server.capabilities ?? server.capability;
-		const toolsTotal = cap?.tools_count ?? 0;
-		const toolsValue =
-			routeMode === "capability_level"
-				? `${exposedToolCount}/${toolsTotal}`
-				: String(toolsTotal);
-		const items = [
-			{
-				key: "tools",
-				label: t("detail.configuration.labels.tools", {
-					defaultValue: "Tools",
-				}),
-				value: toolsValue,
-			},
-			{
-				key: "resources",
-				label: t("detail.configuration.labels.resources", {
-					defaultValue: "Resources",
-				}),
-				value: String(cap?.resources_count ?? 0),
-			},
-			{
-				key: "prompts",
-				label: t("detail.configuration.labels.prompts", {
-					defaultValue: "Prompts",
-				}),
-				value: String(cap?.prompts_count ?? 0),
-			},
-			{
-				key: "resourceTemplates",
-				label: t("detail.configuration.labels.resourceTemplates", {
-					defaultValue: "Resource templates",
-				}),
-				value: String(cap?.resource_templates_count ?? 0),
-			},
-		];
-		return (
-			<div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
-				{items.map((item) => (
-					<span key={item.key}>
-						{item.label}: {item.value}
-					</span>
-				))}
-			</div>
-		);
-	};
-
-	const getConfigurationProfileTokenSlot = (
-		profile: ConfigSuit,
-		stopPropagationOnNavigate: boolean,
-	) => {
-		const capData = profileCapabilities.get(profile.id);
-		const capIdx = capabilityProfileIds.indexOf(profile.id);
-		const capQuery =
-			capIdx >= 0 ? profileCapabilitiesQueries[capIdx] : undefined;
-
-		if (capQuery?.isError) {
-			return (
-				<Link
-					to={`/profiles/${profile.id}`}
-					onClick={
-						stopPropagationOnNavigate ? (e) => e.stopPropagation() : undefined
-					}
-					className="text-xs text-destructive underline underline-offset-2"
-				>
-					{t("detail.configuration.labels.openProfileDetail", {
-						defaultValue: "Open profile details",
-					})}
-				</Link>
-			);
-		}
-
-		if (!capData) {
-			return (
-				<div
-					className="h-14 w-14 shrink-0 animate-pulse rounded-full bg-muted/50"
-					aria-hidden
-				/>
-			);
-		}
-
-		return (
-			<ConfigurationProfileTokenChart
-				profileId={profile.id}
-				enabledByComponentId={capData.enabledByComponentId}
-				profileServerCount={capData.servers.total}
-				stopPropagationOnNavigate={stopPropagationOnNavigate}
-			/>
-		);
-	};
-
-	const { data: policyData, refetch: refetchPolicy } = useQuery({
-		queryKey: ["client-policy", identifier],
-		queryFn: () => clientsApi.getBackupPolicy(identifier || ""),
-		enabled: Boolean(identifier && supportsBackupOperations),
-	});
-
-	const reviewMutation = useMutation({
-		mutationFn: async (action: "approve" | "suspend") => {
-			if (!identifier) throw new Error("No identifier provided");
-			return action === "approve"
-				? clientsApi.approveRecord({ identifier })
-				: clientsApi.suspendRecord({ identifier });
-		},
-		onSuccess: (_, action) => {
-			notifySuccess(
-				t("detail.notifications.reviewSuccess.title", { defaultValue: "Success" }),
-				t(
-					action === "approve"
-						? "detail.notifications.reviewSuccess.messageApproved"
-						: "detail.notifications.reviewSuccess.messageSuspended",
-					{
-						defaultValue:
-							action === "approve"
-								? "Record approved successfully."
-								: "Record suspended successfully.",
-					},
-				),
-			);
-			qc.invalidateQueries({ queryKey: ["clients"] });
-			qc.invalidateQueries({ queryKey: ["client-config", identifier] });
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.reviewFailed.title", { defaultValue: "Review failed" }),
-				String(e),
-			),
-	});
-
-	const detachMutation = useMutation({
-		mutationFn: async () => {
-			if (!identifier) throw new Error("No identifier provided");
-			return clientsApi.detach(identifier);
-		},
-		onSuccess: () => {
-			notifySuccess(
-				t("detail.notifications.detachSuccess.title", { defaultValue: "Detached" }),
-				t("detail.notifications.detachSuccess.message", {
-					defaultValue: "MCPMate was removed from the client configuration file.",
-				}),
-			);
-			qc.invalidateQueries({ queryKey: ["clients"] });
-			qc.invalidateQueries({ queryKey: ["client-config", identifier] });
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.detachFailed.title", { defaultValue: "Detach failed" }),
-				String(e),
-			),
-	});
-
-	const attachMutation = useMutation({
-		mutationFn: async () => {
-			if (!identifier) throw new Error("No identifier provided");
-			return clientsApi.attach(identifier);
-		},
-		onSuccess: () => {
-			notifySuccess(
-				t("detail.notifications.attachSuccess.title", { defaultValue: "Attached" }),
-				t("detail.notifications.attachSuccess.message", {
-					defaultValue: "MCPMate was written back to the client configuration.",
-				}),
-			);
-			qc.invalidateQueries({ queryKey: ["clients"] });
-			qc.invalidateQueries({ queryKey: ["client-config", identifier] });
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.attachFailed.title", { defaultValue: "Attach failed" }),
-				String(e),
-			),
-	});
-
-	const applyMutation = useMutation<
-		{
-			data: ClientConfigUpdateData | null;
-			preview: boolean;
-			clientConfigApplied: boolean;
-		},
-		unknown,
-		{ preview: boolean }
-	>({
-		mutationFn: async ({ preview }) => {
-			if (!identifier) throw new Error("No identifier provided");
-			if (!canSaveManagementSettings) {
-				throw new Error(
-					t("detail.configuration.managementSettingsPendingReason", {
-						defaultValue:
-							"Save management settings after this client leaves pending approval.",
-					}),
-				);
-			}
-
-			// Validate transparent-mode requirements before persisting any management
-			// settings, so a failed precondition never leaves partial state in MCPMate.
-			if (shouldRequireLocalConfigWrite) {
-				if (!canWriteClientConfig) {
-					throw new Error(
-						t("detail.configuration.writeTargetRequiredReason", {
-							defaultValue:
-								"Applying governance to the client configuration requires a verified writable local MCP config file.",
-						}),
-					);
-				}
-				if (!canApplyTransparentConfig) {
-					throw new Error(
-						t("detail.configuration.applyRequiresApprovedReason", {
-							defaultValue:
-								"Applying client configuration requires an approved governance state and a verified local config target.",
-						}),
-					);
-				}
-			}
-
-			await clientsApi.update({
-				identifier,
-				config_mode: mode,
-			});
-
-			const capabilityData = await clientsApi.updateCapabilityConfig(buildCapabilityConfigPayload());
-			if (!capabilityData) {
-				throw new Error(
-					t("detail.configuration.errors.capabilityConfigMissing", {
-						defaultValue:
-							"Capability configuration update returned no data. Please try again.",
-					}),
-				);
-			}
-
-			const selectedConfigForManagedApply =
-				mode === "unify"
-					? "default"
-					: buildClientApplySelectedConfig(capabilityData);
-
-			if (shouldRequireLocalConfigWrite) {
-				const data = await clientsApi.applyConfig({
-					identifier,
-					mode,
-					selected_config: buildClientApplySelectedConfig(capabilityData),
-					preview,
-					backup_policy: preview
-						? undefined
-						: mapDashboardSettingsToClientBackupPolicy(dashboardSettings),
-				});
-				return { data: data ?? null, preview, clientConfigApplied: true };
-			}
-
-			if (!canSyncManagedConfig) {
-				return { data: null, preview, clientConfigApplied: false };
-			}
-
-			const data = await clientsApi.applyConfig({
-				identifier,
-				mode,
-				selected_config: selectedConfigForManagedApply,
-				preview,
-				backup_policy: preview
-					? undefined
-					: mapDashboardSettingsToClientBackupPolicy(dashboardSettings),
-			});
-			return { data: data ?? null, preview, clientConfigApplied: true };
-		},
-		onSuccess: ({ data, preview, clientConfigApplied }) => {
-			if (preview) {
-				if (data) {
-					notifyInfo(
-						t("detail.notifications.previewReady.title", {
-							defaultValue: "Preview ready",
-						}),
-						t("detail.notifications.previewReady.message", {
-							defaultValue: "Review the diff before applying.",
-						}),
-					);
-				} else {
-					notifyInfo(
-						t("detail.notifications.previewReady.title", {
-							defaultValue: "Preview ready",
-						}),
-						t("detail.notifications.previewReady.noChanges", {
-							defaultValue: "No changes detected in this configuration.",
-						}),
-					);
-				}
-			} else if (clientConfigApplied) {
-				notifySuccess(
-					t("detail.notifications.applied.title", {
-						defaultValue: "Applied",
-					}),
-					t("detail.notifications.applied.message", {
-						defaultValue: "Configuration applied",
-					}),
-				);
-				refetchBackups();
-			} else {
-				notifySuccess(
-					t("detail.notifications.managementSaved.title", {
-						defaultValue: "Saved",
-					}),
-					t("detail.notifications.managementSaved.message", {
-						defaultValue:
-							"Management settings were saved in MCPMate. Local client configuration was not updated.",
-					}),
-				);
-			}
-			void refreshClientCapabilityState();
-			setHasUnifyDraftChanges(false);
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.applyFailed.title", {
-					defaultValue: "Apply failed",
-				}),
-				resolveClientConfigSyncErrorMessage(e, t),
-			),
-	});
-
-	const importMutation = useMutation<ClientConfigImportData | null>({
-		mutationFn: async () => {
-			// If no preview yet, generate one first
-			if (!importPreviewData) {
-				if (!identifier) throw new Error("No identifier provided");
-				const res = await clientsApi.importFromClient(identifier, {
-					preview: true,
-				});
-				setImportPreviewData(res);
-				return null; // indicate preview stage; caller handles UI
-			}
-			if (!identifier) throw new Error("No identifier provided");
-			return clientsApi.importFromClient(identifier, { preview: false });
-		},
-		onSuccess: (res) => {
-			// If onSuccess received null means we just did a preview; do not close
-			if (!res) return;
-			const imported =
-				res.imported_servers?.length ?? res.summary?.imported_count ?? 0;
-			if (imported > 0) {
-				notifySuccess(
-					t("detail.notifications.imported.title", {
-						defaultValue: "Imported",
-					}),
-					t("detail.notifications.imported.message", {
-						defaultValue: "{{count}} server(s) imported successfully",
-						count: imported,
-					}),
-				);
-				setImportPreviewOpen(false);
-			} else {
-				notifyInfo(
-					t("detail.notifications.nothingToImport.title", {
-						defaultValue: "Nothing to import",
-					}),
-					t("detail.notifications.nothingToImport.message", {
-						defaultValue:
-							"All entries were skipped or no importable servers found.",
-					}),
-				);
-				setImportPreviewOpen(false);
-			}
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.importFailed.title", {
-					defaultValue: "Import failed",
-				}),
-				String(e),
-			),
-	});
-
-	// Header actions: refresh detection and update governance state
-	const refreshDetectMutation = useMutation({
-		mutationFn: async () => {
-			const data = await clientsApi.list(true);
-			if (data?.client) {
-				const f = data.client.find((c) => c.identifier === identifier);
-				if (f) {
-					if (typeof f.display_name === "string")
-						setDisplayName(f.display_name);
-				}
-			}
-			await refetchDetails();
-		},
-		onSuccess: () =>
-			notifySuccess(
-				t("detail.notifications.refreshed.title", {
-					defaultValue: "Refreshed",
-				}),
-				t("detail.notifications.refreshed.message", {
-					defaultValue: "Detection refreshed",
-				}),
-			),
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.refreshFailed.title", {
-					defaultValue: "Refresh failed",
-				}),
-				String(e),
-			),
-	});
-
-	const governanceMutation = useMutation<void, unknown, { nextStatus: "approved" | "suspended" }>({
-		mutationFn: async ({ nextStatus }) => {
-			if (!identifier) throw new Error("No identifier provided");
-			if (nextStatus === "approved") {
-				await clientsApi.approveRecord({ identifier });
-				return;
-			}
-
-			await governanceClientsApi.suspendRecord({ identifier });
-		},
-		onSuccess: async (_, { nextStatus }) => {
-			await Promise.allSettled([
-				refetchDetails(),
-				qc.invalidateQueries({ queryKey: ["clients"] }),
-				qc.invalidateQueries({ queryKey: ["client-config", identifier] }),
-			]);
-
-			notifySuccess(
-				t(
-					nextStatus === "approved"
-						? "detail.notifications.governanceAllowed.title"
-						: "detail.notifications.governanceDenied.title",
-					{
-						defaultValue: "Updated",
-					},
-				),
-				t(
-					nextStatus === "approved"
-						? "detail.notifications.governanceAllowed.message"
-						: "detail.notifications.governanceDenied.message",
-					{
-						defaultValue:
-							nextStatus === "approved"
-								? "Client governance is now allowed."
-								: "Client governance is now denied.",
-					},
-				),
-			);
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.governanceFailed.title", {
-					defaultValue: "Update failed",
-				}),
-				String(e),
-			),
-	});
-	const importPreviewMutation = useMutation<ClientConfigImportData>({
-		mutationFn: async () => {
-			if (!identifier) throw new Error("No identifier provided");
-			return clientsApi.importFromClient(identifier, { preview: true });
-		},
-		onSuccess: (res) => {
-			setImportPreviewData(res);
-			setImportPreviewOpen(true);
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.previewFailed.title", {
-					defaultValue: "Preview failed",
-				}),
-				String(e),
-			),
-	});
-
-	const restoreMutation = useMutation({
-		mutationFn: ({ backup }: { backup: string }) => {
-			if (!identifier) throw new Error("No identifier provided");
-			return clientsApi.restoreConfig({ identifier, backup });
-		},
-		onSuccess: () => {
-			notifySuccess(
-				t("detail.notifications.restored.title", {
-					defaultValue: "Restored",
-				}),
-				t("detail.notifications.restored.message", {
-					defaultValue: "Local client configuration restored from backup",
-				}),
-			);
-			refetchDetails();
-			refetchBackups();
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.restoreFailed.title", {
-					defaultValue: "Restore failed",
-				}),
-				String(e),
-			),
-	});
-
-	const deleteBackupMutation = useMutation({
-		mutationFn: ({ backup }: { backup: string }) => {
-			if (!identifier) throw new Error("No identifier provided");
-			return clientsApi.deleteBackup(identifier, backup);
-		},
-		onSuccess: () => {
-			notifySuccess(
-				t("detail.notifications.deleted.title", {
-					defaultValue: "Deleted",
-				}),
-				t("detail.notifications.deleted.message", {
-					defaultValue: "Backup deleted",
-				}),
-			);
-			refetchBackups();
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.deleteFailed.title", {
-					defaultValue: "Delete failed",
-				}),
-				String(e),
-			),
-	});
-
-	const bulkDeleteMutation = useMutation({
-		mutationFn: async () => {
-			if (!identifier) throw new Error("No identifier provided");
-			const items = [...selectedBackups];
-			const results = await Promise.allSettled(
-				items.map((b) => clientsApi.deleteBackup(identifier, b)),
-			);
-			const failed = results.filter((r) => r.status === "rejected").length;
-			if (failed > 0) throw new Error(`${failed} deletions failed`);
-		},
-		onSuccess: async () => {
-			notifySuccess(
-				t("detail.notifications.bulkDeleted.title", {
-					defaultValue: "Deleted",
-				}),
-				t("detail.notifications.bulkDeleted.message", {
-					defaultValue: "Selected backups have been deleted",
-				}),
-			);
-			setSelectedBackups([]);
-			setBulkConfirmOpen(false);
-			await refetchBackups();
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.bulkDeleteFailed.title", {
-					defaultValue: "Bulk delete failed",
-				}),
-				String(e),
-			),
-	});
-
-	const [confirm, setConfirm] = useState<null | {
-		kind: "delete" | "restore";
-		backup: string;
-	}>(null);
-
-	const setPolicyMutation = useMutation({
-		mutationFn: (payload: ClientBackupPolicySetReq) =>
-			clientsApi.setBackupPolicy(payload),
-		onSuccess: () => {
-			notifySuccess(
-				t("detail.notifications.saved.title", {
-					defaultValue: "Saved",
-				}),
-				t("detail.notifications.saved.message", {
-					defaultValue: "Backup policy updated",
-				}),
-			);
-			refetchPolicy();
-		},
-		onError: (e) =>
-			notifyError(
-				t("detail.notifications.saveFailed.title", {
-					defaultValue: "Save failed",
-				}),
-				String(e),
-			),
-	});
-
-	const [policyLabel, setPolicyLabel] = useState<string>("keep_n");
-	const [policyLimit, setPolicyLimit] = useState<number | undefined>(5);
-	useEffect(() => {
-		if (policyData) {
-			setPolicyLabel(policyData.policy || "keep_n");
-			setPolicyLimit(policyData.limit ?? undefined);
-		}
-	}, [policyData]);
-	const backupsDisabledByPolicy =
-		visibleBackups.length === 0 && (policyData?.policy === "off" || policyData?.policy === "none");
-
-	// Heuristic extract current servers from config content for preview
-	const currentServers = useMemo(() => {
-		const c = (configDetails as { content?: unknown })?.content;
-		try {
-			if (!c) return [] as string[];
-			if (typeof c === "string") {
-				const parsed = JSON.parse(c);
-				return extractServers(parsed);
-			}
-			return extractServers(c);
-		} catch {
-			return [] as string[];
-		}
-	}, [configDetails]);
-
-	if (!identifier)
-		return (
-			<div className="p-4">
-				{t("detail.noIdentifier", {
-					defaultValue: "No client identifier provided.",
-				})}
-			</div>
-		);
-
-	return (
-		<div className="flex h-full min-h-0 flex-col gap-4 overflow-hidden">
-			<div className="flex shrink-0 items-center justify-between">
-				<div className="flex flex-col gap-1">
-					<div className="flex items-center gap-3 flex-wrap">
-						<h2 className="text-3xl font-bold tracking-tight">
-							{displayName || identifier}
-						</h2>
-
-						{configDetails?.approval_status === "pending" && (
-							<Badge variant="outline" className="bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-950 dark:text-blue-200 dark:border-blue-800">
-								{t("detail.badges.pendingReview", { defaultValue: "Pending Review" })}
-							</Badge>
-						)}
-						{isSuspendedClient && (
-							<Badge variant="destructive">
-								{t("detail.badges.suspended", { defaultValue: "Suspended" })}
-							</Badge>
-						)}
-						{isAttachmentApplicable ? (
-							<Badge variant={isAttachedClient ? "secondary" : "outline"}>
-								{isAttachedClient
-									? t("detail.badges.attached", { defaultValue: "Attached" })
-									: t("detail.badges.detached", {
-										defaultValue: "Detached",
-									})}
-							</Badge>
-						) : null}
-					</div>
-					{detailDescription ? (
-						<p className="text-sm text-muted-foreground leading-snug w-full truncate">
-							{detailDescription}
-						</p>
-					) : null}
-				</div>
-				{/* 操作按钮移至 Overview 卡片右上角 */}
-			</div>
-
-			<Tabs
-				value={tabValue}
-				onValueChange={setTabValue}
-				className="flex min-h-0 flex-1 flex-col gap-4"
-			>
-				<div className="flex shrink-0 items-center justify-between">
-					<TabsList>
-						<TabsTrigger value="overview">
-							{t("detail.tabs.overview", { defaultValue: "Overview" })}
-						</TabsTrigger>
-						<TabsTrigger value="configuration">
-							{t("detail.tabs.configuration", {
-								defaultValue: "Configuration",
-							})}
-						</TabsTrigger>
-						{configDetails?.writable_config !== false && (
-							<TabsTrigger value="backups">
-								{t("detail.tabs.backups", { defaultValue: "Backups" })}
-							</TabsTrigger>
-						)}
-					</TabsList>
-					{renderOverviewActionButtons()}
-				</div>
-
-				<TabsContent
-					value="overview"
-					className="mt-0 flex min-h-0 flex-1 flex-col overflow-y-auto data-[state=inactive]:hidden"
-				>
-					<div className="grid gap-4">
-						<Card>
-							{loadingConfig ? (
-								<CardContent className="text-sm">
-									<div className="animate-pulse h-16 bg-slate-200 dark:bg-slate-800 rounded" />
-								</CardContent>
-							) : configDetails ? (
-								<CardContent className="p-4">
-									<div className="flex flex-col gap-4">
-										<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-											<div className="flex flex-wrap items-start gap-4">
-												<CachedAvatar
-													src={configDetails.logo_url ?? undefined}
-													alt={displayName || identifier}
-													fallback={displayName || identifier || "C"}
-													className="text-sm"
-												/>
-												<div className="grid grid-cols-[auto_1fr] gap-x-5 gap-y-2 text-sm">
-													{showLocalConfigMetadata ? (
-														<>
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.configPath", {
-																	defaultValue: "Config Path",
-																})}
-															</span>
-															<span className="font-mono text-xs truncate max-w-[520px]">
-																{configDetails.config_path}
-															</span>
-
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.lastModified", {
-																	defaultValue: "Last Modified",
-																})}
-															</span>
-															<span className="text-xs">
-																{formatBackupTime(configDetails.last_modified)}
-															</span>
-														</>
-													) : null}
-
-													<span className="text-xs uppercase text-slate-500">
-														{t("detail.overview.labels.supportedTransports", {
-															defaultValue: "Transports",
-														})}
-													</span>
-													<span className="text-xs flex gap-2">
-														{(Object.keys(configDetails?.transports ?? {})).map(
-															(transport) => (
-																<span
-																	key={transport}
-																	className="inline-flex items-center rounded-full bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
-																	title={transport}
-																>
-																	{transport}
-																</span>
-															),
-														)}
-													</span>
-
-													{detailHomepageUrl ? (
-														<>
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.homepage", {
-																	defaultValue: "Homepage",
-																})}
-															</span>
-															<a
-																href={detailHomepageUrl}
-																target="_blank"
-																rel="noreferrer"
-																className="text-xs underline underline-offset-2 truncate"
-															>
-																{detailHomepageUrl}
-															</a>
-														</>
-													) : null}
-													{detailDocsUrl ? (
-														<>
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.docs", {
-																	defaultValue: "Docs",
-																})}
-															</span>
-															<a
-																href={detailDocsUrl}
-																target="_blank"
-																rel="noreferrer"
-																className="text-xs underline underline-offset-2 truncate"
-															>
-																{detailDocsUrl}
-															</a>
-														</>
-													) : null}
-													{detailSupportUrl ? (
-														<>
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.support", {
-																	defaultValue: "Support",
-																})}
-															</span>
-															<a
-																href={detailSupportUrl}
-																target="_blank"
-																rel="noreferrer"
-																className="text-xs underline underline-offset-2 truncate"
-															>
-																{detailSupportUrl}
-															</a>
-														</>
-													) : null}
-												</div>
-											</div>
-											<ButtonGroup className="ml-auto flex-shrink-0 flex-nowrap self-start">
-												{configDetails?.approval_status === "pending" && (
-													<>
-														<Button
-															variant="outline"
-															size="sm"
-															className="bg-green-50 text-green-700 hover:bg-green-100 hover:text-green-800 border-green-200 dark:bg-green-950 dark:text-green-300 dark:hover:bg-green-900 dark:border-green-800 gap-2"
-															onClick={() => reviewMutation.mutate("approve")}
-															disabled={reviewMutation.isPending}
-														>
-															<Check className="h-4 w-4" />
-															{t("detail.overview.buttons.approve", { defaultValue: "Approve" })}
-														</Button>
-														<Button
-															variant="outline"
-															size="sm"
-															className="bg-red-50 text-red-700 hover:bg-red-100 hover:text-red-800 border-red-200 dark:bg-red-950 dark:text-red-300 dark:hover:bg-red-900 dark:border-red-800 gap-2"
-															onClick={() => reviewMutation.mutate("suspend")}
-															disabled={reviewMutation.isPending}
-														>
-															<Trash2 className="h-4 w-4" />
-															{t("detail.overview.buttons.suspend", { defaultValue: "Suspend" })}
-														</Button>
-													</>
-												)}
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() =>
-														governanceMutation.mutate({
-															nextStatus: isDeniedApprovalStatus(configDetails?.approval_status)
-																? "approved"
-																: "suspended",
-														})
-													}
-													disabled={
-														governanceMutation.isPending ||
-														!configDetails ||
-														configDetails.approval_status === "pending"
-													}
-													className="gap-2"
-												>
-													{isDeniedApprovalStatus(configDetails?.approval_status) ? (
-														<ShieldCheck className="h-4 w-4" />
-													) : (
-														<ShieldX className="h-4 w-4" />
-													)}
-													{isDeniedApprovalStatus(configDetails?.approval_status)
-														? t("detail.overview.buttons.allow", {
-															defaultValue: "Allow",
-														})
-														: t("detail.overview.buttons.deny", {
-															defaultValue: "Deny",
-														})}
-												</Button>
-												{isAttachmentApplicable ? (
-													<Button
-														variant="outline"
-														size="sm"
-														onClick={() =>
-															setAttachmentActionConfirm(isAttachedClient ? "detach" : "attach")
-														}
-														disabled={detachMutation.isPending || attachMutation.isPending}
-														className="gap-2"
-													>
-														{isAttachedClient ? (
-															<Unlink className="h-4 w-4" />
-														) : (
-															<Link2 className="h-4 w-4" />
-														)}
-														{isAttachedClient
-															? t("detail.overview.buttons.detach", { defaultValue: "Detach" })
-															: t("detail.overview.buttons.attach", { defaultValue: "Attach" })}
-													</Button>
-												) : null}
-												{supportedTransportOptions.length > 0 ? (
-													<ButtonGroupText className="h-9 p-0 select-none shadow-none">
-														<Select
-															value={transport}
-															onValueChange={async (v) => {
-																if (!identifier) return;
-																const previousTransport = transport;
-																setTransport(v);
-														try {
-															const selectedTransport = isSupportedTransportOption(v) ? v : "auto";
-															await clientsApi.update({
-																identifier,
-																transport: selectedTransport,
-																transports: withSelectedTransport(
-																	configDetails?.transports,
-																	selectedTransport,
-																),
-															});
-
-																	let configApplied = false;
-																	const shouldApplyManagedConfig =
-																		(mode === "hosted" || mode === "unify") &&
-																		canSyncManagedConfig;
-																	if (shouldApplyManagedConfig) {
-																		try {
-																			const capabilityData =
-																				(await clientsApi.getCapabilityConfig(identifier)) ??
-																				effectiveCapabilityConfig;
-																			if (!capabilityData) {
-																				throw new Error(
-																					t("detail.configuration.errors.capabilityConfigMissing", {
-																						defaultValue:
-																							"Capability configuration update returned no data. Please try again.",
-																					}),
-																				);
-																			}
-
-																			await applyClientConfigWithResolvedSelection({
-																				identifier,
-																				mode,
-																				backupPolicy:
-																					mapDashboardSettingsToClientBackupPolicy(
-																						dashboardSettings,
-																					),
-																				capabilityData,
-																			});
-																			configApplied = true;
-																		} catch (err) {
-																			notifyError(
-																				t("detail.notifications.applyFailed.title", {
-																					defaultValue: "Apply failed",
-																				}),
-																				resolveClientConfigSyncErrorMessage(err, t),
-																			);
-																		}
-																	}
-
-																	notifySuccess(
-																		t("detail.overview.transport.updated", {
-																			defaultValue: "Transport updated",
-																		}),
-																		configApplied
-																			? t("detail.notifications.applied.message", {
-																				defaultValue: "Configuration applied",
-																			})
-																			: "",
-																	);
-																	await refreshClientCapabilityState();
-																} catch (err) {
-																	setTransport(previousTransport);
-																	notifyError(
-																		t(
-																			"detail.overview.transport.updateFailed",
-																			{ defaultValue: "Update failed" },
-																		),
-																		resolveClientConfigSyncErrorMessage(err, t),
-																	);
-																}
-															}}
-														>
-															<SelectTrigger
-																className="h-8 border-0 shadow-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus:outline-none select-none bg-transparent px-3 min-w-[9rem]"
-																aria-label={t("detail.overview.transport.selectorAria", {
-																	defaultValue: "Transport selector",
-																})}
-															>
-																<SelectValue />
-															</SelectTrigger>
-															<SelectContent align="end">
-																<SelectItem value="auto">
-																	{t("detail.configuration.transportOptions.auto", {
-																		defaultValue: "Auto",
-																	})}
-																</SelectItem>
-																{supportedTransportOptions.map((v) => (
-																	<SelectItem key={v} value={v}>
-																		{getTransportOptionLabel(v, t)}
-																	</SelectItem>
-																))}
-															</SelectContent>
-														</Select>
-													</ButtonGroupText>
-												) : null}
-											</ButtonGroup>
-										</div>
-									</div>
-								</CardContent>
-							) : (
-								<CardContent className="text-sm text-slate-500">
-									{t("detail.overview.noDetails", {
-										defaultValue: "No details available",
-									})}
-								</CardContent>
-							)}
-						</Card>
-						<Card>
-							<CardHeader>
-								<div className="flex items-center justify-between">
-									<CardTitle>
-										{t("detail.overview.currentServers.title", {
-											defaultValue: "Current Servers",
-										})}
-									</CardTitle>
-									<div className="flex items-center gap-2">
-										<Button
-											size="sm"
-											variant="outline"
-											onClick={() => importPreviewMutation.mutate()}
-											disabled={configDetails?.writable_config === false}
-										>
-											<Download className="mr-2 h-4 w-4" />{" "}
-											{t("detail.overview.currentServers.import", {
-												defaultValue: "Import from Config",
-											})}
-										</Button>
-									</div>
-								</div>
-							</CardHeader>
-							<CardContent>
-								{loadingConfig ? (
-									<div className="space-y-2">
-										{[1, 2, 3].map((i) => (
-											<div
-												key={i}
-												className="h-8 bg-slate-200 dark:bg-slate-800 animate-pulse rounded-[10px]"
-											/>
-										))}
-									</div>
-								) : currentServers.length ? (
-									<CapsuleStripeList>
-										{currentServers.map((n) => (
-											<CapsuleStripeListItem key={n}>
-												<div className="font-mono">{n}</div>
-												<div className="text-xs text-slate-500">
-													{t("detail.overview.currentServers.configuredLabel", {
-														defaultValue: "configured",
-													})}
-												</div>
-											</CapsuleStripeListItem>
-										))}
-									</CapsuleStripeList>
-								) : (
-									<div className="text-sm text-slate-500">
-										{t("detail.overview.currentServers.empty", {
-											defaultValue: "No servers extracted from current config.",
-										})}
-									</div>
-								)}
-							</CardContent>
-						</Card>
-						{showClientLiveLogs ? (
-							<AuditLogsPanel
-								title={t("detail.logs.title", { defaultValue: "Logs" })}
-								description={t("detail.logs.description", {
-									defaultValue: "Runtime warnings and backend notes for this client.",
-								})}
-								searchPlaceholder={t("detail.logs.searchPlaceholder", {
-									defaultValue: "Search logs...",
-								})}
-								refreshLabel={t("detail.logs.refresh", { defaultValue: "Refresh Logs" })}
-								loadingLabel={t("detail.logs.loading", {
-									defaultValue: "Loading logs...",
-								})}
-								emptyLabel={t("detail.logs.empty", {
-									defaultValue: "No log entries recorded for this client yet.",
-								})}
-								headers={{
-									timestamp: t("detail.logs.headers.timestamp", {
-										defaultValue: "Timestamp",
-									}),
-									action: t("detail.logs.headers.action", { defaultValue: "Action" }),
-									category: t("detail.logs.headers.category", {
-										defaultValue: "Category",
-									}),
-									status: t("detail.logs.headers.status", { defaultValue: "Status" }),
-									target: t("detail.logs.headers.target", { defaultValue: "Target" }),
-								}}
-								searchValue={logFilter}
-								onSearchChange={setLogFilter}
-								onRefresh={() => void logsQuery.refetch()}
-								rows={filteredLogs}
-								isLoading={logsQuery.isLoading}
-								isFetching={logsQuery.isFetching}
-								isPaginationActionLoading={isLogPaginationActionLoading}
-								currentPage={logCurrentPageIndex + 1}
-								hasPreviousPage={logCurrentPageIndex > 0}
-								hasNextPage={Boolean(logsQuery.data?.next_cursor)}
-								itemsPerPage={logPageSize}
-								onItemsPerPageChange={setLogPageSize}
-								onPreviousPage={handleLogsPrevPage}
-								onFirstPage={handleLogsFirstPage}
-								onNextPage={handleLogsNextPage}
-								onLastPage={() => void handleLogsLastPage()}
-								expandLabel={t("detail.logs.expand", { defaultValue: "Expand Logs" })}
-								collapseLabel={t("detail.logs.collapse", { defaultValue: "Collapse Logs" })}
-							/>
-						) : null}
-					</div>
-				</TabsContent>
-
-				<TabsContent
-					value="configuration"
-					className={DETAIL_TAB_CONTENT_CLASS}
-				>
-					<div className="min-h-0 flex-1 overflow-y-auto">
-						<div className="grid gap-4">
-							<Card>
-								<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-									<div>
-										<CardTitle>
-											{t("detail.configuration.title", {
-												defaultValue: "Configuration Mode",
-											})}
-										</CardTitle>
-										<CardDescription>
-											{t("detail.configuration.description", {
-												defaultValue:
-													"If you don't understand what this means, please don't make any changes and keep the current settings.",
-											})}
-										</CardDescription>
-									</div>
-									<Button
-										size="sm"
-										variant="default"
-										onClick={() => applyMutation.mutate({ preview: false })}
-										disabled={
-											loadingConfig ||
-											applyMutation.isPending ||
-											!canSaveManagementSettings ||
-											(shouldRequireLocalConfigWrite && !canApplyTransparentConfig)
-										}
-										className="gap-2"
-									>
-										<HardDrive
-											className={`h-4 w-4 ${applyMutation.isPending ? "animate-pulse" : ""}`}
-										/>
-										{t(
-											isAttachmentApplicable && isAttachedClient
-												? "detail.configuration.reapply"
-												: "detail.configuration.apply",
-											{
-												defaultValue: isAttachmentApplicable && isAttachedClient ? "Re-Apply" : "Apply",
-											},
-										)}
-									</Button>
-								</CardHeader>
-								<CardContent className="pt-0">
-									<div className="grid grid-cols-10 gap-8">
-										{/* Left side - Mode and Source (4/10) */}
-										<div className="col-span-4 space-y-6">
-											{/* Mode Selection */}
-											<div className="space-y-3">
-												<div className="space-y-1">
-													<h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
-														{t("detail.configuration.sections.mode.title", {
-															defaultValue: "1. Management Mode",
-														})}
-													</h4>
-													<p className="text-xs text-slate-500 leading-relaxed">
-														{mode === "hosted" &&
-															t(
-																"detail.configuration.sections.mode.descriptions.hosted",
-																{
-																	defaultValue:
-																		"Hosted keeps a durable managed configuration for this client and remembers the selected working state.",
-																},
-															)}
-														{mode === "unify" &&
-															t(
-																"detail.configuration.sections.mode.descriptions.unify",
-																{
-																	defaultValue:
-																		"Unify starts with builtin control-plane tools only and keeps its workspace inside the current MCP session.",
-																},
-															)}
-														{mode === "transparent" &&
-															t(
-																"detail.configuration.sections.mode.descriptions.transparent",
-																{
-																	defaultValue:
-																		"MCPMate writes the selected profile servers directly into this client's MCP configuration and does not preserve capability-level controls.",
-																},
-															)}
-													</p>
-												</div>
-												<Segment
-													value={mode}
-													onValueChange={(v) => setMode(v as ClientConfigMode)}
-													options={managementModeSegmentOptions}
-													showDots={true}
-													className="w-full"
-												/>
-											</div>
-
-											{/* Source Selection */}
-											<div className="space-y-3">
-												<div className="space-y-1">
-													<h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
-														{t("detail.configuration.sections.source.title", {
-															defaultValue: "2. Configuration",
-														})}
-													</h4>
-													<p className="text-xs text-slate-500 leading-relaxed">
-														{mode === "unify" && unifyRouteMode === "broker_only" &&
-															t(
-																"detail.configuration.sections.source.descriptions.unify_broker_only",
-																{
-																	defaultValue:
-																		"All capabilities are kept behind the UCAN broker catalog. Builtin MCP tools will browse and call capabilities from globally enabled servers.",
-																},
-															)}
-														{mode === "unify" && unifyRouteMode === "server_level" &&
-															t(
-																"detail.configuration.sections.source.descriptions.unify_server_level",
-																{
-																	defaultValue:
-																		"Directly expose all capabilities from selected eligible servers to this client. Exposed capabilities are excluded from the UCAN catalog.",
-																},
-															)}
-														{mode === "unify" && unifyRouteMode === "capability_level" &&
-															t(
-																"detail.configuration.sections.source.descriptions.unify_capability_level",
-																{
-																	defaultValue:
-																		"Directly expose only selected capabilities (tools, prompts, resources, templates) from eligible servers to this client. (Advanced)",
-																},
-															)}
-														{mode === "transparent" && selectedConfig === "default" &&
-															t(
-																"detail.configuration.sections.source.descriptions.transparentDefault",
-																{
-																	defaultValue:
-																		"Write the servers from all currently activated profiles directly into this client's MCP configuration.",
-																},
-															)}
-														{mode === "transparent" && selectedConfig === "profile" &&
-															t(
-																"detail.configuration.sections.source.descriptions.transparentProfile",
-																{
-																	defaultValue:
-																		"Write the servers from the selected shared profiles directly into this client's MCP configuration.",
-																},
-															)}
-														{mode === "transparent" && selectedConfig === "custom" &&
-															t(
-																"detail.configuration.sections.source.descriptions.transparentCustom",
-																{
-																	defaultValue:
-																		"Write the servers from the client-specific custom profile directly into this client's MCP configuration.",
-																},
-															)}
-														{mode === "hosted" && selectedConfig === "default" &&
-															t(
-																"detail.configuration.sections.source.descriptions.default",
-																{
-																	defaultValue:
-																		"Review the profiles that are currently active for this client runtime.",
-																},
-															)}
-														{mode === "hosted" && selectedConfig === "profile" &&
-															t(
-																"detail.configuration.sections.source.descriptions.profile",
-																{
-																	defaultValue:
-																		"Browse the shared scene library and choose the exact working set for this client.",
-																},
-															)}
-														{mode === "hosted" && selectedConfig === "custom" &&
-															t(
-																"detail.configuration.sections.source.descriptions.custom",
-																{
-																	defaultValue:
-																		"Create client-specific adjustments on top of the current unify-mode working state.",
-																},
-															)}
-													</p>
-												</div>
-												{mode === "unify" ? (
-													<Segment
-														value={unifyRouteMode}
-														onValueChange={(v) => {
-															setHasUnifyDraftChanges(true);
-															setUnifyRouteMode(v as UnifyRouteMode);
-														}}
-														options={unifyRouteModeSegmentOptions}
-														showDots={true}
-														className="w-full"
-													/>
-												) : (
-													<Segment
-														value={selectedConfig}
-														onValueChange={(v) =>
-															setSelectedConfig(v as ClientCapabilitySourceSelection)
-														}
-														options={configurationSourceSegmentOptions}
-														showDots={true}
-														className="w-full"
-													/>
-												)}
-											</div>
-										</div>
-
-										{/* Right side - Profiles List (6/10) */}
-										{(mode === "unify" || mode === "hosted" || mode === "transparent") && (
-											<div className="col-span-6">
-												<div className="mb-3">
-													<h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
-														{mode === "unify" ? t("detail.configuration.sections.exposure.title", {
-															defaultValue: "3. Direct Exposure",
-														}) : t("detail.configuration.sections.profiles.title", {
-															defaultValue: "3. Profiles",
-														})}
-													</h4>
-													{mode === "unify" && unifyRouteMode === "broker_only" && (
-														<p className="text-xs text-slate-500 mt-1 leading-relaxed">
-															{t("detail.configuration.sections.exposure.descriptions.broker_only", {
-																defaultValue:
-																	"All enabled MCP servers, including servers marked for direct exposure, remain reachable through the builtin UCAN tools in Broker Only mode.",
-															})}
-														</p>
-													)}
-													{mode === "unify" && unifyRouteMode === "server_level" && (
-														<p className="text-xs text-slate-500 mt-1 leading-relaxed">
-															{t("detail.configuration.sections.exposure.descriptions.server_level", {
-																defaultValue:
-																	"Select the eligible servers whose tools, prompts, resources, and resource templates should be exposed directly to the client.",
-															})}
-														</p>
-													)}
-													{mode === "unify" && unifyRouteMode === "capability_level" && (
-														<p className="text-xs text-slate-500 mt-1 leading-relaxed">
-															{t("detail.configuration.sections.exposure.descriptions.capability_level", {
-																defaultValue:
-																	"Toggle each eligible server on the left, then use the more button to configure direct exposure at capability level across tools, prompts, resources, and templates. (Advanced)",
-															})}
-														</p>
-													)}
-													{/* Dynamic description based on source */}
-													{mode !== "unify" && selectedConfig === "default" && (
-														<p className="text-xs text-slate-500 mt-1 leading-relaxed">
-															{mode === "transparent"
-																? t(
-																	"detail.configuration.sections.profiles.descriptions.transparentDefault",
-																	{
-																		defaultValue:
-																			"Transparent mode will write the enabled servers from all currently activated profiles directly into this client's MCP configuration.",
-																	},
-																)
-																: t(
-																	"detail.configuration.sections.profiles.descriptions.default",
-																	{
-																		defaultValue:
-																			"Review the profiles that are already active for this client runtime. This view is read-only to keep the active scene set consistent.",
-																	},
-																)}
-														</p>
-													)}
-													{mode !== "unify" && selectedConfig === "profile" && (
-														<p className="text-xs text-slate-500 mt-1 leading-relaxed">
-															{mode === "transparent"
-																? t(
-																	"detail.configuration.sections.profiles.descriptions.transparentProfile",
-																	{
-																		defaultValue:
-																			"Select which shared profiles contribute enabled servers to this client's MCP configuration in transparent mode.",
-																	},
-																)
-																: t(
-																	"detail.configuration.sections.profiles.descriptions.profile",
-																	{
-																		defaultValue:
-																			"Choose the reusable shared profiles that define this client's working set.",
-																	},
-																)}
-														</p>
-													)}
-													{mode !== "unify" && selectedConfig === "custom" && (
-														<p className="text-xs text-slate-500 mt-1 leading-relaxed">
-															{mode === "transparent"
-																? t(
-																	"detail.configuration.sections.profiles.descriptions.transparentCustom",
-																	{
-																		defaultValue:
-																			"Transparent mode uses only the enabled servers from this client-specific custom profile when writing the MCP configuration.",
-																	},
-																)
-																: t(
-																	"detail.configuration.sections.profiles.descriptions.custom",
-																	{
-																		defaultValue:
-																			"Create and maintain client-specific overrides for the current working state.",
-																	},
-																)}
-														</p>
-													)}
-												</div>
-
-												{loadingProfiles ? (
-													<div className="space-y-2">
-														{[1, 2, 3].map((i) => (
-															<div
-																key={i}
-																className="h-12 bg-slate-200 dark:bg-slate-800 animate-pulse rounded"
-															/>
-														))}
-													</div>
-												) : (
-													<CapsuleStripeList>
-														{mode === "unify" ? (
-															unifyRouteMode === "broker_only" ? (
-																<CapsuleStripeListItem className="items-start">
-																	<div className="w-full text-xs leading-relaxed text-slate-500 dark:text-slate-400">
-																		{t("detail.configuration.sections.exposure.labels.ucanRoutingDescription", {
-																			defaultValue:
-																				"In Broker Only mode, all enabled MCP servers — including servers marked for direct exposure — are still accessed through the UCAN catalog and call tools.",
-																		})}
-																	</div>
-																</CapsuleStripeListItem>
-															) : eligibleServers.length > 0 ? (
-																eligibleServers.map((server) => {
-																	const isSelected = unifySelectedServers.includes(server.id);
-																	const toolSurfaces = getUnifyServerSurfaces(
-																		effectiveCapabilityConfig?.unify_direct_exposure
-																			?.resolved_capabilities?.selected_tool_surfaces ?? [],
-																		server.id,
-																	);
-																	const promptSurfaces = getUnifyServerSurfaces(
-																		effectiveCapabilityConfig?.unify_direct_exposure
-																			?.resolved_capabilities?.selected_prompt_surfaces ?? [],
-																		server.id,
-																	);
-																	const resourceSurfaces = getUnifyServerSurfaces(
-																		effectiveCapabilityConfig?.unify_direct_exposure
-																			?.resolved_capabilities?.selected_resource_surfaces ?? [],
-																		server.id,
-																	);
-																	const templateSurfaces = getUnifyServerSurfaces(
-																		effectiveCapabilityConfig?.unify_direct_exposure
-																			?.resolved_capabilities?.selected_template_surfaces ?? [],
-																		server.id,
-																	);
-																	const selectedCapabilityCount =
-																		toolSurfaces.length +
-																		promptSurfaces.length +
-																		resourceSurfaces.length +
-																		templateSurfaces.length;
-																	const directPath = getClientDirectCapabilitiesPath(identifier, server.id);
-																	const isMixed = isUnifyServerMixedRouting(
-																		unifyRouteMode,
-																		toolSurfaces.length,
-																		server.capabilities?.tools_count,
-																	);
-																	const showDirectSelection =
-																		unifyRouteMode === "capability_level"
-																			? selectedCapabilityCount > 0
-																			: isSelected;
-																	const serverDescription =
-																		server.meta?.description ||
-																		t("detail.configuration.labels.noDescription", {
-																			defaultValue: "No description",
-																		});
-
-																	return (
-																		<CapsuleStripeListItem
-																			key={server.id}
-																			interactive={true}
-																			className={`group relative transition-colors ${showDirectSelection ? "bg-primary/10 ring-1 ring-primary/40" : ""}`}
-																			onClick={() => {
-																				if (unifyRouteMode === "capability_level") {
-																					directExposureServerMutation.mutate({ server, routeMode: "capability_level" });
-																				} else if (unifyRouteMode === "server_level") {
-																					if (hasUnifyDraftChanges) {
-																						setUnifySelectedServers((prev) =>
-																							toggleSelectedServerIds(prev, server.id),
-																						);
-																					} else {
-																						directExposureServerMutation.mutate({ server, routeMode: "server_level" });
-																					}
-																				}
-																			}}
-																		>
-																			<CapsuleStripeRowBody
-																				lead={
-																					<CapsuleStripeLeadCircle
-																						variant="toggle"
-																						selected={showDirectSelection}
-																					/>
-																				}
-																				trailing={
-																					unifyRouteMode === "capability_level" ? (
-																						<Button
-																							variant="ghost"
-																							size="icon"
-																							className="h-8 w-8 text-slate-400 hover:text-slate-900 dark:hover:text-slate-100"
-																							onClick={(e) => {
-																								e.stopPropagation();
-																								if (directPath) {
-																									navigate(directPath);
-																								}
-																							}}
-																						>
-																							<MoreVertical className="h-4 w-4" />
-																						</Button>
-																					) : undefined
-																				}
-																			>
-																				<div className="font-medium text-sm truncate">
-																					{server.name}
-																					{unifyRouteMode === "capability_level" && selectedCapabilityCount > 0 && (
-																						<span className="ml-2 text-xs font-normal text-slate-500 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded-md">
-																							{selectedCapabilityCount}{" "}
-																							{t("detail.configuration.labels.capabilitiesExposed", {
-																								defaultValue: "capabilities exposed",
-																							})}
-																						</span>
-																					)}
-																				</div>
-																				<div className="text-xs text-slate-500 truncate">{serverDescription}</div>
-																				{renderUnifyEligibleServerCapabilitySummary(
-																					server,
-																					unifyRouteMode,
-																					toolSurfaces.length,
-																				)}
-																				{isMixed && (
-																					<div className="mt-1 flex items-center gap-1 text-[11px] font-medium text-amber-600 dark:text-amber-500">
-																						<Info className="h-3 w-3" />
-																						{t("detail.configuration.warnings.mixedRouting", {
-																							defaultValue:
-																								"Mixed routing: splitting stateful workflows may cause issues.",
-																						})}
-																					</div>
-																				)}
-																			</CapsuleStripeRowBody>
-																		</CapsuleStripeListItem>
-																	);
-																})
-															) : (
-
-																<CapsuleStripeListItem>
-																	<div className="text-sm text-slate-500 py-4 text-center w-full">
-																		{t("detail.configuration.sections.exposure.empty.no_eligible", {
-																			defaultValue: "No eligible servers found. Enable Unify Direct Exposure on a server first.",
-																		})}
-																	</div>
-																</CapsuleStripeListItem>
-															)
-														) : selectedConfig === "default" ? (
-															// Show active profiles for default source
-															activeProfiles.length > 0 ? (
-																activeProfiles.map((profile) => {
-																	const capabilities = profileCapabilities.get(
-																		profile.id,
-																	);
-																	return (
-																		<CapsuleStripeListItem
-																			key={profile.id}
-																			className="cursor-default"
-																		>
-																			<CapsuleStripeRowBody
-																				lead={<CapsuleStripeLeadCircle variant="readOnlyActive" />}
-																				trailing={getConfigurationProfileTokenSlot(profile, false)}
-																			>
-																				<div className="font-medium text-sm truncate">{profile.name}</div>
-																				<div className="text-xs text-slate-500 truncate">
-																					{profile.description ||
-																						t("detail.configuration.labels.noDescription", {
-																							defaultValue: "No description",
-																						})}
-																				</div>
-																				{capabilities && renderProfileCapabilitySummary(capabilities)}
-																			</CapsuleStripeRowBody>
-																		</CapsuleStripeListItem>
-																	);
-																})
-															) : (
-																<CapsuleStripeListItem>
-																	<div className="text-sm text-slate-500 py-4 text-center w-full">
-																		{t(
-																			"detail.configuration.sections.profiles.empty.active",
-																			{
-																				defaultValue: "No active profiles found",
-																			},
-																		)}
-																	</div>
-																</CapsuleStripeListItem>
-															)
-														) : selectedConfig === "profile" ? (
-															// Show shared profiles for profile source
-															sharedProfiles.length > 0 ? (
-																sharedProfiles.map((profile) => {
-																	const capabilities = profileCapabilities.get(
-																		profile.id,
-																	);
-																	const isSelected = selectedProfiles.includes(
-																		profile.id,
-																	);
-																	return (
-																		<CapsuleStripeListItem
-																			key={profile.id}
-																			interactive={unifyRouteMode !== "broker_only"}
-																			className={`group relative transition-colors ${isSelected
-																				? "bg-primary/10 ring-1 ring-primary/40"
-																				: ""
-																				}`}
-																			onClick={() => {
-																				setSelectedProfiles((prev) =>
-																					prev.includes(profile.id)
-																						? prev.filter(
-																							(id) => id !== profile.id,
-																						)
-																						: [...prev, profile.id],
-																				);
-																			}}
-																		>
-																			<CapsuleStripeRowBody
-																				lead={
-																					<CapsuleStripeLeadCircle variant="toggle" selected={isSelected} />
-																				}
-																				trailing={getConfigurationProfileTokenSlot(profile, true)}
-																			>
-																				<div className="font-medium text-sm truncate">{profile.name}</div>
-																				<div className="text-xs text-slate-500 truncate">
-																					{profile.description ||
-																						t("detail.configuration.labels.noDescription", {
-																							defaultValue: "No description",
-																						})}
-																				</div>
-																				{capabilities && renderProfileCapabilitySummary(capabilities)}
-																			</CapsuleStripeRowBody>
-																		</CapsuleStripeListItem>
-																	);
-																})
-															) : (
-																<CapsuleStripeListItem>
-																	<div className="text-sm text-slate-500 py-4 text-center w-full">
-																		{t(
-																			"detail.configuration.sections.profiles.empty.shared",
-																			{
-																				defaultValue: "No shared profiles found",
-																			},
-																		)}
-																	</div>
-																</CapsuleStripeListItem>
-															)
-														) : null}
-
-														{mode !== "unify" && (
-															<CapsuleStripeListItem
-																interactive
-																className={
-																	selectedConfig === "custom" && customProfileId
-																		? "border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500"
-																		: "border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500"
-																}
-																onClick={() => {
-																	if (selectedConfig === "custom") {
-																		if (customProfileId) {
-																			navigate(`/profiles/${customProfileId}?mode=custom`);
-																		} else {
-																			applyMutation.mutate({ preview: false });
-																		}
-																	} else {
-																		navigate("/profiles");
-																	}
-																}}
-															>
-																<CapsuleStripeRowBody
-																	lead={
-																		<CapsuleStripeLeadCircle
-																			variant="ghost"
-																			hasProfile={selectedConfig === "custom" && !!customProfileId}
-																		/>
-																	}
-																>
-																	<div className="font-medium text-sm truncate text-slate-700 dark:text-slate-300">
-																		{selectedConfig === "custom"
-																			? t("detail.configuration.sections.profiles.ghost.titleCustom", {
-																				defaultValue: customProfileId
-																					? "Customize current state"
-																					: "Create custom workspace",
-																			})
-																			: t("detail.configuration.sections.profiles.ghost.titleDefault", {
-																				defaultValue: "Open profiles library",
-																			})}
-																	</div>
-																	<div className="text-xs text-slate-400 dark:text-slate-600 truncate">
-																		{selectedConfig === "custom"
-																			? t(
-																				mode === "transparent"
-																					? "detail.configuration.sections.profiles.ghost.subtitleCustomTransparent"
-																					: "detail.configuration.sections.profiles.ghost.subtitleCustom",
-																				{
-																					defaultValue: customProfileId
-																						? "Adjust client-specific capabilities on top of the current workspace"
-																						: "Create client-specific overrides for this workspace",
-																				},
-																			)
-																			: t("detail.configuration.sections.profiles.ghost.subtitleDefault", {
-																				defaultValue:
-																					"Browse reusable shared scenes and edit them from the profiles page",
-																			})}
-																	</div>
-																	{customProfileCapabilities
-																		? renderProfileCapabilitySummary(customProfileCapabilities)
-																		: null}
-																</CapsuleStripeRowBody>
-															</CapsuleStripeListItem>
-														)}
-													</CapsuleStripeList>
-												)}
-											</div>
-										)}
-									</div>
-								</CardContent>
-							</Card>
-						</div>
-					</div>
-				</TabsContent>
-
-				<TabsContent
-					value="backups"
-					className="mt-0 flex min-h-0 flex-1 flex-col overflow-y-auto data-[state=inactive]:hidden"
-				>
-					<Card>
-						<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-							<div>
-								<CardTitle>
-									{t("detail.backups.title", { defaultValue: "Backups" })}
-								</CardTitle>
-								<CardDescription>
-									{t("detail.backups.description", {
-										defaultValue: "Restore or delete configuration snapshots.",
-									})}
-								</CardDescription>
-							</div>
-							<div className="flex flex-wrap items-center gap-2">
-								<Button
-									size="sm"
-									variant="outline"
-									onClick={() => refetchBackups()}
-									disabled={loadingBackups}
-								>
-									<RefreshCw
-										className={`mr-2 h-4 w-4 ${loadingBackups ? "animate-spin" : ""}`}
-									/>
-									{t("detail.backups.buttons.refresh", {
-										defaultValue: "Refresh",
-									})}
-								</Button>
-								{!loadingBackups && visibleBackups.length > 0 && (
-									<ButtonGroup>
-										<Button
-											variant="outline"
-											size="sm"
-											onClick={() =>
-												setSelectedBackups(visibleBackups.map((b) => b.backup))
-											}
-										>
-											{t("detail.backups.buttons.selectAll", {
-												defaultValue: "Select all",
-											})}
-										</Button>
-										<Button
-											variant="outline"
-											size="sm"
-											onClick={() => setSelectedBackups([])}
-										>
-											{t("detail.backups.buttons.clear", {
-												defaultValue: "Clear",
-											})}
-										</Button>
-										<Button
-											size="sm"
-											variant="destructive"
-											disabled={
-												bulkDeleteMutation.isPending ||
-												selectedBackups.length === 0
-											}
-											onClick={() => setBulkConfirmOpen(true)}
-										>
-											<Trash2 className="mr-2 h-4 w-4" />
-											{t("detail.backups.buttons.deleteSelected", {
-												defaultValue: "Delete selected ({{count}})",
-												count: selectedBackups.length,
-											})}
-										</Button>
-									</ButtonGroup>
-								)}
-							</div>
-						</CardHeader>
-						<CardContent className="space-y-4 pt-0">
-							{loadingBackups ? (
-								<div className="space-y-2">
-									{[1, 2, 3].map((i) => (
-										<div
-											key={i}
-											className="h-10 bg-slate-200 dark:bg-slate-800 animate-pulse rounded"
-										/>
-									))}
-								</div>
-							) : visibleBackups.length ? (
-								<CapsuleStripeList>
-									{visibleBackups.map((b) => {
-										const selected = selectedBackups.includes(b.backup);
-										return (
-											<CapsuleStripeListItem
-												key={b.path}
-												interactive
-												className={`group relative transition-colors ${selected ? "bg-primary/10 ring-1 ring-primary/40" : ""}`}
-												onClick={() =>
-													setSelectedBackups((prev) =>
-														prev.includes(b.backup)
-															? prev.filter((x) => x !== b.backup)
-															: [...prev, b.backup],
-													)
-												}
-											>
-												<div className="flex items-center justify-between flex-1">
-													<div className="flex items-center gap-3">
-														<div
-															className={`flex h-6 w-6 items-center justify-center rounded-full border text-[0px] transition-all duration-200 ${selected
-																? "border-primary bg-primary text-white shadow-sm"
-																: "border-slate-300 text-transparent group-hover:border-primary/50 group-hover:text-primary/60 dark:border-slate-700 dark:group-hover:border-primary/50"
-																}`}
-														>
-															<Check className="h-3 w-3" />
-														</div>
-														<div
-															className={`font-mono transition-colors duration-200 ${selected
-																? "text-primary"
-																: "text-slate-700 dark:text-slate-200"
-																}`}
-														>
-															{b.backup}
-														</div>
-													</div>
-													<div className="flex items-center justify-end gap-4">
-														<div
-															className={`flex items-center gap-4 text-slate-500 transition-all duration-200 ${selected ? "text-primary" : ""
-																}`}
-														>
-															<div>{formatBackupTime(b.created_at)}</div>
-															<div>{(b.size / 1024).toFixed(1)} KB</div>
-														</div>
-														<div className="flex items-center gap-2 overflow-hidden transition-all duration-200 opacity-0 max-w-0 pointer-events-none group-hover:max-w-[12rem] group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:max-w-[12rem] group-focus-within:opacity-100 group-focus-within:pointer-events-auto">
-															<Button
-																size="sm"
-																variant="outline"
-																onClick={(e) => {
-																	e.stopPropagation();
-																	setConfirm({
-																		kind: "restore",
-																		backup: b.backup,
-																	});
-																}}
-															>
-																<RotateCcw className="mr-2 h-4 w-4" />
-																{t("detail.backups.buttons.restore", {
-																	defaultValue: "Restore",
-																})}
-															</Button>
-															<Button
-																size="icon"
-																variant="outline"
-																onClick={(e) => {
-																	e.stopPropagation();
-																	setConfirm({
-																		kind: "delete",
-																		backup: b.backup,
-																	});
-																}}
-															>
-																<Trash2 className="h-4 w-4" />
-															</Button>
-														</div>
-													</div>
-												</div>
-											</CapsuleStripeListItem>
-										);
-									})}
-								</CapsuleStripeList>
-							) : (
-								<div className="text-slate-500 text-sm">
-									{backupsDisabledByPolicy
-										? t("detail.backups.emptyDisabledByPolicy", {
-											defaultValue: "Backups are currently disabled by system policy.",
-										})
-										: t("detail.backups.empty", {
-											defaultValue: "No backups.",
-										})}
-								</div>
-							)}
-						</CardContent>
-					</Card>
-				</TabsContent>
-
-			</Tabs>
-
-			<ConfirmDialog
-				isOpen={!!confirm}
-				onClose={() => setConfirm(null)}
-				title={
-					confirm?.kind === "delete"
-						? t("detail.confirm.deleteTitle", { defaultValue: "Delete Backup" })
-						: t("detail.confirm.restoreTitle", {
-							defaultValue: "Restore Backup",
-						})
-				}
-				description={
-					confirm?.kind === "delete"
-						? t("detail.confirm.deleteDescription", {
-							defaultValue:
-								"Are you sure you want to delete this backup? This action cannot be undone.",
-						})
-						: t("detail.confirm.restoreDescription", {
-							defaultValue:
-								"Restore the local client configuration file from the selected backup? MCPMate management mode and capability settings stay unchanged.",
-						})
-				}
-				confirmLabel={
-					confirm?.kind === "delete"
-						? t("detail.confirm.deleteLabel", { defaultValue: "Delete" })
-						: t("detail.confirm.restoreLabel", { defaultValue: "Restore" })
-				}
-				cancelLabel={t("detail.confirm.cancelLabel", {
-					defaultValue: "Cancel",
-				})}
-				variant={confirm?.kind === "delete" ? "destructive" : "default"}
-				isLoading={deleteBackupMutation.isPending || restoreMutation.isPending}
-				onConfirm={async () => {
-					if (!confirm) return;
-					if (confirm.kind === "delete") {
-						await deleteBackupMutation.mutateAsync({ backup: confirm.backup });
-					} else {
-						await restoreMutation.mutateAsync({ backup: confirm.backup });
-					}
-					setConfirm(null);
-				}}
-			/>
-
-			<ConfirmDialog
-				isOpen={attachmentActionConfirm !== null}
-				onClose={() => setAttachmentActionConfirm(null)}
-				title={
-					attachmentActionConfirm === "attach"
-						? t("detail.confirm.attachTitle", {
-							defaultValue: "Attach MCPMate to this client configuration?",
-						})
-						: t("detail.confirm.detachTitle", {
-							defaultValue: "Detach MCPMate from this client configuration?",
-						})
-				}
-				description={
-					attachmentActionConfirm === "attach"
-						? t("detail.confirm.attachDescription", {
-							defaultValue:
-								"This writes the MCPMate server entry back into the client configuration file. The client's MCP session may restart or reconnect; confirm before continuing.",
-						})
-						: t("detail.confirm.detachDescription", {
-							defaultValue:
-								"This removes the MCPMate server entry from the client configuration file. Running MCP connections for that client may break until you attach again; confirm before continuing.",
-						})
-				}
-				confirmLabel={
-					attachmentActionConfirm === "attach"
-						? t("detail.confirm.attachLabel", { defaultValue: "Attach" })
-						: t("detail.confirm.detachLabel", { defaultValue: "Detach" })
-				}
-				cancelLabel={t("detail.confirm.cancelLabel", {
-					defaultValue: "Cancel",
-				})}
-				variant="default"
-				isLoading={detachMutation.isPending || attachMutation.isPending}
-				onConfirm={async () => {
-					if (!attachmentActionConfirm || !identifier) return;
-					if (attachmentActionConfirm === "detach") {
-						await detachMutation.mutateAsync();
-					} else {
-						await attachMutation.mutateAsync();
-					}
-					setAttachmentActionConfirm(null);
-				}}
-			/>
-
-			{/* Bulk delete confirmation */}
-			<ConfirmDialog
-				isOpen={bulkConfirmOpen}
-				onClose={() => setBulkConfirmOpen(false)}
-				title={t("detail.backups.bulk.title", {
-					defaultValue: "Delete Selected Backups",
-				})}
-				description={t("detail.backups.bulk.description", {
-					defaultValue:
-						"Are you sure you want to delete {{count}} backup(s)? This action cannot be undone.",
-					count: selectedBackups.length,
-				})}
-				confirmLabel={t("detail.confirm.deleteLabel", {
-					defaultValue: "Delete",
-				})}
-				cancelLabel={t("detail.confirm.cancelLabel", {
-					defaultValue: "Cancel",
-				})}
-				variant="destructive"
-				isLoading={bulkDeleteMutation.isPending}
-				onConfirm={() => bulkDeleteMutation.mutate()}
-			/>
-
-
-
-			{/* Backup Policy Drawer */}
-			<Drawer open={policyOpen} onOpenChange={setPolicyOpen}>
-				<DrawerContent>
-					<DrawerHeader>
-						<DrawerTitle>
-							{t("detail.policy.title", { defaultValue: "Backup Policy" })}
-						</DrawerTitle>
-					</DrawerHeader>
-					<div className="p-4 space-y-4">
-						<div className="space-y-1">
-							<Label>
-								{t("detail.policy.fields.policy", { defaultValue: "Policy" })}
-							</Label>
-							<p className="text-xs text-slate-500">
-								{t("detail.policy.fields.policyDescription", {
-									defaultValue:
-										'Backup retention strategy. For now, only "keep_n" is supported, which keeps at most N recent backups and prunes older ones.',
-								})}
-							</p>
-							<Select value={policyLabel} onValueChange={setPolicyLabel}>
-								<SelectTrigger>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="keep_n">
-										{t("detail.policy.fields.options.keepN", {
-											defaultValue: "keep_n",
-										})}
-									</SelectItem>
-								</SelectContent>
-							</Select>
-						</div>
-						<div className="space-y-1">
-							<Label htmlFor={limitId}>
-								{t("detail.policy.fields.limit", { defaultValue: "Limit" })}
-							</Label>
-							<p className="text-xs text-slate-500">
-								{t("detail.policy.fields.limitDescription", {
-									defaultValue:
-										"Maximum number of backups to keep for this client. Set to 0 for no limit.",
-								})}
-							</p>
-							<Input
-								id={limitId}
-								type="number"
-								min={0}
-								value={policyLimit ?? 0}
-								onChange={(e) => setPolicyLimit(Number(e.target.value))}
-							/>
-						</div>
-						<div>
-							<Button
-								onClick={() => {
-									if (!identifier) return;
-									setPolicyMutation.mutate({
-										identifier,
-										policy: { policy: policyLabel, limit: policyLimit },
-									});
-								}}
-								disabled={setPolicyMutation.isPending}
-							>
-								{t("detail.policy.buttons.save", {
-									defaultValue: "Save Policy",
-								})}
-							</Button>
-						</div>
-					</div>
-					<DrawerFooter />
-				</DrawerContent>
-			</Drawer>
-
-			{/* Import Preview Drawer */}
-			<Drawer open={importPreviewOpen} onOpenChange={setImportPreviewOpen}>
-				<DrawerContent>
-					<DrawerHeader>
-						<DrawerTitle>
-							{t("detail.importPreview.title", {
-								defaultValue: "Import Preview",
-							})}
-						</DrawerTitle>
-						<DrawerDescription>
-							{t("detail.importPreview.description", {
-								defaultValue:
-									"Summary of servers detected from current client config.",
-							})}
-						</DrawerDescription>
-					</DrawerHeader>
-					<div className="p-4 text-sm flex flex-col gap-4 max-h-[70vh]">
-						{importPreviewMutation.isPending ? (
-							<div className="h-16 bg-slate-200 dark:bg-slate-800 animate-pulse rounded" />
-						) : importPreviewData ? (
-							<div className="flex-1 min-h-0 flex flex-col gap-4">
-								<div className="grid grid-cols-[120px_1fr] gap-y-2 gap-x-4 text-sm leading-6">
-									<div className="text-slate-500">
-										{t("detail.importPreview.fields.attempted", {
-											defaultValue: "Attempted",
-										})}
-									</div>
-									<div>
-										{typeof importPreviewData.summary?.attempted === "boolean"
-											? importPreviewData.summary.attempted
-												? t("states.yes", { defaultValue: "Yes" })
-												: t("states.no", { defaultValue: "No" })
-											: "-"}
-									</div>
-									<div className="text-slate-500">
-										{t("detail.importPreview.fields.imported", {
-											defaultValue: "Imported",
-										})}
-									</div>
-									<div>{importPreviewData.summary?.imported_count ?? 0}</div>
-									<div className="text-slate-500">
-										{t("detail.importPreview.fields.skipped", {
-											defaultValue: "Skipped",
-										})}
-									</div>
-									<div>{importPreviewData.summary?.skipped_count ?? 0}</div>
-									<div className="text-slate-500">
-										{t("detail.importPreview.fields.failed", {
-											defaultValue: "Failed",
-										})}
-									</div>
-									<div>{importPreviewData.summary?.failed_count ?? 0}</div>
-								</div>
-								{Array.isArray(importPreviewData.items) &&
-									importPreviewData.items.length > 0 ? (
-									<div className="rounded border">
-										<div className="px-3 py-2 text-xs text-slate-500 border-b">
-											{t("detail.importPreview.sections.servers", {
-												defaultValue: "Servers to import",
-											})}
-										</div>
-										<ul className="divide-y max-h-[30vh] overflow-auto">
-											{importPreviewData.items.map((it, idx: number) => (
-												<li
-													key={`import-item-${idx}-${it.name || it.server_name || "unnamed"}`}
-													className="p-3 text-xs"
-												>
-													<div className="font-medium">
-														{it.name || it.server_name || `#${idx + 1}`}
-													</div>
-													{it.error ? (
-														<div className="text-red-500">
-															{String(it.error)}
-														</div>
-													) : null}
-													<div className="mt-1 text-slate-500">
-														{t("detail.importPreview.sections.stats", {
-															defaultValue:
-																"tools: {{tools}} • resources: {{resources}} • templates: {{templates}} • prompts: {{prompts}}",
-															tools: it.tools?.items?.length ?? 0,
-															resources: it.resources?.items?.length ?? 0,
-															templates:
-																it.resource_templates?.items?.length ?? 0,
-															prompts: it.prompts?.items?.length ?? 0,
-														})}
-													</div>
-												</li>
-											))}
-										</ul>
-									</div>
-								) : null}
-								{importPreviewData.summary?.errors ? (
-									<details>
-										<summary className="text-xs text-slate-500 cursor-pointer">
-											{t("detail.importPreview.sections.errors", {
-												defaultValue: "Errors",
-											})}
-										</summary>
-										<pre className="text-xs bg-slate-50 dark:bg-slate-900 p-2 rounded overflow-auto max-h-[26vh]">
-											{JSON.stringify(
-												importPreviewData.summary.errors,
-												null,
-												2,
-											)}
-										</pre>
-									</details>
-								) : null}
-								{(importPreviewData.summary?.skipped_count ?? 0) > 0 &&
-								importPreviewData.summary?.skipped_servers?.length ? (
-									<details className="mt-2">
-										<summary className="text-xs text-slate-500 cursor-pointer">
-											{t("detail.importPreview.sections.skippedDetails", {
-												defaultValue:
-													"Skip details ({{count}} servers)",
-												count: importPreviewData.summary.skipped_count,
-											})}
-										</summary>
-										<ul className="mt-2 space-y-2">
-											{importPreviewData.summary.skipped_servers.map(
-												(s, idx) => (
-													<li
-														key={`skipped-${idx}-${s.name}`}
-														className="text-xs p-2 bg-slate-50 dark:bg-slate-900 rounded"
-													>
-														<span className="font-medium">{s.name}</span>
-														<span className="text-slate-500 ml-2">
-															&mdash; {s.reason}
-														</span>
-														{s.existing_query && (
-															<div className="mt-1 text-slate-400">
-																existing query: {s.existing_query}
-															</div>
-														)}
-														{s.incoming_query && (
-															<div className="mt-1 text-slate-400">
-																incoming query: {s.incoming_query}
-															</div>
-														)}
-													</li>
-												),
-											)}
-										</ul>
-									</details>
-								) : null}
-								<details className="mt-2 flex-1 min-h-0">
-									<summary className="text-xs text-slate-500 cursor-pointer">
-										{t("detail.importPreview.sections.raw", {
-											defaultValue: "Raw preview JSON",
-										})}
-									</summary>
-									<pre className="text-xs bg-slate-50 dark:bg-slate-900 p-2 rounded overflow-auto flex-1 min-h-0 max-h-[40vh]">
-										{JSON.stringify(importPreviewData, null, 2)}
-									</pre>
-								</details>
-							</div>
-						) : (
-							<div className="text-slate-500">
-								{t("detail.importPreview.noPreview", {
-									defaultValue: "No preview data.",
-								})}
-							</div>
-						)}
-					</div>
-					<DrawerFooter>
-						<div className="flex w-full items-center justify-between">
-							<Button
-								variant="outline"
-								onClick={() => setImportPreviewOpen(false)}
-							>
-								{t("detail.importPreview.buttons.close", {
-									defaultValue: "Close",
-								})}
-							</Button>
-							{importPreviewData ? (
-								(importPreviewData?.summary?.imported_count ?? 0) > 0 ? (
-									<Button
-										onClick={() => importMutation.mutate()}
-										disabled={importMutation.isPending}
-									>
-										{t("detail.importPreview.buttons.apply", {
-											defaultValue: "Apply Import",
-										})}
-									</Button>
-								) : (
-									<div className="text-xs text-slate-500">
-										{t("detail.importPreview.states.noImportNeeded", {
-											defaultValue: "No import needed",
-										})}
-									</div>
-								)
-							) : (
-								<Button
-									onClick={() => importPreviewMutation.mutate()}
-									disabled={importPreviewMutation.isPending}
-								>
-									{t("detail.importPreview.buttons.preview", {
-										defaultValue: "Preview",
-									})}
-								</Button>
-							)}
-						</div>
-					</DrawerFooter>
-				</DrawerContent>
-			</Drawer>
-			<ClientFormDrawer
-				open={isClientFormOpen}
-				onOpenChange={setIsClientFormOpen}
-				mode="edit"
-				client={(currentClient as ClientInfo | undefined) ?? null}
-				onSuccess={() => {
-					void refetchDetails();
-					qc.invalidateQueries({ queryKey: ["clients"] });
-				}}
-				onDeleteSuccess={() => {
-					navigate("/clients");
-				}}
-			/>
-
-
-
-		</div>
-	);
+  const { identifier } = useParams<{ identifier: string }>();
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+  usePageTranslations("clients");
+  const { t, i18n } = useTranslation("clients");
+  const showClientLiveLogs = useAppStore(
+    (state) => state.dashboardSettings.showClientLiveLogs,
+  );
+  const dashboardSettings = useAppStore((state) => state.dashboardSettings);
+  const clientDefaultMode = useAppStore(
+    (state) => state.dashboardSettings.clientDefaultMode,
+  );
+  const [displayName, setDisplayName] = useState("");
+  const [selectedBackups, setSelectedBackups] = useState<string[]>([]);
+  const [isClientFormOpen, setIsClientFormOpen] = useState(false);
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
+  const [attachmentActionConfirm, setAttachmentActionConfirm] = useState<
+    "detach" | "attach" | null
+  >(null);
+
+  const { data: clientsData } = useQuery({
+    queryKey: ["clients"],
+    queryFn: () => clientsApi.list(false),
+    retry: 1,
+  });
+
+  const currentClient = useMemo(
+    () =>
+      clientsData?.client?.find((client) => client.identifier === identifier),
+    [clientsData?.client, identifier],
+  );
+  const supportsBackupOperations =
+    Boolean(currentClient) &&
+    currentClient?.writable_config !== false &&
+    currentClient?.template?.managed_source !== "runtime_active_client";
+  const detailTabs = useMemo(
+    () =>
+      !supportsBackupOperations
+        ? ["overview", "configuration"]
+        : ["overview", "configuration", "backups"],
+    [supportsBackupOperations],
+  );
+  const { activeTab: tabValue, setActiveTab: setTabValue } = useUrlTab({
+    paramName: "tab",
+    defaultTab: "overview",
+    validTabs: detailTabs,
+  });
+  const [selectedProfiles, setSelectedProfiles] = useState<string[]>([]);
+
+  const limitId = useId();
+  const [mode, setMode] = useState<ClientConfigMode>("hosted");
+  const [transport, setTransport] = useState<string>("auto");
+  const [unifyRouteMode, setUnifyRouteMode] =
+    useState<UnifyRouteMode>("broker_only");
+  const [unifySelectedServers, setUnifySelectedServers] = useState<string[]>(
+    [],
+  );
+  const [unifyCapabilityIds, setUnifyCapabilityIds] =
+    useState<UnifyDirectCapabilityIds>({});
+  const [hasUnifyDraftChanges, setHasUnifyDraftChanges] = useState(false);
+
+  useEffect(() => {
+    if (!currentClient) {
+      return;
+    }
+    const isWritableConfig = currentClient.writable_config !== false;
+    setDisplayName(currentClient.display_name || "");
+    if (typeof currentClient.config_mode === "string") {
+      const configMode = currentClient.config_mode;
+      if (configMode === "unify") {
+        setMode("unify");
+      } else if (configMode === "transparent") {
+        setMode(
+          resolveConfigModeForWritableState("transparent", isWritableConfig),
+        );
+      } else {
+        setMode("hosted");
+      }
+    } else {
+      setMode(
+        resolveConfigModeForWritableState(clientDefaultMode, isWritableConfig),
+      );
+    }
+    setTransport(resolveSelectedTransport(currentClient.transports));
+  }, [clientDefaultMode, currentClient]);
+
+  useEffect(() => {
+    if (currentClient?.writable_config === false && tabValue === "backups") {
+      setTabValue("configuration");
+    }
+  }, [currentClient?.writable_config, setTabValue, tabValue]);
+
+  const [selectedConfig, setSelectedConfig] =
+    useState<ClientCapabilitySourceSelection>("default");
+  const [policyOpen, setPolicyOpen] = useState(false);
+  const [importPreviewOpen, setImportPreviewOpen] = useState(false);
+  const [importPreviewData, setImportPreviewData] =
+    useState<ClientConfigImportData | null>(null);
+
+  const {
+    data: configDetails,
+    isLoading: loadingConfig,
+    refetch: refetchDetails,
+  } = useQuery({
+    queryKey: ["client-config", identifier],
+    queryFn: () => clientsApi.configDetails(identifier || "", false),
+    enabled: !!identifier,
+  });
+
+  const { data: capabilityConfig } = useQuery({
+    queryKey: ["client-capability-config", identifier],
+    queryFn: () => clientsApi.getCapabilityConfig(identifier || ""),
+    enabled: !!identifier,
+  });
+
+  const {
+    data: backupsData,
+    isLoading: loadingBackups,
+    refetch: refetchBackups,
+  } = useQuery({
+    queryKey: ["client-backups", identifier],
+    queryFn: () => clientsApi.listBackups(identifier || undefined),
+    enabled: Boolean(identifier && supportsBackupOperations),
+  });
+
+  // Fetch eligible servers for Unify direct exposure
+  const { data: serversListData } = useQuery({
+    queryKey: ["servers", "unify-candidates"],
+    queryFn: () => serversApi.getAll(),
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
+    refetchOnReconnect: "always",
+    retry: 1,
+  });
+  const eligibleServers = useMemo(() => {
+    return (
+      serversListData?.servers?.filter(
+        (s) => s.unify_direct_exposure_eligible,
+      ) || []
+    );
+  }, [serversListData]);
+
+  const refreshClientCapabilityState = useCallback(async () => {
+    await Promise.allSettled([
+      qc.invalidateQueries({
+        queryKey: ["client-capability-config", identifier],
+      }),
+      qc.invalidateQueries({ queryKey: ["client-config", identifier] }),
+      qc.invalidateQueries({ queryKey: ["clients"] }),
+    ]);
+  }, [identifier, qc]);
+
+  const { data: profilesData, isLoading: loadingProfiles } = useQuery({
+    queryKey: ["profiles"],
+    queryFn: () => configSuitsApi.getAll(),
+    retry: 1,
+  });
+
+  const visibleBackups = useMemo(() => {
+    const backups: ClientBackupEntry[] = backupsData?.backups || [];
+    return backups.filter((backup) => backup.identifier === identifier);
+  }, [backupsData?.backups, identifier]);
+
+  // Process profiles data
+  const activeProfiles = useMemo(() => {
+    const profiles: ConfigSuit[] = profilesData?.suits || [];
+    return arrangeProfilesWithDefaultFirst(
+      profiles.filter((profile) => profile.is_active),
+    );
+  }, [profilesData?.suits]);
+  const sharedProfiles = useMemo(() => {
+    const profiles: ConfigSuit[] = profilesData?.suits || [];
+    return arrangeProfilesWithDefaultFirst(
+      profiles.filter((profile) => profile.suit_type === "shared"),
+    );
+  }, [profilesData?.suits]);
+
+  const effectiveCapabilityConfig =
+    useMemo<ClientCapabilityConfigData | null>(() => {
+      if (capabilityConfig) {
+        return capabilityConfig;
+      }
+      if (!identifier) {
+        return null;
+      }
+      return {
+        identifier,
+        capability_source: configDetails?.capability_source || "activated",
+        selected_profile_ids: configDetails?.selected_profile_ids || [],
+        custom_profile_id: configDetails?.custom_profile_id ?? null,
+        custom_profile_missing: configDetails?.custom_profile_missing ?? false,
+      };
+    }, [
+      capabilityConfig,
+      configDetails?.capability_source,
+      configDetails?.custom_profile_id,
+      configDetails?.custom_profile_missing,
+      configDetails?.selected_profile_ids,
+      identifier,
+    ]);
+
+  const customProfileMissing =
+    effectiveCapabilityConfig?.custom_profile_missing ??
+    configDetails?.custom_profile_missing ??
+    false;
+
+  const customProfileId = customProfileMissing
+    ? null
+    : (effectiveCapabilityConfig?.custom_profile_id ??
+      configDetails?.custom_profile_id ??
+      null);
+
+  useEffect(() => {
+    setHasUnifyDraftChanges(false);
+  }, [identifier]);
+
+  useEffect(() => {
+    if (!effectiveCapabilityConfig) {
+      return;
+    }
+    if (hasUnifyDraftChanges) {
+      return;
+    }
+    switch (effectiveCapabilityConfig.capability_source) {
+      case "profiles":
+        setSelectedConfig("profile");
+        setSelectedProfiles(
+          effectiveCapabilityConfig.selected_profile_ids || [],
+        );
+        break;
+      case "custom":
+        setSelectedConfig("custom");
+        setSelectedProfiles([]);
+        break;
+      case "activated":
+      default:
+        setSelectedConfig("default");
+        setSelectedProfiles([]);
+        break;
+    }
+    if (effectiveCapabilityConfig.unify_direct_exposure) {
+      const exposure = effectiveCapabilityConfig.unify_direct_exposure;
+      setUnifyRouteMode(exposure.route_mode || "broker_only");
+      setUnifySelectedServers(exposure.server_ids ?? []);
+      setUnifyCapabilityIds(
+        normalizeDirectCapabilityIds(exposure.capability_ids),
+      );
+    } else {
+      setUnifyRouteMode("broker_only");
+      setUnifySelectedServers([]);
+      setUnifyCapabilityIds({});
+    }
+  }, [effectiveCapabilityConfig, hasUnifyDraftChanges]);
+
+  const capabilityProfileIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const profile of [...activeProfiles, ...sharedProfiles]) {
+      ids.add(profile.id);
+    }
+    if (customProfileId) {
+      ids.add(customProfileId);
+    }
+    return Array.from(ids);
+  }, [activeProfiles, customProfileId, sharedProfiles]);
+
+  // Fetch capabilities for profiles
+  const profileCapabilitiesQueries = useQueries({
+    queries: capabilityProfileIds.map((profileId) => ({
+      queryKey: ["profile-capabilities", profileId],
+      queryFn: async () => {
+        const [serversRes, toolsRes, resourcesRes, promptsRes, templatesRes] =
+          await Promise.all([
+            configSuitsApi.getServers(profileId),
+            configSuitsApi.getTools(profileId),
+            configSuitsApi.getResources(profileId),
+            configSuitsApi.getPrompts(profileId),
+            configSuitsApi.getResourceTemplates(profileId),
+          ]);
+
+        const enabledByComponentId = new Map<string, boolean>();
+        for (const s of serversRes?.servers ?? []) {
+          enabledByComponentId.set(s.id, Boolean(s.enabled));
+        }
+        for (const tool of toolsRes?.tools ?? []) {
+          enabledByComponentId.set(tool.id, Boolean(tool.enabled));
+        }
+        for (const r of resourcesRes?.resources ?? []) {
+          enabledByComponentId.set(r.id, Boolean(r.enabled));
+        }
+        for (const p of promptsRes?.prompts ?? []) {
+          enabledByComponentId.set(p.id, Boolean(p.enabled));
+        }
+        for (const tmpl of templatesRes?.templates ?? []) {
+          enabledByComponentId.set(tmpl.id, Boolean(tmpl.enabled));
+        }
+
+        return {
+          profileId,
+          enabledByComponentId,
+          servers: {
+            total: serversRes?.servers?.length || 0,
+            enabled:
+              serversRes?.servers?.filter(
+                (s: { enabled?: boolean }) => s.enabled,
+              ).length || 0,
+          },
+          tools: {
+            total: toolsRes?.tools?.length || 0,
+            enabled:
+              toolsRes?.tools?.filter(
+                (tool: { enabled?: boolean }) => tool.enabled,
+              ).length || 0,
+          },
+          resources: {
+            total: resourcesRes?.resources?.length || 0,
+            enabled:
+              resourcesRes?.resources?.filter(
+                (r: { enabled?: boolean }) => r.enabled,
+              ).length || 0,
+          },
+          prompts: {
+            total: promptsRes?.prompts?.length || 0,
+            enabled:
+              promptsRes?.prompts?.filter(
+                (p: { enabled?: boolean }) => p.enabled,
+              ).length || 0,
+          },
+        };
+      },
+      enabled: capabilityProfileIds.length > 0,
+      retry: 1,
+    })),
+  });
+
+  // Create capabilities map
+  const profileCapabilities = useMemo(() => {
+    const map = new Map();
+    profileCapabilitiesQueries.forEach((query) => {
+      const data = query.data ?? undefined;
+      if (data) {
+        map.set(data.profileId, data);
+      }
+    });
+    return map;
+  }, [profileCapabilitiesQueries]);
+
+  const customProfileCapabilities = customProfileId
+    ? profileCapabilities.get(customProfileId)
+    : undefined;
+  const managedTransportSupported =
+    Object.keys(configDetails?.transports ?? {}).length > 0;
+  const canWriteClientConfig = configDetails?.writable_config !== false;
+  const isPendingApproval = configDetails?.approval_status === "pending";
+  const isSuspendedClient = isDeniedApprovalStatus(
+    configDetails?.approval_status,
+  );
+  const isAttachmentApplicable =
+    configDetails?.attachment_state === "attached" ||
+    configDetails?.attachment_state === "detached";
+  const isAttachedClient =
+    isAttachmentApplicable && configDetails?.attachment_state === "attached";
+  const showLocalConfigMetadata =
+    isAttachmentApplicable && Boolean(configDetails?.config_path);
+  const overviewActionButtonClass =
+    "gap-2 rounded-none first:rounded-l-md last:rounded-r-md";
+  const canSaveManagementSettings = !isPendingApproval;
+  const canApplyTransparentConfig =
+    canSaveManagementSettings &&
+    canWriteClientConfig &&
+    !isDeniedApprovalStatus(configDetails?.approval_status);
+  const canSyncManagedConfig =
+    canWriteClientConfig &&
+    canSaveManagementSettings &&
+    !isDeniedApprovalStatus(configDetails?.approval_status) &&
+    managedTransportSupported;
+  const shouldRequireLocalConfigWrite = mode === "transparent";
+
+  const supportedTransportOptions = useMemo(() => {
+    const supported = Object.keys(configDetails?.transports ?? {});
+    if (supported.length < 2) {
+      return [] as string[];
+    }
+
+    const allowed = new Set(supported);
+    return SUPPORTED_TRANSPORT_OPTIONS.filter((transportOption) =>
+      allowed.has(transportOption),
+    );
+  }, [configDetails?.transports]);
+
+  const unifyRouteModeSegmentOptions = useMemo(() => {
+    return [
+      {
+        value: "broker_only",
+        label: t(
+          "detail.configuration.sections.source.unifyRouteModes.broker_only",
+          {
+            defaultValue: "Broker Only",
+          },
+        ),
+      },
+      {
+        value: "server_level",
+        label: t(
+          "detail.configuration.sections.source.unifyRouteModes.server_level",
+          {
+            defaultValue: "Server Level",
+          },
+        ),
+      },
+      {
+        value: "capability_level",
+        label: t(
+          "detail.configuration.sections.source.unifyRouteModes.capability_level",
+          {
+            defaultValue: "Capability Level",
+          },
+        ),
+      },
+    ];
+  }, [t, i18n.language]);
+
+  const configurationSourceSegmentOptions = useMemo(() => {
+    const statusOrUndefined = (raw: string) => {
+      const trimmed = raw.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    };
+    return [
+      {
+        value: "default",
+        label: t("detail.configuration.sections.source.options.default", {
+          defaultValue: "Active",
+        }),
+        status: statusOrUndefined(
+          t("detail.configuration.sections.source.statusLabel.default", {
+            defaultValue: "",
+          }),
+        ),
+      },
+      {
+        value: "profile",
+        label: t("detail.configuration.sections.source.options.profile", {
+          defaultValue: "Profiles",
+        }),
+        status: statusOrUndefined(
+          t("detail.configuration.sections.source.statusLabel.profile", {
+            defaultValue: "",
+          }),
+        ),
+      },
+      {
+        value: "custom",
+        label: t("detail.configuration.sections.source.options.custom", {
+          defaultValue: "Customize",
+        }),
+        status: statusOrUndefined(
+          t("detail.configuration.sections.source.statusLabel.custom", {
+            defaultValue: "",
+          }),
+        ),
+      },
+    ];
+  }, [t, i18n.language]);
+
+  const detailDescription = configDetails?.description ?? "";
+  const detailHomepageUrl = configDetails?.homepage_url ?? "";
+  const detailDocsUrl = configDetails?.docs_url ?? "";
+  const detailSupportUrl = configDetails?.support_url ?? "";
+  const renderOverviewActionButtons = () => {
+    if (!configDetails) return null;
+    return (
+      <ButtonGroup className="ml-auto flex-shrink-0 flex-nowrap self-start">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refreshDetectMutation.mutate()}
+          disabled={refreshDetectMutation.isPending}
+          className={overviewActionButtonClass}
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${refreshDetectMutation.isPending ? "animate-spin" : ""}`}
+          />
+          {t("detail.overview.buttons.refresh", {
+            defaultValue: "Refresh",
+          })}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setIsClientFormOpen(true)}
+          className={overviewActionButtonClass}
+        >
+          <Pencil className="h-4 w-4" />
+          {t("detail.overview.buttons.edit", {
+            defaultValue: "Edit",
+          })}
+        </Button>
+      </ButtonGroup>
+    );
+  };
+  const managementModeSegmentOptions = useMemo(() => {
+    return [
+      {
+        value: "unify",
+        label: t("detail.configuration.sections.mode.options.unify", {
+          defaultValue: "Unify",
+        }),
+      },
+      {
+        value: "hosted",
+        label: t("detail.configuration.sections.mode.options.hosted", {
+          defaultValue: "Hosted",
+        }),
+      },
+      {
+        value: "transparent",
+        label: t("detail.configuration.sections.mode.options.transparent", {
+          defaultValue: "Transparent",
+        }),
+        disabled: configDetails?.writable_config === false,
+        tooltip:
+          configDetails?.writable_config === false
+            ? t(
+                "detail.configuration.sections.mode.transparentDisabledReason",
+                {
+                  defaultValue:
+                    "Transparent requires a writable local config path.",
+                },
+              )
+            : undefined,
+      },
+    ];
+  }, [configDetails?.writable_config, t, i18n.language]);
+  const [logFilter, setLogFilter] = useState("");
+  const [logPageSize, setLogPageSize] = useState<number>(10);
+  const [logPageCursors, setLogPageCursors] = useState<string[]>([]);
+  const [logCurrentPageIndex, setLogCurrentPageIndex] = useState(0);
+  const [isLogPaginationActionLoading, setIsLogPaginationActionLoading] =
+    useState(false);
+  const logCurrentCursor = logPageCursors[logCurrentPageIndex];
+
+  const logsQuery = useQuery({
+    queryKey: [
+      "client-audit-logs",
+      identifier,
+      logCurrentCursor,
+      logPageSize,
+      showClientLiveLogs,
+    ],
+    queryFn: () =>
+      auditApi.list({
+        limit: logPageSize,
+        cursor: logCurrentCursor,
+        client_id: identifier,
+      }),
+    enabled: Boolean(identifier && showClientLiveLogs),
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  useEffect(() => {
+    setLogPageCursors([]);
+    setLogCurrentPageIndex(0);
+  }, [identifier, logPageSize]);
+
+  const filteredLogs = useMemo(() => {
+    const logs = logsQuery.data?.events ?? [];
+    const term = logFilter.trim().toLowerCase();
+    if (!term) {
+      return logs;
+    }
+    return logs.filter((event) => {
+      const haystacks = [
+        event.action,
+        event.category,
+        event.status,
+        event.target,
+        event.route,
+        event.error_message,
+        event.detail,
+        event.mcp_method,
+        event.request_id,
+      ]
+        .filter(Boolean)
+        .map((value) => String(value).toLowerCase());
+      return haystacks.some((value) => value.includes(term));
+    });
+  }, [logsQuery.data?.events, logFilter]);
+
+  const handleLogsNextPage = () => {
+    if (!logsQuery.data?.next_cursor) {
+      return;
+    }
+    const nextCursor = logsQuery.data.next_cursor;
+    setLogPageCursors((prev) => {
+      const next = [...prev];
+      next[logCurrentPageIndex + 1] = nextCursor;
+      return next;
+    });
+    setLogCurrentPageIndex((prev) => prev + 1);
+  };
+
+  const handleLogsPrevPage = () => {
+    if (logCurrentPageIndex > 0) {
+      setLogCurrentPageIndex((prev) => prev - 1);
+    }
+  };
+
+  const handleLogsFirstPage = () => {
+    setLogCurrentPageIndex(0);
+  };
+
+  const handleLogsLastPage = async () => {
+    if (!logsQuery.data?.next_cursor || !identifier) {
+      return;
+    }
+    setIsLogPaginationActionLoading(true);
+    try {
+      let nextCursor: string | undefined = logsQuery.data.next_cursor;
+      let targetPageIndex = logCurrentPageIndex;
+      const nextPageCursors = [...logPageCursors];
+      while (nextCursor) {
+        targetPageIndex += 1;
+        nextPageCursors[targetPageIndex] = nextCursor;
+        const page = await auditApi.list({
+          limit: logPageSize,
+          cursor: nextCursor,
+          client_id: identifier,
+        });
+        if (!page) {
+          break;
+        }
+        nextCursor = page.next_cursor ?? undefined;
+      }
+      setLogPageCursors(nextPageCursors);
+      setLogCurrentPageIndex(targetPageIndex);
+    } finally {
+      setIsLogPaginationActionLoading(false);
+    }
+  };
+
+  const buildCapabilityConfigPayload = (): ClientCapabilityConfigReq => {
+    if (!identifier) {
+      throw new Error("No identifier provided");
+    }
+
+    const payload: ClientCapabilityConfigReq = {
+      identifier,
+      capability_source: "activated",
+      selected_profile_ids: [],
+    };
+
+    if (mode === "unify") {
+      payload.capability_source = "activated";
+      payload.selected_profile_ids = [];
+      payload.unify_direct_exposure = buildUnifyDirectExposurePayload(
+        unifyRouteMode,
+        unifySelectedServers,
+        unifyCapabilityIds,
+      );
+    } else {
+      payload.unify_direct_exposure =
+        effectiveCapabilityConfig?.unify_direct_exposure || null;
+      if (selectedConfig === "profile") {
+        const profileIds =
+          selectedProfiles.length > 0
+            ? selectedProfiles
+            : ([sharedProfiles.find((p) => p.is_default)?.id].filter(
+                Boolean,
+              ) as string[]);
+
+        if (profileIds.length === 0) {
+          throw new Error(
+            t("detail.configuration.errors.profileRequired", {
+              defaultValue:
+                "Select at least one shared profile before applying this capability source.",
+            }),
+          );
+        }
+        payload.capability_source = "profiles";
+        payload.selected_profile_ids = profileIds;
+      } else if (selectedConfig === "custom") {
+        payload.capability_source = "custom";
+        payload.selected_profile_ids = [];
+      } else {
+        payload.capability_source = "activated";
+        payload.selected_profile_ids = [];
+      }
+    }
+
+    return payload;
+  };
+
+  const directExposureServerMutation = useMutation<
+    ClientCapabilityConfigData | null,
+    unknown,
+    { server: ServerSummary; routeMode: DirectExposureRouteMode }
+  >({
+    mutationFn: async ({ server, routeMode }) => {
+      if (!identifier) {
+        throw new Error("No identifier provided");
+      }
+
+      const currentConfig =
+        (await clientsApi.getCapabilityConfig(identifier)) ??
+        effectiveCapabilityConfig;
+      if (!currentConfig) {
+        throw new Error(
+          t("detail.configuration.errors.capabilityConfigMissing", {
+            defaultValue:
+              "Capability configuration update returned no data. Please try again.",
+          }),
+        );
+      }
+
+      if (routeMode === "server_level") {
+        return clientsApi.updateCapabilityConfig(
+          buildServerLevelExposureUpdate(identifier, currentConfig, server.id),
+        );
+      }
+
+      const [
+        toolsResponse,
+        promptsResponse,
+        resourcesResponse,
+        templatesResponse,
+      ] = await Promise.all([
+        serversApi.listTools(server.id).catch(() => ({ items: [] })),
+        serversApi.listPrompts(server.id).catch(() => ({ items: [] })),
+        serversApi.listResources(server.id).catch(() => ({ items: [] })),
+        serversApi
+          .listResourceTemplates(server.id)
+          .catch(() => ({ items: [] })),
+      ]);
+
+      const currentUnifyExposure = currentConfig.unify_direct_exposure ?? {
+        route_mode: "capability_level" as const,
+        server_ids: [],
+        capability_ids: {},
+      };
+
+      const currentCapabilityIds = normalizeDirectCapabilityIds(
+        currentUnifyExposure.capability_ids,
+      );
+
+      const rawTools = Array.isArray(toolsResponse.items)
+        ? (toolsResponse.items as Array<Record<string, unknown>>)
+        : [];
+      const rawPrompts = Array.isArray(promptsResponse.items)
+        ? (promptsResponse.items as Array<Record<string, unknown>>)
+        : [];
+      const rawResources = Array.isArray(resourcesResponse.items)
+        ? (resourcesResponse.items as Array<Record<string, unknown>>)
+        : [];
+      const rawTemplates = Array.isArray(templatesResponse.items)
+        ? (templatesResponse.items as Array<Record<string, unknown>>)
+        : [];
+
+      const serverToolIds = rawTools
+        .map((tool) => getCapabilityId(tool, ["unique_name"]))
+        .filter((id): id is string => Boolean(id));
+      const serverPromptIds = rawPrompts
+        .map((prompt) => getCapabilityId(prompt, ["unique_name"]))
+        .filter((id): id is string => Boolean(id));
+      const serverResourceIds = rawResources
+        .map((resource) => getCapabilityId(resource, ["unique_uri"]))
+        .filter((id): id is string => Boolean(id));
+      const serverTemplateIds = rawTemplates
+        .map((template) =>
+          getCapabilityId(template, ["unique_uri_template", "unique_name"]),
+        )
+        .filter((id): id is string => Boolean(id));
+      const serverCapabilityIdSet = new Set([
+        ...serverToolIds,
+        ...serverPromptIds,
+        ...serverResourceIds,
+        ...serverTemplateIds,
+      ]);
+      const hasAnySelectedForServer = [
+        ...(currentCapabilityIds.tool_ids ?? []),
+        ...(currentCapabilityIds.prompt_ids ?? []),
+        ...(currentCapabilityIds.resource_ids ?? []),
+        ...(currentCapabilityIds.template_ids ?? []),
+      ].some((id) => serverCapabilityIdSet.has(id));
+
+      const nextCapabilityIds: UnifyDirectCapabilityIds = {
+        tool_ids: resolveNextCapabilityIds(
+          currentCapabilityIds.tool_ids,
+          hasAnySelectedForServer,
+          serverToolIds,
+        ),
+        prompt_ids: resolveNextCapabilityIds(
+          currentCapabilityIds.prompt_ids,
+          hasAnySelectedForServer,
+          serverPromptIds,
+        ),
+        resource_ids: resolveNextCapabilityIds(
+          currentCapabilityIds.resource_ids,
+          hasAnySelectedForServer,
+          serverResourceIds,
+        ),
+        template_ids: resolveNextCapabilityIds(
+          currentCapabilityIds.template_ids,
+          hasAnySelectedForServer,
+          serverTemplateIds,
+        ),
+      };
+
+      return clientsApi.updateCapabilityConfig(
+        buildCapabilityLevelExposureUpdate(
+          identifier,
+          currentConfig,
+          nextCapabilityIds,
+        ),
+      );
+    },
+    onSuccess: async (data, { routeMode }) => {
+      if (routeMode === "server_level") {
+        setUnifySelectedServers(data?.unify_direct_exposure?.server_ids ?? []);
+        setHasUnifyDraftChanges(false);
+      }
+      await refreshClientCapabilityState();
+    },
+    onError: (error) =>
+      notifyError(
+        t("detail.directExposure.notifications.saveFailedTitle", {
+          defaultValue: "Unable to update direct capabilities",
+        }),
+        String(error),
+      ),
+  });
+
+  const renderProfileCapabilitySummary = (
+    capabilities: NonNullable<ReturnType<typeof profileCapabilities.get>>,
+  ) => {
+    const capabilityItems = [
+      {
+        key: "servers",
+        label: t("detail.configuration.labels.servers", {
+          defaultValue: "Servers",
+        }),
+        counts: capabilities.servers,
+      },
+      {
+        key: "tools",
+        label: t("detail.configuration.labels.tools", {
+          defaultValue: "Tools",
+        }),
+        counts: capabilities.tools,
+      },
+      {
+        key: "resources",
+        label: t("detail.configuration.labels.resources", {
+          defaultValue: "Resources",
+        }),
+        counts: capabilities.resources,
+      },
+      {
+        key: "prompts",
+        label: t("detail.configuration.labels.prompts", {
+          defaultValue: "Prompts",
+        }),
+        counts: capabilities.prompts,
+      },
+    ];
+
+    return (
+      <div className="mt-1 flex gap-4 text-xs text-slate-500">
+        {capabilityItems.map((item) => (
+          <span key={item.key}>
+            {item.label}: {item.counts.enabled}/{item.counts.total}
+          </span>
+        ))}
+      </div>
+    );
+  };
+
+  const renderUnifyEligibleServerCapabilitySummary = (
+    server: ServerSummary,
+    routeMode: DirectExposureRouteMode,
+    exposedToolCount: number,
+  ) => {
+    const cap = server.capabilities ?? server.capability;
+    const toolsTotal = cap?.tools_count ?? 0;
+    const toolsValue =
+      routeMode === "capability_level"
+        ? `${exposedToolCount}/${toolsTotal}`
+        : String(toolsTotal);
+    const items = [
+      {
+        key: "tools",
+        label: t("detail.configuration.labels.tools", {
+          defaultValue: "Tools",
+        }),
+        value: toolsValue,
+      },
+      {
+        key: "resources",
+        label: t("detail.configuration.labels.resources", {
+          defaultValue: "Resources",
+        }),
+        value: String(cap?.resources_count ?? 0),
+      },
+      {
+        key: "prompts",
+        label: t("detail.configuration.labels.prompts", {
+          defaultValue: "Prompts",
+        }),
+        value: String(cap?.prompts_count ?? 0),
+      },
+      {
+        key: "resourceTemplates",
+        label: t("detail.configuration.labels.resourceTemplates", {
+          defaultValue: "Resource templates",
+        }),
+        value: String(cap?.resource_templates_count ?? 0),
+      },
+    ];
+    return (
+      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
+        {items.map((item) => (
+          <span key={item.key}>
+            {item.label}: {item.value}
+          </span>
+        ))}
+      </div>
+    );
+  };
+
+  const getConfigurationProfileTokenSlot = (
+    profile: ConfigSuit,
+    stopPropagationOnNavigate: boolean,
+  ) => {
+    const capData = profileCapabilities.get(profile.id);
+    const capIdx = capabilityProfileIds.indexOf(profile.id);
+    const capQuery =
+      capIdx >= 0 ? profileCapabilitiesQueries[capIdx] : undefined;
+
+    if (capQuery?.isError) {
+      return (
+        <Link
+          to={`/profiles/${profile.id}`}
+          onClick={
+            stopPropagationOnNavigate ? (e) => e.stopPropagation() : undefined
+          }
+          className="text-xs text-destructive underline underline-offset-2"
+        >
+          {t("detail.configuration.labels.openProfileDetail", {
+            defaultValue: "Open profile details",
+          })}
+        </Link>
+      );
+    }
+
+    if (!capData) {
+      return (
+        <div
+          className="h-14 w-14 shrink-0 animate-pulse rounded-full bg-muted/50"
+          aria-hidden
+        />
+      );
+    }
+
+    return (
+      <ConfigurationProfileTokenChart
+        profileId={profile.id}
+        enabledByComponentId={capData.enabledByComponentId}
+        profileServerCount={capData.servers.total}
+        stopPropagationOnNavigate={stopPropagationOnNavigate}
+      />
+    );
+  };
+
+  const { data: policyData, refetch: refetchPolicy } = useQuery({
+    queryKey: ["client-policy", identifier],
+    queryFn: () => clientsApi.getBackupPolicy(identifier || ""),
+    enabled: Boolean(identifier && supportsBackupOperations),
+  });
+
+  const reviewMutation = useMutation({
+    mutationFn: async (action: "approve" | "suspend") => {
+      if (!identifier) throw new Error("No identifier provided");
+      return action === "approve"
+        ? clientsApi.approveRecord({ identifier })
+        : clientsApi.suspendRecord({ identifier });
+    },
+    onSuccess: (_, action) => {
+      notifySuccess(
+        t("detail.notifications.reviewSuccess.title", {
+          defaultValue: "Success",
+        }),
+        t(
+          action === "approve"
+            ? "detail.notifications.reviewSuccess.messageApproved"
+            : "detail.notifications.reviewSuccess.messageSuspended",
+          {
+            defaultValue:
+              action === "approve"
+                ? "Record approved successfully."
+                : "Record suspended successfully.",
+          },
+        ),
+      );
+      qc.invalidateQueries({ queryKey: ["clients"] });
+      qc.invalidateQueries({ queryKey: ["client-config", identifier] });
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.reviewFailed.title", {
+          defaultValue: "Review failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const detachMutation = useMutation({
+    mutationFn: async () => {
+      if (!identifier) throw new Error("No identifier provided");
+      return clientsApi.detach(identifier);
+    },
+    onSuccess: () => {
+      notifySuccess(
+        t("detail.notifications.detachSuccess.title", {
+          defaultValue: "Detached",
+        }),
+        t("detail.notifications.detachSuccess.message", {
+          defaultValue:
+            "MCPMate was removed from the client configuration file.",
+        }),
+      );
+      qc.invalidateQueries({ queryKey: ["clients"] });
+      qc.invalidateQueries({ queryKey: ["client-config", identifier] });
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.detachFailed.title", {
+          defaultValue: "Detach failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const attachMutation = useMutation({
+    mutationFn: async () => {
+      if (!identifier) throw new Error("No identifier provided");
+      return clientsApi.attach(identifier);
+    },
+    onSuccess: () => {
+      notifySuccess(
+        t("detail.notifications.attachSuccess.title", {
+          defaultValue: "Attached",
+        }),
+        t("detail.notifications.attachSuccess.message", {
+          defaultValue: "MCPMate was written back to the client configuration.",
+        }),
+      );
+      qc.invalidateQueries({ queryKey: ["clients"] });
+      qc.invalidateQueries({ queryKey: ["client-config", identifier] });
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.attachFailed.title", {
+          defaultValue: "Attach failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const applyMutation = useMutation<
+    {
+      data: ClientConfigUpdateData | null;
+      preview: boolean;
+      clientConfigApplied: boolean;
+    },
+    unknown,
+    { preview: boolean }
+  >({
+    mutationFn: async ({ preview }) => {
+      if (!identifier) throw new Error("No identifier provided");
+      if (!canSaveManagementSettings) {
+        throw new Error(
+          t("detail.configuration.managementSettingsPendingReason", {
+            defaultValue:
+              "Save management settings after this client leaves pending approval.",
+          }),
+        );
+      }
+
+      // Validate transparent-mode requirements before persisting any management
+      // settings, so a failed precondition never leaves partial state in MCPMate.
+      if (shouldRequireLocalConfigWrite) {
+        if (!canWriteClientConfig) {
+          throw new Error(
+            t("detail.configuration.writeTargetRequiredReason", {
+              defaultValue:
+                "Applying governance to the client configuration requires a verified writable local MCP config file.",
+            }),
+          );
+        }
+        if (!canApplyTransparentConfig) {
+          throw new Error(
+            t("detail.configuration.applyRequiresApprovedReason", {
+              defaultValue:
+                "Applying client configuration requires an approved governance state and a verified local config target.",
+            }),
+          );
+        }
+      }
+
+      await clientsApi.update({
+        identifier,
+        config_mode: mode,
+      });
+
+      const capabilityData = await clientsApi.updateCapabilityConfig(
+        buildCapabilityConfigPayload(),
+      );
+      if (!capabilityData) {
+        throw new Error(
+          t("detail.configuration.errors.capabilityConfigMissing", {
+            defaultValue:
+              "Capability configuration update returned no data. Please try again.",
+          }),
+        );
+      }
+
+      const selectedConfigForManagedApply =
+        mode === "unify"
+          ? "default"
+          : buildClientApplySelectedConfig(capabilityData);
+
+      if (shouldRequireLocalConfigWrite) {
+        const data = await clientsApi.applyConfig({
+          identifier,
+          mode,
+          selected_config: buildClientApplySelectedConfig(capabilityData),
+          preview,
+          backup_policy: preview
+            ? undefined
+            : mapDashboardSettingsToClientBackupPolicy(dashboardSettings),
+        });
+        return { data: data ?? null, preview, clientConfigApplied: true };
+      }
+
+      if (!canSyncManagedConfig) {
+        return { data: null, preview, clientConfigApplied: false };
+      }
+
+      const data = await clientsApi.applyConfig({
+        identifier,
+        mode,
+        selected_config: selectedConfigForManagedApply,
+        preview,
+        backup_policy: preview
+          ? undefined
+          : mapDashboardSettingsToClientBackupPolicy(dashboardSettings),
+      });
+      return { data: data ?? null, preview, clientConfigApplied: true };
+    },
+    onSuccess: ({ data, preview, clientConfigApplied }) => {
+      if (preview) {
+        if (data) {
+          notifyInfo(
+            t("detail.notifications.previewReady.title", {
+              defaultValue: "Preview ready",
+            }),
+            t("detail.notifications.previewReady.message", {
+              defaultValue: "Review the diff before applying.",
+            }),
+          );
+        } else {
+          notifyInfo(
+            t("detail.notifications.previewReady.title", {
+              defaultValue: "Preview ready",
+            }),
+            t("detail.notifications.previewReady.noChanges", {
+              defaultValue: "No changes detected in this configuration.",
+            }),
+          );
+        }
+      } else if (clientConfigApplied) {
+        notifySuccess(
+          t("detail.notifications.applied.title", {
+            defaultValue: "Applied",
+          }),
+          t("detail.notifications.applied.message", {
+            defaultValue: "Configuration applied",
+          }),
+        );
+        refetchBackups();
+      } else {
+        notifySuccess(
+          t("detail.notifications.managementSaved.title", {
+            defaultValue: "Saved",
+          }),
+          t("detail.notifications.managementSaved.message", {
+            defaultValue:
+              "Management settings were saved in MCPMate. Local client configuration was not updated.",
+          }),
+        );
+      }
+      void refreshClientCapabilityState();
+      setHasUnifyDraftChanges(false);
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.applyFailed.title", {
+          defaultValue: "Apply failed",
+        }),
+        resolveClientConfigSyncErrorMessage(e, t),
+      ),
+  });
+
+  const importMutation = useMutation<ClientConfigImportData | null>({
+    mutationFn: async () => {
+      // If no preview yet, generate one first
+      if (!importPreviewData) {
+        if (!identifier) throw new Error("No identifier provided");
+        const res = await clientsApi.importFromClient(identifier, {
+          preview: true,
+        });
+        setImportPreviewData(res);
+        return null; // indicate preview stage; caller handles UI
+      }
+      if (!identifier) throw new Error("No identifier provided");
+      return clientsApi.importFromClient(identifier, { preview: false });
+    },
+    onSuccess: (res) => {
+      // If onSuccess received null means we just did a preview; do not close
+      if (!res) return;
+      const imported =
+        res.imported_servers?.length ?? res.summary?.imported_count ?? 0;
+      if (imported > 0) {
+        notifySuccess(
+          t("detail.notifications.imported.title", {
+            defaultValue: "Imported",
+          }),
+          imported === 1
+            ? t("detail.notifications.imported.messageSingle", {
+                defaultValue: "{{count}} server imported successfully",
+                count: imported,
+              })
+            : t("detail.notifications.imported.messagePlural", {
+                defaultValue: "{{count}} servers imported successfully",
+                count: imported,
+              }),
+        );
+        setImportPreviewOpen(false);
+      } else {
+        notifyInfo(
+          t("detail.notifications.nothingToImport.title", {
+            defaultValue: "Nothing to import",
+          }),
+          t("detail.notifications.nothingToImport.message", {
+            defaultValue:
+              "All entries were skipped or no importable servers found.",
+          }),
+        );
+        setImportPreviewOpen(false);
+      }
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.importFailed.title", {
+          defaultValue: "Import failed",
+        }),
+        String(e),
+      ),
+  });
+
+  // Header actions: refresh detection and update governance state
+  const refreshDetectMutation = useMutation({
+    mutationFn: async () => {
+      const data = await clientsApi.list(true);
+      if (data?.client) {
+        const f = data.client.find((c) => c.identifier === identifier);
+        if (f) {
+          if (typeof f.display_name === "string")
+            setDisplayName(f.display_name);
+        }
+      }
+      await refetchDetails();
+    },
+    onSuccess: () =>
+      notifySuccess(
+        t("detail.notifications.refreshed.title", {
+          defaultValue: "Refreshed",
+        }),
+        t("detail.notifications.refreshed.message", {
+          defaultValue: "Detection refreshed",
+        }),
+      ),
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.refreshFailed.title", {
+          defaultValue: "Refresh failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const governanceMutation = useMutation<
+    void,
+    unknown,
+    { nextStatus: "approved" | "suspended" }
+  >({
+    mutationFn: async ({ nextStatus }) => {
+      if (!identifier) throw new Error("No identifier provided");
+      if (nextStatus === "approved") {
+        await clientsApi.approveRecord({ identifier });
+        return;
+      }
+
+      await governanceClientsApi.suspendRecord({ identifier });
+    },
+    onSuccess: async (_, { nextStatus }) => {
+      await Promise.allSettled([
+        refetchDetails(),
+        qc.invalidateQueries({ queryKey: ["clients"] }),
+        qc.invalidateQueries({ queryKey: ["client-config", identifier] }),
+      ]);
+
+      notifySuccess(
+        t(
+          nextStatus === "approved"
+            ? "detail.notifications.governanceAllowed.title"
+            : "detail.notifications.governanceDenied.title",
+          {
+            defaultValue: "Updated",
+          },
+        ),
+        t(
+          nextStatus === "approved"
+            ? "detail.notifications.governanceAllowed.message"
+            : "detail.notifications.governanceDenied.message",
+          {
+            defaultValue:
+              nextStatus === "approved"
+                ? "Client governance is now allowed."
+                : "Client governance is now denied.",
+          },
+        ),
+      );
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.governanceFailed.title", {
+          defaultValue: "Update failed",
+        }),
+        String(e),
+      ),
+  });
+  const importPreviewMutation = useMutation<ClientConfigImportData>({
+    mutationFn: async () => {
+      if (!identifier) throw new Error("No identifier provided");
+      return clientsApi.importFromClient(identifier, { preview: true });
+    },
+    onSuccess: (res) => {
+      setImportPreviewData(res);
+      setImportPreviewOpen(true);
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.previewFailed.title", {
+          defaultValue: "Preview failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const restoreMutation = useMutation({
+    mutationFn: ({ backup }: { backup: string }) => {
+      if (!identifier) throw new Error("No identifier provided");
+      return clientsApi.restoreConfig({ identifier, backup });
+    },
+    onSuccess: () => {
+      notifySuccess(
+        t("detail.notifications.restored.title", {
+          defaultValue: "Restored",
+        }),
+        t("detail.notifications.restored.message", {
+          defaultValue: "Local client configuration restored from backup",
+        }),
+      );
+      refetchDetails();
+      refetchBackups();
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.restoreFailed.title", {
+          defaultValue: "Restore failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const deleteBackupMutation = useMutation({
+    mutationFn: ({ backup }: { backup: string }) => {
+      if (!identifier) throw new Error("No identifier provided");
+      return clientsApi.deleteBackup(identifier, backup);
+    },
+    onSuccess: () => {
+      notifySuccess(
+        t("detail.notifications.deleted.title", {
+          defaultValue: "Deleted",
+        }),
+        t("detail.notifications.deleted.message", {
+          defaultValue: "Backup deleted",
+        }),
+      );
+      refetchBackups();
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.deleteFailed.title", {
+          defaultValue: "Delete failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: async () => {
+      if (!identifier) throw new Error("No identifier provided");
+      const items = [...selectedBackups];
+      const results = await Promise.allSettled(
+        items.map((b) => clientsApi.deleteBackup(identifier, b)),
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed > 0) throw new Error(`${failed} deletions failed`);
+    },
+    onSuccess: async () => {
+      notifySuccess(
+        t("detail.notifications.bulkDeleted.title", {
+          defaultValue: "Deleted",
+        }),
+        t("detail.notifications.bulkDeleted.message", {
+          defaultValue: "Selected backups have been deleted",
+        }),
+      );
+      setSelectedBackups([]);
+      setBulkConfirmOpen(false);
+      await refetchBackups();
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.bulkDeleteFailed.title", {
+          defaultValue: "Bulk delete failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const [confirm, setConfirm] = useState<null | {
+    kind: "delete" | "restore";
+    backup: string;
+  }>(null);
+
+  const setPolicyMutation = useMutation({
+    mutationFn: (payload: ClientBackupPolicySetReq) =>
+      clientsApi.setBackupPolicy(payload),
+    onSuccess: () => {
+      notifySuccess(
+        t("detail.notifications.saved.title", {
+          defaultValue: "Saved",
+        }),
+        t("detail.notifications.saved.message", {
+          defaultValue: "Backup policy updated",
+        }),
+      );
+      refetchPolicy();
+    },
+    onError: (e) =>
+      notifyError(
+        t("detail.notifications.saveFailed.title", {
+          defaultValue: "Save failed",
+        }),
+        String(e),
+      ),
+  });
+
+  const [policyLabel, setPolicyLabel] = useState<string>("keep_n");
+  const [policyLimit, setPolicyLimit] = useState<number | undefined>(5);
+  useEffect(() => {
+    if (policyData) {
+      setPolicyLabel(policyData.policy || "keep_n");
+      setPolicyLimit(policyData.limit ?? undefined);
+    }
+  }, [policyData]);
+  const backupsDisabledByPolicy =
+    visibleBackups.length === 0 &&
+    (policyData?.policy === "off" || policyData?.policy === "none");
+
+  // Heuristic extract current servers from config content for preview
+  const currentServers = useMemo(() => {
+    const c = (configDetails as { content?: unknown })?.content;
+    try {
+      if (!c) return [] as string[];
+      if (typeof c === "string") {
+        const parsed = JSON.parse(c);
+        return extractServers(parsed);
+      }
+      return extractServers(c);
+    } catch {
+      return [] as string[];
+    }
+  }, [configDetails]);
+
+  if (!identifier)
+    return (
+      <div className="p-4">
+        {t("detail.noIdentifier", {
+          defaultValue: "No client identifier provided.",
+        })}
+      </div>
+    );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h2 className="text-3xl font-bold tracking-tight">
+              {displayName || identifier}
+            </h2>
+
+            {configDetails?.approval_status === "pending" && (
+              <Badge
+                variant="outline"
+                className="bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-950 dark:text-blue-200 dark:border-blue-800"
+              >
+                {t("detail.badges.pendingReview", {
+                  defaultValue: "Pending Review",
+                })}
+              </Badge>
+            )}
+            {isSuspendedClient && (
+              <Badge variant="destructive">
+                {t("detail.badges.suspended", { defaultValue: "Suspended" })}
+              </Badge>
+            )}
+            {isAttachmentApplicable ? (
+              <Badge variant={isAttachedClient ? "secondary" : "outline"}>
+                {isAttachedClient
+                  ? t("detail.badges.attached", { defaultValue: "Attached" })
+                  : t("detail.badges.detached", {
+                      defaultValue: "Detached",
+                    })}
+              </Badge>
+            ) : null}
+          </div>
+          {detailDescription ? (
+            <p className="text-sm text-muted-foreground leading-snug w-full truncate">
+              {detailDescription}
+            </p>
+          ) : null}
+        </div>
+        {/* 操作按钮移至 Overview 卡片右上角 */}
+      </div>
+
+      <Tabs
+        value={tabValue}
+        onValueChange={setTabValue}
+        className="flex min-h-0 flex-1 flex-col gap-4"
+      >
+        <div className="flex shrink-0 items-center justify-between">
+          <TabsList>
+            <TabsTrigger value="overview">
+              {t("detail.tabs.overview", { defaultValue: "Overview" })}
+            </TabsTrigger>
+            <TabsTrigger value="configuration">
+              {t("detail.tabs.configuration", {
+                defaultValue: "Configuration",
+              })}
+            </TabsTrigger>
+            {configDetails?.writable_config !== false && (
+              <TabsTrigger value="backups">
+                {t("detail.tabs.backups", { defaultValue: "Backups" })}
+              </TabsTrigger>
+            )}
+          </TabsList>
+          {renderOverviewActionButtons()}
+        </div>
+
+        <TabsContent
+          value="overview"
+          className="mt-0 flex min-h-0 flex-1 flex-col overflow-y-auto data-[state=inactive]:hidden"
+        >
+          <div className="grid gap-4">
+            <Card>
+              {loadingConfig ? (
+                <CardContent className="text-sm">
+                  <div className="animate-pulse h-16 bg-slate-200 dark:bg-slate-800 rounded" />
+                </CardContent>
+              ) : configDetails ? (
+                <CardContent className="p-4">
+                  <div className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                      <div className="flex flex-wrap items-start gap-4">
+                        <CachedAvatar
+                          src={configDetails.logo_url ?? undefined}
+                          alt={displayName || identifier}
+                          fallback={displayName || identifier || "C"}
+                          className="text-sm"
+                        />
+                        <div className="grid grid-cols-[auto_1fr] gap-x-5 gap-y-2 text-sm">
+                          {showLocalConfigMetadata ? (
+                            <>
+                              <span className="text-xs uppercase text-slate-500">
+                                {t("detail.overview.labels.configPath", {
+                                  defaultValue: "Config Path",
+                                })}
+                              </span>
+                              <span className="font-mono text-xs truncate max-w-[520px]">
+                                {configDetails.config_path}
+                              </span>
+
+                              <span className="text-xs uppercase text-slate-500">
+                                {t("detail.overview.labels.lastModified", {
+                                  defaultValue: "Last Modified",
+                                })}
+                              </span>
+                              <span className="text-xs">
+                                {formatBackupTime(configDetails.last_modified)}
+                              </span>
+                            </>
+                          ) : null}
+
+                          <span className="text-xs uppercase text-slate-500">
+                            {t("detail.overview.labels.supportedTransports", {
+                              defaultValue: "Transports",
+                            })}
+                          </span>
+                          <span className="text-xs flex gap-2">
+                            {Object.keys(configDetails?.transports ?? {}).map(
+                              (transport) => (
+                                <span
+                                  key={transport}
+                                  className="inline-flex items-center rounded-full bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+                                  title={transport}
+                                >
+                                  {transport}
+                                </span>
+                              ),
+                            )}
+                          </span>
+
+                          {detailHomepageUrl ? (
+                            <>
+                              <span className="text-xs uppercase text-slate-500">
+                                {t("detail.overview.labels.homepage", {
+                                  defaultValue: "Homepage",
+                                })}
+                              </span>
+                              <a
+                                href={detailHomepageUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-xs underline underline-offset-2 truncate"
+                              >
+                                {detailHomepageUrl}
+                              </a>
+                            </>
+                          ) : null}
+                          {detailDocsUrl ? (
+                            <>
+                              <span className="text-xs uppercase text-slate-500">
+                                {t("detail.overview.labels.docs", {
+                                  defaultValue: "Docs",
+                                })}
+                              </span>
+                              <a
+                                href={detailDocsUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-xs underline underline-offset-2 truncate"
+                              >
+                                {detailDocsUrl}
+                              </a>
+                            </>
+                          ) : null}
+                          {detailSupportUrl ? (
+                            <>
+                              <span className="text-xs uppercase text-slate-500">
+                                {t("detail.overview.labels.support", {
+                                  defaultValue: "Support",
+                                })}
+                              </span>
+                              <a
+                                href={detailSupportUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-xs underline underline-offset-2 truncate"
+                              >
+                                {detailSupportUrl}
+                              </a>
+                            </>
+                          ) : null}
+                        </div>
+                      </div>
+                      <ButtonGroup className="ml-auto flex-shrink-0 flex-nowrap self-start">
+                        {configDetails?.approval_status === "pending" && (
+                          <>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="bg-green-50 text-green-700 hover:bg-green-100 hover:text-green-800 border-green-200 dark:bg-green-950 dark:text-green-300 dark:hover:bg-green-900 dark:border-green-800 gap-2"
+                              onClick={() => reviewMutation.mutate("approve")}
+                              disabled={reviewMutation.isPending}
+                            >
+                              <Check className="h-4 w-4" />
+                              {t("detail.overview.buttons.approve", {
+                                defaultValue: "Approve",
+                              })}
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="bg-red-50 text-red-700 hover:bg-red-100 hover:text-red-800 border-red-200 dark:bg-red-950 dark:text-red-300 dark:hover:bg-red-900 dark:border-red-800 gap-2"
+                              onClick={() => reviewMutation.mutate("suspend")}
+                              disabled={reviewMutation.isPending}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              {t("detail.overview.buttons.suspend", {
+                                defaultValue: "Suspend",
+                              })}
+                            </Button>
+                          </>
+                        )}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            governanceMutation.mutate({
+                              nextStatus: isDeniedApprovalStatus(
+                                configDetails?.approval_status,
+                              )
+                                ? "approved"
+                                : "suspended",
+                            })
+                          }
+                          disabled={
+                            governanceMutation.isPending ||
+                            !configDetails ||
+                            configDetails.approval_status === "pending"
+                          }
+                          className="gap-2"
+                        >
+                          {isDeniedApprovalStatus(
+                            configDetails?.approval_status,
+                          ) ? (
+                            <ShieldCheck className="h-4 w-4" />
+                          ) : (
+                            <ShieldX className="h-4 w-4" />
+                          )}
+                          {isDeniedApprovalStatus(
+                            configDetails?.approval_status,
+                          )
+                            ? t("detail.overview.buttons.allow", {
+                                defaultValue: "Allow",
+                              })
+                            : t("detail.overview.buttons.deny", {
+                                defaultValue: "Deny",
+                              })}
+                        </Button>
+                        {isAttachmentApplicable ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              setAttachmentActionConfirm(
+                                isAttachedClient ? "detach" : "attach",
+                              )
+                            }
+                            disabled={
+                              detachMutation.isPending ||
+                              attachMutation.isPending
+                            }
+                            className="gap-2"
+                          >
+                            {isAttachedClient ? (
+                              <Unlink className="h-4 w-4" />
+                            ) : (
+                              <Link2 className="h-4 w-4" />
+                            )}
+                            {isAttachedClient
+                              ? t("detail.overview.buttons.detach", {
+                                  defaultValue: "Detach",
+                                })
+                              : t("detail.overview.buttons.attach", {
+                                  defaultValue: "Attach",
+                                })}
+                          </Button>
+                        ) : null}
+                        {supportedTransportOptions.length > 0 ? (
+                          <ButtonGroupText className="h-9 p-0 select-none shadow-none">
+                            <Select
+                              value={transport}
+                              onValueChange={async (v) => {
+                                if (!identifier) return;
+                                const previousTransport = transport;
+                                setTransport(v);
+                                try {
+                                  const selectedTransport =
+                                    isSupportedTransportOption(v) ? v : "auto";
+                                  await clientsApi.update({
+                                    identifier,
+                                    transport: selectedTransport,
+                                    transports: withSelectedTransport(
+                                      configDetails?.transports,
+                                      selectedTransport,
+                                    ),
+                                  });
+
+                                  let configApplied = false;
+                                  const shouldApplyManagedConfig =
+                                    (mode === "hosted" || mode === "unify") &&
+                                    canSyncManagedConfig;
+                                  if (shouldApplyManagedConfig) {
+                                    try {
+                                      const capabilityData =
+                                        (await clientsApi.getCapabilityConfig(
+                                          identifier,
+                                        )) ?? effectiveCapabilityConfig;
+                                      if (!capabilityData) {
+                                        throw new Error(
+                                          t(
+                                            "detail.configuration.errors.capabilityConfigMissing",
+                                            {
+                                              defaultValue:
+                                                "Capability configuration update returned no data. Please try again.",
+                                            },
+                                          ),
+                                        );
+                                      }
+
+                                      await applyClientConfigWithResolvedSelection(
+                                        {
+                                          identifier,
+                                          mode,
+                                          backupPolicy:
+                                            mapDashboardSettingsToClientBackupPolicy(
+                                              dashboardSettings,
+                                            ),
+                                          capabilityData,
+                                        },
+                                      );
+                                      configApplied = true;
+                                    } catch (err) {
+                                      notifyError(
+                                        t(
+                                          "detail.notifications.applyFailed.title",
+                                          {
+                                            defaultValue: "Apply failed",
+                                          },
+                                        ),
+                                        resolveClientConfigSyncErrorMessage(
+                                          err,
+                                          t,
+                                        ),
+                                      );
+                                    }
+                                  }
+
+                                  notifySuccess(
+                                    t("detail.overview.transport.updated", {
+                                      defaultValue: "Transport updated",
+                                    }),
+                                    configApplied
+                                      ? t(
+                                          "detail.notifications.applied.message",
+                                          {
+                                            defaultValue:
+                                              "Configuration applied",
+                                          },
+                                        )
+                                      : "",
+                                  );
+                                  await refreshClientCapabilityState();
+                                } catch (err) {
+                                  setTransport(previousTransport);
+                                  notifyError(
+                                    t(
+                                      "detail.overview.transport.updateFailed",
+                                      { defaultValue: "Update failed" },
+                                    ),
+                                    resolveClientConfigSyncErrorMessage(err, t),
+                                  );
+                                }
+                              }}
+                            >
+                              <SelectTrigger
+                                className="h-8 border-0 shadow-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus:outline-none select-none bg-transparent px-3 min-w-[9rem]"
+                                aria-label={t(
+                                  "detail.overview.transport.selectorAria",
+                                  {
+                                    defaultValue: "Transport selector",
+                                  },
+                                )}
+                              >
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent align="end">
+                                <SelectItem value="auto">
+                                  {t(
+                                    "detail.configuration.transportOptions.auto",
+                                    {
+                                      defaultValue: "Auto",
+                                    },
+                                  )}
+                                </SelectItem>
+                                {supportedTransportOptions.map((v) => (
+                                  <SelectItem key={v} value={v}>
+                                    {getTransportOptionLabel(v, t)}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </ButtonGroupText>
+                        ) : null}
+                      </ButtonGroup>
+                    </div>
+                  </div>
+                </CardContent>
+              ) : (
+                <CardContent className="text-sm text-slate-500">
+                  {t("detail.overview.noDetails", {
+                    defaultValue: "No details available",
+                  })}
+                </CardContent>
+              )}
+            </Card>
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle>
+                    {t("detail.overview.currentServers.title", {
+                      defaultValue: "Current Servers",
+                    })}
+                  </CardTitle>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => importPreviewMutation.mutate()}
+                      disabled={configDetails?.writable_config === false}
+                    >
+                      <Download className="mr-2 h-4 w-4" />{" "}
+                      {t("detail.overview.currentServers.import", {
+                        defaultValue: "Import from Config",
+                      })}
+                    </Button>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {loadingConfig ? (
+                  <div className="space-y-2">
+                    {[1, 2, 3].map((i) => (
+                      <div
+                        key={i}
+                        className="h-8 bg-slate-200 dark:bg-slate-800 animate-pulse rounded-[10px]"
+                      />
+                    ))}
+                  </div>
+                ) : currentServers.length ? (
+                  <CapsuleStripeList>
+                    {currentServers.map((n) => (
+                      <CapsuleStripeListItem key={n}>
+                        <div className="font-mono">{n}</div>
+                        <div className="text-xs text-slate-500">
+                          {t("detail.overview.currentServers.configuredLabel", {
+                            defaultValue: "configured",
+                          })}
+                        </div>
+                      </CapsuleStripeListItem>
+                    ))}
+                  </CapsuleStripeList>
+                ) : (
+                  <div className="text-sm text-slate-500">
+                    {t("detail.overview.currentServers.empty", {
+                      defaultValue: "No servers extracted from current config.",
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            {showClientLiveLogs ? (
+              <AuditLogsPanel
+                title={t("detail.logs.title", { defaultValue: "Logs" })}
+                description={t("detail.logs.description", {
+                  defaultValue:
+                    "Runtime warnings and backend notes for this client.",
+                })}
+                searchPlaceholder={t("detail.logs.searchPlaceholder", {
+                  defaultValue: "Search logs...",
+                })}
+                refreshLabel={t("detail.logs.refresh", {
+                  defaultValue: "Refresh Logs",
+                })}
+                loadingLabel={t("detail.logs.loading", {
+                  defaultValue: "Loading logs...",
+                })}
+                emptyLabel={t("detail.logs.empty", {
+                  defaultValue: "No log entries recorded for this client yet.",
+                })}
+                headers={{
+                  timestamp: t("detail.logs.headers.timestamp", {
+                    defaultValue: "Timestamp",
+                  }),
+                  action: t("detail.logs.headers.action", {
+                    defaultValue: "Action",
+                  }),
+                  category: t("detail.logs.headers.category", {
+                    defaultValue: "Category",
+                  }),
+                  status: t("detail.logs.headers.status", {
+                    defaultValue: "Status",
+                  }),
+                  target: t("detail.logs.headers.target", {
+                    defaultValue: "Target",
+                  }),
+                }}
+                searchValue={logFilter}
+                onSearchChange={setLogFilter}
+                onRefresh={() => void logsQuery.refetch()}
+                rows={filteredLogs}
+                isLoading={logsQuery.isLoading}
+                isFetching={logsQuery.isFetching}
+                isPaginationActionLoading={isLogPaginationActionLoading}
+                currentPage={logCurrentPageIndex + 1}
+                hasPreviousPage={logCurrentPageIndex > 0}
+                hasNextPage={Boolean(logsQuery.data?.next_cursor)}
+                itemsPerPage={logPageSize}
+                onItemsPerPageChange={setLogPageSize}
+                onPreviousPage={handleLogsPrevPage}
+                onFirstPage={handleLogsFirstPage}
+                onNextPage={handleLogsNextPage}
+                onLastPage={() => void handleLogsLastPage()}
+                expandLabel={t("detail.logs.expand", {
+                  defaultValue: "Expand Logs",
+                })}
+                collapseLabel={t("detail.logs.collapse", {
+                  defaultValue: "Collapse Logs",
+                })}
+              />
+            ) : null}
+          </div>
+        </TabsContent>
+
+        <TabsContent value="configuration" className={DETAIL_TAB_CONTENT_CLASS}>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="grid gap-4">
+              <Card>
+                <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <CardTitle>
+                      {t("detail.configuration.title", {
+                        defaultValue: "Configuration Mode",
+                      })}
+                    </CardTitle>
+                    <CardDescription>
+                      {t("detail.configuration.description", {
+                        defaultValue:
+                          "If you don't understand what this means, please don't make any changes and keep the current settings.",
+                      })}
+                    </CardDescription>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="default"
+                    onClick={() => applyMutation.mutate({ preview: false })}
+                    disabled={
+                      loadingConfig ||
+                      applyMutation.isPending ||
+                      !canSaveManagementSettings ||
+                      (shouldRequireLocalConfigWrite &&
+                        !canApplyTransparentConfig)
+                    }
+                    className="gap-2"
+                  >
+                    <HardDrive
+                      className={`h-4 w-4 ${applyMutation.isPending ? "animate-pulse" : ""}`}
+                    />
+                    {t(
+                      isAttachmentApplicable && isAttachedClient
+                        ? "detail.configuration.reapply"
+                        : "detail.configuration.apply",
+                      {
+                        defaultValue:
+                          isAttachmentApplicable && isAttachedClient
+                            ? "Re-Apply"
+                            : "Apply",
+                      },
+                    )}
+                  </Button>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <div className="grid grid-cols-10 gap-8">
+                    {/* Left side - Mode and Source (4/10) */}
+                    <div className="col-span-4 space-y-6">
+                      {/* Mode Selection */}
+                      <div className="space-y-3">
+                        <div className="space-y-1">
+                          <h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                            {t("detail.configuration.sections.mode.title", {
+                              defaultValue: "1. Management Mode",
+                            })}
+                          </h4>
+                          <p className="text-xs text-slate-500 leading-relaxed">
+                            {mode === "hosted" &&
+                              t(
+                                "detail.configuration.sections.mode.descriptions.hosted",
+                                {
+                                  defaultValue:
+                                    "Hosted keeps a durable managed configuration for this client and remembers the selected working state.",
+                                },
+                              )}
+                            {mode === "unify" &&
+                              t(
+                                "detail.configuration.sections.mode.descriptions.unify",
+                                {
+                                  defaultValue:
+                                    "Unify starts with builtin control-plane tools only and keeps its workspace inside the current MCP session.",
+                                },
+                              )}
+                            {mode === "transparent" &&
+                              t(
+                                "detail.configuration.sections.mode.descriptions.transparent",
+                                {
+                                  defaultValue:
+                                    "MCPMate writes the selected profile servers directly into this client's MCP configuration and does not preserve capability-level controls.",
+                                },
+                              )}
+                          </p>
+                        </div>
+                        <Segment
+                          value={mode}
+                          onValueChange={(v) => setMode(v as ClientConfigMode)}
+                          options={managementModeSegmentOptions}
+                          showDots={true}
+                          className="w-full"
+                        />
+                      </div>
+
+                      {/* Source Selection */}
+                      <div className="space-y-3">
+                        <div className="space-y-1">
+                          <h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                            {t("detail.configuration.sections.source.title", {
+                              defaultValue: "2. Configuration",
+                            })}
+                          </h4>
+                          <p className="text-xs text-slate-500 leading-relaxed">
+                            {mode === "unify" &&
+                              unifyRouteMode === "broker_only" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.unify_broker_only",
+                                {
+                                  defaultValue:
+                                    "All capabilities are kept behind the UCAN broker catalog. Builtin MCP tools will browse and call capabilities from globally enabled servers.",
+                                },
+                              )}
+                            {mode === "unify" &&
+                              unifyRouteMode === "server_level" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.unify_server_level",
+                                {
+                                  defaultValue:
+                                    "Directly expose all capabilities from selected eligible servers to this client. Exposed capabilities are excluded from the UCAN catalog.",
+                                },
+                              )}
+                            {mode === "unify" &&
+                              unifyRouteMode === "capability_level" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.unify_capability_level",
+                                {
+                                  defaultValue:
+                                    "Directly expose only selected capabilities (tools, prompts, resources, templates) from eligible servers to this client. (Advanced)",
+                                },
+                              )}
+                            {mode === "transparent" &&
+                              selectedConfig === "default" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.transparentDefault",
+                                {
+                                  defaultValue:
+                                    "Write the servers from all currently activated profiles directly into this client's MCP configuration.",
+                                },
+                              )}
+                            {mode === "transparent" &&
+                              selectedConfig === "profile" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.transparentProfile",
+                                {
+                                  defaultValue:
+                                    "Write the servers from the selected shared profiles directly into this client's MCP configuration.",
+                                },
+                              )}
+                            {mode === "transparent" &&
+                              selectedConfig === "custom" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.transparentCustom",
+                                {
+                                  defaultValue:
+                                    "Write the servers from the client-specific custom profile directly into this client's MCP configuration.",
+                                },
+                              )}
+                            {mode === "hosted" &&
+                              selectedConfig === "default" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.default",
+                                {
+                                  defaultValue:
+                                    "Review the profiles that are currently active for this client runtime.",
+                                },
+                              )}
+                            {mode === "hosted" &&
+                              selectedConfig === "profile" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.profile",
+                                {
+                                  defaultValue:
+                                    "Browse the shared scene library and choose the exact working set for this client.",
+                                },
+                              )}
+                            {mode === "hosted" &&
+                              selectedConfig === "custom" &&
+                              t(
+                                "detail.configuration.sections.source.descriptions.custom",
+                                {
+                                  defaultValue:
+                                    "Create client-specific adjustments on top of the current unify-mode working state.",
+                                },
+                              )}
+                          </p>
+                        </div>
+                        {mode === "unify" ? (
+                          <Segment
+                            value={unifyRouteMode}
+                            onValueChange={(v) => {
+                              setHasUnifyDraftChanges(true);
+                              setUnifyRouteMode(v as UnifyRouteMode);
+                            }}
+                            options={unifyRouteModeSegmentOptions}
+                            showDots={true}
+                            className="w-full"
+                          />
+                        ) : (
+                          <Segment
+                            value={selectedConfig}
+                            onValueChange={(v) =>
+                              setSelectedConfig(
+                                v as ClientCapabilitySourceSelection,
+                              )
+                            }
+                            options={configurationSourceSegmentOptions}
+                            showDots={true}
+                            className="w-full"
+                          />
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Right side - Profiles List (6/10) */}
+                    {(mode === "unify" ||
+                      mode === "hosted" ||
+                      mode === "transparent") && (
+                      <div className="col-span-6">
+                        <div className="mb-3">
+                          <h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                            {mode === "unify"
+                              ? t(
+                                  "detail.configuration.sections.exposure.title",
+                                  {
+                                    defaultValue: "3. Direct Exposure",
+                                  },
+                                )
+                              : t(
+                                  "detail.configuration.sections.profiles.title",
+                                  {
+                                    defaultValue: "3. Profiles",
+                                  },
+                                )}
+                          </h4>
+                          {mode === "unify" &&
+                            unifyRouteMode === "broker_only" && (
+                              <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                                {t(
+                                  "detail.configuration.sections.exposure.descriptions.broker_only",
+                                  {
+                                    defaultValue:
+                                      "All enabled MCP servers, including servers marked for direct exposure, remain reachable through the builtin UCAN tools in Broker Only mode.",
+                                  },
+                                )}
+                              </p>
+                            )}
+                          {mode === "unify" &&
+                            unifyRouteMode === "server_level" && (
+                              <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                                {t(
+                                  "detail.configuration.sections.exposure.descriptions.server_level",
+                                  {
+                                    defaultValue:
+                                      "Select the eligible servers whose tools, prompts, resources, and resource templates should be exposed directly to the client.",
+                                  },
+                                )}
+                              </p>
+                            )}
+                          {mode === "unify" &&
+                            unifyRouteMode === "capability_level" && (
+                              <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                                {t(
+                                  "detail.configuration.sections.exposure.descriptions.capability_level",
+                                  {
+                                    defaultValue:
+                                      "Toggle each eligible server on the left, then use the more button to configure direct exposure at capability level across tools, prompts, resources, and templates. (Advanced)",
+                                  },
+                                )}
+                              </p>
+                            )}
+                          {/* Dynamic description based on source */}
+                          {mode !== "unify" && selectedConfig === "default" && (
+                            <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                              {mode === "transparent"
+                                ? t(
+                                    "detail.configuration.sections.profiles.descriptions.transparentDefault",
+                                    {
+                                      defaultValue:
+                                        "Transparent mode will write the enabled servers from all currently activated profiles directly into this client's MCP configuration.",
+                                    },
+                                  )
+                                : t(
+                                    "detail.configuration.sections.profiles.descriptions.default",
+                                    {
+                                      defaultValue:
+                                        "Review the profiles that are already active for this client runtime. This view is read-only to keep the active scene set consistent.",
+                                    },
+                                  )}
+                            </p>
+                          )}
+                          {mode !== "unify" && selectedConfig === "profile" && (
+                            <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                              {mode === "transparent"
+                                ? t(
+                                    "detail.configuration.sections.profiles.descriptions.transparentProfile",
+                                    {
+                                      defaultValue:
+                                        "Select which shared profiles contribute enabled servers to this client's MCP configuration in transparent mode.",
+                                    },
+                                  )
+                                : t(
+                                    "detail.configuration.sections.profiles.descriptions.profile",
+                                    {
+                                      defaultValue:
+                                        "Choose the reusable shared profiles that define this client's working set.",
+                                    },
+                                  )}
+                            </p>
+                          )}
+                          {mode !== "unify" && selectedConfig === "custom" && (
+                            <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                              {mode === "transparent"
+                                ? t(
+                                    "detail.configuration.sections.profiles.descriptions.transparentCustom",
+                                    {
+                                      defaultValue:
+                                        "Transparent mode uses only the enabled servers from this client-specific custom profile when writing the MCP configuration.",
+                                    },
+                                  )
+                                : t(
+                                    "detail.configuration.sections.profiles.descriptions.custom",
+                                    {
+                                      defaultValue:
+                                        "Create and maintain client-specific overrides for the current working state.",
+                                    },
+                                  )}
+                            </p>
+                          )}
+                        </div>
+
+                        {loadingProfiles ? (
+                          <div className="space-y-2">
+                            {[1, 2, 3].map((i) => (
+                              <div
+                                key={i}
+                                className="h-12 bg-slate-200 dark:bg-slate-800 animate-pulse rounded"
+                              />
+                            ))}
+                          </div>
+                        ) : (
+                          <CapsuleStripeList>
+                            {mode === "unify" ? (
+                              unifyRouteMode === "broker_only" ? (
+                                <CapsuleStripeListItem className="items-start">
+                                  <div className="w-full text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+                                    {t(
+                                      "detail.configuration.sections.exposure.labels.ucanRoutingDescription",
+                                      {
+                                        defaultValue:
+                                          "In Broker Only mode, all enabled MCP servers — including servers marked for direct exposure — are still accessed through the UCAN catalog and call tools.",
+                                      },
+                                    )}
+                                  </div>
+                                </CapsuleStripeListItem>
+                              ) : eligibleServers.length > 0 ? (
+                                eligibleServers.map((server) => {
+                                  const isSelected =
+                                    unifySelectedServers.includes(server.id);
+                                  const toolSurfaces = getUnifyServerSurfaces(
+                                    effectiveCapabilityConfig
+                                      ?.unify_direct_exposure
+                                      ?.resolved_capabilities
+                                      ?.selected_tool_surfaces ?? [],
+                                    server.id,
+                                  );
+                                  const promptSurfaces = getUnifyServerSurfaces(
+                                    effectiveCapabilityConfig
+                                      ?.unify_direct_exposure
+                                      ?.resolved_capabilities
+                                      ?.selected_prompt_surfaces ?? [],
+                                    server.id,
+                                  );
+                                  const resourceSurfaces =
+                                    getUnifyServerSurfaces(
+                                      effectiveCapabilityConfig
+                                        ?.unify_direct_exposure
+                                        ?.resolved_capabilities
+                                        ?.selected_resource_surfaces ?? [],
+                                      server.id,
+                                    );
+                                  const templateSurfaces =
+                                    getUnifyServerSurfaces(
+                                      effectiveCapabilityConfig
+                                        ?.unify_direct_exposure
+                                        ?.resolved_capabilities
+                                        ?.selected_template_surfaces ?? [],
+                                      server.id,
+                                    );
+                                  const selectedCapabilityCount =
+                                    toolSurfaces.length +
+                                    promptSurfaces.length +
+                                    resourceSurfaces.length +
+                                    templateSurfaces.length;
+                                  const directPath =
+                                    getClientDirectCapabilitiesPath(
+                                      identifier,
+                                      server.id,
+                                    );
+                                  const isMixed = isUnifyServerMixedRouting(
+                                    unifyRouteMode,
+                                    toolSurfaces.length,
+                                    server.capabilities?.tools_count,
+                                  );
+                                  const showDirectSelection =
+                                    unifyRouteMode === "capability_level"
+                                      ? selectedCapabilityCount > 0
+                                      : isSelected;
+                                  const serverDescription =
+                                    server.meta?.description ||
+                                    t(
+                                      "detail.configuration.labels.noDescription",
+                                      {
+                                        defaultValue: "No description",
+                                      },
+                                    );
+
+                                  return (
+                                    <CapsuleStripeListItem
+                                      key={server.id}
+                                      interactive={true}
+                                      className={`group relative transition-colors ${showDirectSelection ? "bg-primary/10 ring-1 ring-primary/40" : ""}`}
+                                      onClick={() => {
+                                        if (
+                                          unifyRouteMode === "capability_level"
+                                        ) {
+                                          directExposureServerMutation.mutate({
+                                            server,
+                                            routeMode: "capability_level",
+                                          });
+                                        } else if (
+                                          unifyRouteMode === "server_level"
+                                        ) {
+                                          if (hasUnifyDraftChanges) {
+                                            setUnifySelectedServers((prev) =>
+                                              toggleSelectedServerIds(
+                                                prev,
+                                                server.id,
+                                              ),
+                                            );
+                                          } else {
+                                            directExposureServerMutation.mutate(
+                                              {
+                                                server,
+                                                routeMode: "server_level",
+                                              },
+                                            );
+                                          }
+                                        }
+                                      }}
+                                    >
+                                      <CapsuleStripeRowBody
+                                        lead={
+                                          <CapsuleStripeLeadCircle
+                                            variant="toggle"
+                                            selected={showDirectSelection}
+                                          />
+                                        }
+                                        trailing={
+                                          unifyRouteMode ===
+                                          "capability_level" ? (
+                                            <Button
+                                              variant="ghost"
+                                              size="icon"
+                                              className="h-8 w-8 text-slate-400 hover:text-slate-900 dark:hover:text-slate-100"
+                                              onClick={(e) => {
+                                                e.stopPropagation();
+                                                if (directPath) {
+                                                  navigate(directPath);
+                                                }
+                                              }}
+                                            >
+                                              <MoreVertical className="h-4 w-4" />
+                                            </Button>
+                                          ) : undefined
+                                        }
+                                      >
+                                        <div className="font-medium text-sm truncate">
+                                          {server.name}
+                                          {unifyRouteMode ===
+                                            "capability_level" &&
+                                            selectedCapabilityCount > 0 && (
+                                              <span className="ml-2 text-xs font-normal text-slate-500 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded-md">
+                                                {selectedCapabilityCount}{" "}
+                                                {t(
+                                                  "detail.configuration.labels.capabilitiesExposed",
+                                                  {
+                                                    defaultValue:
+                                                      "capabilities exposed",
+                                                  },
+                                                )}
+                                              </span>
+                                            )}
+                                        </div>
+                                        <div className="text-xs text-slate-500 truncate">
+                                          {serverDescription}
+                                        </div>
+                                        {renderUnifyEligibleServerCapabilitySummary(
+                                          server,
+                                          unifyRouteMode,
+                                          toolSurfaces.length,
+                                        )}
+                                        {isMixed && (
+                                          <div className="mt-1 flex items-center gap-1 text-[11px] font-medium text-amber-600 dark:text-amber-500">
+                                            <Info className="h-3 w-3" />
+                                            {t(
+                                              "detail.configuration.warnings.mixedRouting",
+                                              {
+                                                defaultValue:
+                                                  "Mixed routing: splitting stateful workflows may cause issues.",
+                                              },
+                                            )}
+                                          </div>
+                                        )}
+                                      </CapsuleStripeRowBody>
+                                    </CapsuleStripeListItem>
+                                  );
+                                })
+                              ) : (
+                                <CapsuleStripeListItem>
+                                  <div className="text-sm text-slate-500 py-4 text-center w-full">
+                                    {t(
+                                      "detail.configuration.sections.exposure.empty.no_eligible",
+                                      {
+                                        defaultValue:
+                                          "No eligible servers found. Enable Unify Direct Exposure on a server first.",
+                                      },
+                                    )}
+                                  </div>
+                                </CapsuleStripeListItem>
+                              )
+                            ) : selectedConfig === "default" ? (
+                              // Show active profiles for default source
+                              activeProfiles.length > 0 ? (
+                                activeProfiles.map((profile) => {
+                                  const capabilities = profileCapabilities.get(
+                                    profile.id,
+                                  );
+                                  return (
+                                    <CapsuleStripeListItem
+                                      key={profile.id}
+                                      className="cursor-default"
+                                    >
+                                      <CapsuleStripeRowBody
+                                        lead={
+                                          <CapsuleStripeLeadCircle variant="readOnlyActive" />
+                                        }
+                                        trailing={getConfigurationProfileTokenSlot(
+                                          profile,
+                                          false,
+                                        )}
+                                      >
+                                        <div className="font-medium text-sm truncate">
+                                          {profile.name}
+                                        </div>
+                                        <div className="text-xs text-slate-500 truncate">
+                                          {profile.description ||
+                                            t(
+                                              "detail.configuration.labels.noDescription",
+                                              {
+                                                defaultValue: "No description",
+                                              },
+                                            )}
+                                        </div>
+                                        {capabilities &&
+                                          renderProfileCapabilitySummary(
+                                            capabilities,
+                                          )}
+                                      </CapsuleStripeRowBody>
+                                    </CapsuleStripeListItem>
+                                  );
+                                })
+                              ) : (
+                                <CapsuleStripeListItem>
+                                  <div className="text-sm text-slate-500 py-4 text-center w-full">
+                                    {t(
+                                      "detail.configuration.sections.profiles.empty.active",
+                                      {
+                                        defaultValue:
+                                          "No active profiles found",
+                                      },
+                                    )}
+                                  </div>
+                                </CapsuleStripeListItem>
+                              )
+                            ) : selectedConfig === "profile" ? (
+                              // Show shared profiles for profile source
+                              sharedProfiles.length > 0 ? (
+                                sharedProfiles.map((profile) => {
+                                  const capabilities = profileCapabilities.get(
+                                    profile.id,
+                                  );
+                                  const isSelected = selectedProfiles.includes(
+                                    profile.id,
+                                  );
+                                  return (
+                                    <CapsuleStripeListItem
+                                      key={profile.id}
+                                      interactive={
+                                        unifyRouteMode !== "broker_only"
+                                      }
+                                      className={`group relative transition-colors ${
+                                        isSelected
+                                          ? "bg-primary/10 ring-1 ring-primary/40"
+                                          : ""
+                                      }`}
+                                      onClick={() => {
+                                        setSelectedProfiles((prev) =>
+                                          prev.includes(profile.id)
+                                            ? prev.filter(
+                                                (id) => id !== profile.id,
+                                              )
+                                            : [...prev, profile.id],
+                                        );
+                                      }}
+                                    >
+                                      <CapsuleStripeRowBody
+                                        lead={
+                                          <CapsuleStripeLeadCircle
+                                            variant="toggle"
+                                            selected={isSelected}
+                                          />
+                                        }
+                                        trailing={getConfigurationProfileTokenSlot(
+                                          profile,
+                                          true,
+                                        )}
+                                      >
+                                        <div className="font-medium text-sm truncate">
+                                          {profile.name}
+                                        </div>
+                                        <div className="text-xs text-slate-500 truncate">
+                                          {profile.description ||
+                                            t(
+                                              "detail.configuration.labels.noDescription",
+                                              {
+                                                defaultValue: "No description",
+                                              },
+                                            )}
+                                        </div>
+                                        {capabilities &&
+                                          renderProfileCapabilitySummary(
+                                            capabilities,
+                                          )}
+                                      </CapsuleStripeRowBody>
+                                    </CapsuleStripeListItem>
+                                  );
+                                })
+                              ) : (
+                                <CapsuleStripeListItem>
+                                  <div className="text-sm text-slate-500 py-4 text-center w-full">
+                                    {t(
+                                      "detail.configuration.sections.profiles.empty.shared",
+                                      {
+                                        defaultValue:
+                                          "No shared profiles found",
+                                      },
+                                    )}
+                                  </div>
+                                </CapsuleStripeListItem>
+                              )
+                            ) : null}
+
+                            {mode !== "unify" && (
+                              <CapsuleStripeListItem
+                                interactive
+                                className={
+                                  selectedConfig === "custom" && customProfileId
+                                    ? "border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500"
+                                    : "border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500"
+                                }
+                                onClick={() => {
+                                  if (selectedConfig === "custom") {
+                                    if (customProfileId) {
+                                      navigate(
+                                        `/profiles/${customProfileId}?mode=custom`,
+                                      );
+                                    } else {
+                                      applyMutation.mutate({ preview: false });
+                                    }
+                                  } else {
+                                    navigate("/profiles");
+                                  }
+                                }}
+                              >
+                                <CapsuleStripeRowBody
+                                  lead={
+                                    <CapsuleStripeLeadCircle
+                                      variant="ghost"
+                                      hasProfile={
+                                        selectedConfig === "custom" &&
+                                        !!customProfileId
+                                      }
+                                    />
+                                  }
+                                >
+                                  <div className="font-medium text-sm truncate text-slate-700 dark:text-slate-300">
+                                    {selectedConfig === "custom"
+                                      ? t(
+                                          "detail.configuration.sections.profiles.ghost.titleCustom",
+                                          {
+                                            defaultValue: customProfileId
+                                              ? "Customize current state"
+                                              : "Create custom workspace",
+                                          },
+                                        )
+                                      : t(
+                                          "detail.configuration.sections.profiles.ghost.titleDefault",
+                                          {
+                                            defaultValue:
+                                              "Open profiles library",
+                                          },
+                                        )}
+                                  </div>
+                                  <div className="text-xs text-slate-400 dark:text-slate-600 truncate">
+                                    {selectedConfig === "custom"
+                                      ? t(
+                                          mode === "transparent"
+                                            ? "detail.configuration.sections.profiles.ghost.subtitleCustomTransparent"
+                                            : "detail.configuration.sections.profiles.ghost.subtitleCustom",
+                                          {
+                                            defaultValue: customProfileId
+                                              ? "Adjust client-specific capabilities on top of the current workspace"
+                                              : "Create client-specific overrides for this workspace",
+                                          },
+                                        )
+                                      : t(
+                                          "detail.configuration.sections.profiles.ghost.subtitleDefault",
+                                          {
+                                            defaultValue:
+                                              "Browse reusable shared scenes and edit them from the profiles page",
+                                          },
+                                        )}
+                                  </div>
+                                  {customProfileCapabilities
+                                    ? renderProfileCapabilitySummary(
+                                        customProfileCapabilities,
+                                      )
+                                    : null}
+                                </CapsuleStripeRowBody>
+                              </CapsuleStripeListItem>
+                            )}
+                          </CapsuleStripeList>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent
+          value="backups"
+          className="mt-0 flex min-h-0 flex-1 flex-col overflow-y-auto data-[state=inactive]:hidden"
+        >
+          <Card>
+            <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle>
+                  {t("detail.backups.title", { defaultValue: "Backups" })}
+                </CardTitle>
+                <CardDescription>
+                  {t("detail.backups.description", {
+                    defaultValue: "Restore or delete configuration snapshots.",
+                  })}
+                </CardDescription>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => refetchBackups()}
+                  disabled={loadingBackups}
+                >
+                  <RefreshCw
+                    className={`mr-2 h-4 w-4 ${loadingBackups ? "animate-spin" : ""}`}
+                  />
+                  {t("detail.backups.buttons.refresh", {
+                    defaultValue: "Refresh",
+                  })}
+                </Button>
+                {!loadingBackups && visibleBackups.length > 0 && (
+                  <ButtonGroup>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        setSelectedBackups(visibleBackups.map((b) => b.backup))
+                      }
+                    >
+                      {t("detail.backups.buttons.selectAll", {
+                        defaultValue: "Select all",
+                      })}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setSelectedBackups([])}
+                    >
+                      {t("detail.backups.buttons.clear", {
+                        defaultValue: "Clear",
+                      })}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      disabled={
+                        bulkDeleteMutation.isPending ||
+                        selectedBackups.length === 0
+                      }
+                      onClick={() => setBulkConfirmOpen(true)}
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      {t("detail.backups.buttons.deleteSelected", {
+                        defaultValue: "Delete selected ({{count}})",
+                        count: selectedBackups.length,
+                      })}
+                    </Button>
+                  </ButtonGroup>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-0">
+              {loadingBackups ? (
+                <div className="space-y-2">
+                  {[1, 2, 3].map((i) => (
+                    <div
+                      key={i}
+                      className="h-10 bg-slate-200 dark:bg-slate-800 animate-pulse rounded"
+                    />
+                  ))}
+                </div>
+              ) : visibleBackups.length ? (
+                <CapsuleStripeList>
+                  {visibleBackups.map((b) => {
+                    const selected = selectedBackups.includes(b.backup);
+                    return (
+                      <CapsuleStripeListItem
+                        key={b.path}
+                        interactive
+                        className={`group relative transition-colors ${selected ? "bg-primary/10 ring-1 ring-primary/40" : ""}`}
+                        onClick={() =>
+                          setSelectedBackups((prev) =>
+                            prev.includes(b.backup)
+                              ? prev.filter((x) => x !== b.backup)
+                              : [...prev, b.backup],
+                          )
+                        }
+                      >
+                        <div className="flex items-center justify-between flex-1">
+                          <div className="flex items-center gap-3">
+                            <div
+                              className={`flex h-6 w-6 items-center justify-center rounded-full border text-[0px] transition-all duration-200 ${
+                                selected
+                                  ? "border-primary bg-primary text-white shadow-sm"
+                                  : "border-slate-300 text-transparent group-hover:border-primary/50 group-hover:text-primary/60 dark:border-slate-700 dark:group-hover:border-primary/50"
+                              }`}
+                            >
+                              <Check className="h-3 w-3" />
+                            </div>
+                            <div
+                              className={`font-mono transition-colors duration-200 ${
+                                selected
+                                  ? "text-primary"
+                                  : "text-slate-700 dark:text-slate-200"
+                              }`}
+                            >
+                              {b.backup}
+                            </div>
+                          </div>
+                          <div className="flex items-center justify-end gap-4">
+                            <div
+                              className={`flex items-center gap-4 text-slate-500 transition-all duration-200 ${
+                                selected ? "text-primary" : ""
+                              }`}
+                            >
+                              <div>{formatBackupTime(b.created_at)}</div>
+                              <div>{(b.size / 1024).toFixed(1)} KB</div>
+                            </div>
+                            <div className="flex items-center gap-2 overflow-hidden transition-all duration-200 opacity-0 max-w-0 pointer-events-none group-hover:max-w-[12rem] group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:max-w-[12rem] group-focus-within:opacity-100 group-focus-within:pointer-events-auto">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setConfirm({
+                                    kind: "restore",
+                                    backup: b.backup,
+                                  });
+                                }}
+                              >
+                                <RotateCcw className="mr-2 h-4 w-4" />
+                                {t("detail.backups.buttons.restore", {
+                                  defaultValue: "Restore",
+                                })}
+                              </Button>
+                              <Button
+                                size="icon"
+                                variant="outline"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setConfirm({
+                                    kind: "delete",
+                                    backup: b.backup,
+                                  });
+                                }}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </div>
+                        </div>
+                      </CapsuleStripeListItem>
+                    );
+                  })}
+                </CapsuleStripeList>
+              ) : (
+                <div className="text-slate-500 text-sm">
+                  {backupsDisabledByPolicy
+                    ? t("detail.backups.emptyDisabledByPolicy", {
+                        defaultValue:
+                          "Backups are currently disabled by system policy.",
+                      })
+                    : t("detail.backups.empty", {
+                        defaultValue: "No backups.",
+                      })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      <ConfirmDialog
+        isOpen={!!confirm}
+        onClose={() => setConfirm(null)}
+        title={
+          confirm?.kind === "delete"
+            ? t("detail.confirm.deleteTitle", { defaultValue: "Delete Backup" })
+            : t("detail.confirm.restoreTitle", {
+                defaultValue: "Restore Backup",
+              })
+        }
+        description={
+          confirm?.kind === "delete"
+            ? t("detail.confirm.deleteDescription", {
+                defaultValue:
+                  "Are you sure you want to delete this backup? This action cannot be undone.",
+              })
+            : t("detail.confirm.restoreDescription", {
+                defaultValue:
+                  "Restore the local client configuration file from the selected backup? MCPMate management mode and capability settings stay unchanged.",
+              })
+        }
+        confirmLabel={
+          confirm?.kind === "delete"
+            ? t("detail.confirm.deleteLabel", { defaultValue: "Delete" })
+            : t("detail.confirm.restoreLabel", { defaultValue: "Restore" })
+        }
+        cancelLabel={t("detail.confirm.cancelLabel", {
+          defaultValue: "Cancel",
+        })}
+        variant={confirm?.kind === "delete" ? "destructive" : "default"}
+        isLoading={deleteBackupMutation.isPending || restoreMutation.isPending}
+        onConfirm={async () => {
+          if (!confirm) return;
+          if (confirm.kind === "delete") {
+            await deleteBackupMutation.mutateAsync({ backup: confirm.backup });
+          } else {
+            await restoreMutation.mutateAsync({ backup: confirm.backup });
+          }
+          setConfirm(null);
+        }}
+      />
+
+      <ConfirmDialog
+        isOpen={attachmentActionConfirm !== null}
+        onClose={() => setAttachmentActionConfirm(null)}
+        title={
+          attachmentActionConfirm === "attach"
+            ? t("detail.confirm.attachTitle", {
+                defaultValue: "Attach MCPMate to this client configuration?",
+              })
+            : t("detail.confirm.detachTitle", {
+                defaultValue: "Detach MCPMate from this client configuration?",
+              })
+        }
+        description={
+          attachmentActionConfirm === "attach"
+            ? t("detail.confirm.attachDescription", {
+                defaultValue:
+                  "This writes the MCPMate server entry back into the client configuration file. The client's MCP session may restart or reconnect; confirm before continuing.",
+              })
+            : t("detail.confirm.detachDescription", {
+                defaultValue:
+                  "This removes the MCPMate server entry from the client configuration file. Running MCP connections for that client may break until you attach again; confirm before continuing.",
+              })
+        }
+        confirmLabel={
+          attachmentActionConfirm === "attach"
+            ? t("detail.confirm.attachLabel", { defaultValue: "Attach" })
+            : t("detail.confirm.detachLabel", { defaultValue: "Detach" })
+        }
+        cancelLabel={t("detail.confirm.cancelLabel", {
+          defaultValue: "Cancel",
+        })}
+        variant="default"
+        isLoading={detachMutation.isPending || attachMutation.isPending}
+        onConfirm={async () => {
+          if (!attachmentActionConfirm || !identifier) return;
+          if (attachmentActionConfirm === "detach") {
+            await detachMutation.mutateAsync();
+          } else {
+            await attachMutation.mutateAsync();
+          }
+          setAttachmentActionConfirm(null);
+        }}
+      />
+
+      {/* Bulk delete confirmation */}
+      <ConfirmDialog
+        isOpen={bulkConfirmOpen}
+        onClose={() => setBulkConfirmOpen(false)}
+        title={t("detail.backups.bulk.title", {
+          defaultValue: "Delete Selected Backups",
+        })}
+        description={t("detail.backups.bulk.description", {
+          defaultValue:
+            "Are you sure you want to delete {{count}} backup(s)? This action cannot be undone.",
+          count: selectedBackups.length,
+        })}
+        confirmLabel={t("detail.confirm.deleteLabel", {
+          defaultValue: "Delete",
+        })}
+        cancelLabel={t("detail.confirm.cancelLabel", {
+          defaultValue: "Cancel",
+        })}
+        variant="destructive"
+        isLoading={bulkDeleteMutation.isPending}
+        onConfirm={() => bulkDeleteMutation.mutate()}
+      />
+
+      {/* Backup Policy Drawer */}
+      <Drawer open={policyOpen} onOpenChange={setPolicyOpen}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>
+              {t("detail.policy.title", { defaultValue: "Backup Policy" })}
+            </DrawerTitle>
+          </DrawerHeader>
+          <div className="p-4 space-y-4">
+            <div className="space-y-1">
+              <Label>
+                {t("detail.policy.fields.policy", { defaultValue: "Policy" })}
+              </Label>
+              <p className="text-xs text-slate-500">
+                {t("detail.policy.fields.policyDescription", {
+                  defaultValue:
+                    'Backup retention strategy. For now, only "keep_n" is supported, which keeps at most N recent backups and prunes older ones.',
+                })}
+              </p>
+              <Select value={policyLabel} onValueChange={setPolicyLabel}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="keep_n">
+                    {t("detail.policy.fields.options.keepN", {
+                      defaultValue: "keep_n",
+                    })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor={limitId}>
+                {t("detail.policy.fields.limit", { defaultValue: "Limit" })}
+              </Label>
+              <p className="text-xs text-slate-500">
+                {t("detail.policy.fields.limitDescription", {
+                  defaultValue:
+                    "Maximum number of backups to keep for this client. Set to 0 for no limit.",
+                })}
+              </p>
+              <Input
+                id={limitId}
+                type="number"
+                min={0}
+                value={policyLimit ?? 0}
+                onChange={(e) => setPolicyLimit(Number(e.target.value))}
+              />
+            </div>
+            <div>
+              <Button
+                onClick={() => {
+                  if (!identifier) return;
+                  setPolicyMutation.mutate({
+                    identifier,
+                    policy: { policy: policyLabel, limit: policyLimit },
+                  });
+                }}
+                disabled={setPolicyMutation.isPending}
+              >
+                {t("detail.policy.buttons.save", {
+                  defaultValue: "Save Policy",
+                })}
+              </Button>
+            </div>
+          </div>
+          <DrawerFooter />
+        </DrawerContent>
+      </Drawer>
+
+      {/* Import Preview Drawer */}
+      <Drawer open={importPreviewOpen} onOpenChange={setImportPreviewOpen}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>
+              {t("detail.importPreview.title", {
+                defaultValue: "Import Preview",
+              })}
+            </DrawerTitle>
+            <DrawerDescription>
+              {t("detail.importPreview.description", {
+                defaultValue:
+                  "Summary of servers detected from current client config.",
+              })}
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="p-4 text-sm flex flex-col gap-4 max-h-[70vh]">
+            {importPreviewMutation.isPending ? (
+              <div className="h-16 bg-slate-200 dark:bg-slate-800 animate-pulse rounded" />
+            ) : importPreviewData ? (
+              <div className="flex-1 min-h-0 flex flex-col gap-4">
+                <div className="grid grid-cols-[120px_1fr] gap-y-2 gap-x-4 text-sm leading-6">
+                  <div className="text-slate-500">
+                    {t("detail.importPreview.fields.attempted", {
+                      defaultValue: "Attempted",
+                    })}
+                  </div>
+                  <div>
+                    {typeof importPreviewData.summary?.attempted === "boolean"
+                      ? importPreviewData.summary.attempted
+                        ? t("states.yes", { defaultValue: "Yes" })
+                        : t("states.no", { defaultValue: "No" })
+                      : "-"}
+                  </div>
+                  <div className="text-slate-500">
+                    {t("detail.importPreview.fields.imported", {
+                      defaultValue: "Imported",
+                    })}
+                  </div>
+                  <div>{importPreviewData.summary?.imported_count ?? 0}</div>
+                  <div className="text-slate-500">
+                    {t("detail.importPreview.fields.skipped", {
+                      defaultValue: "Skipped",
+                    })}
+                  </div>
+                  <div>{importPreviewData.summary?.skipped_count ?? 0}</div>
+                  <div className="text-slate-500">
+                    {t("detail.importPreview.fields.failed", {
+                      defaultValue: "Failed",
+                    })}
+                  </div>
+                  <div>{importPreviewData.summary?.failed_count ?? 0}</div>
+                </div>
+                {Array.isArray(importPreviewData.items) &&
+                importPreviewData.items.length > 0 ? (
+                  <div className="rounded border">
+                    <div className="px-3 py-2 text-xs text-slate-500 border-b">
+                      {t("detail.importPreview.sections.servers", {
+                        defaultValue: "Servers to import",
+                      })}
+                    </div>
+                    <ul className="divide-y max-h-[30vh] overflow-auto">
+                      {importPreviewData.items.map((it, idx: number) => (
+                        <li
+                          key={`import-item-${idx}-${it.name || it.server_name || "unnamed"}`}
+                          className="p-3 text-xs"
+                        >
+                          <div className="font-medium">
+                            {it.name || it.server_name || `#${idx + 1}`}
+                          </div>
+                          {it.error ? (
+                            <div className="text-red-500">
+                              {String(it.error)}
+                            </div>
+                          ) : null}
+                          <div className="mt-1 text-slate-500">
+                            {t("detail.importPreview.sections.stats", {
+                              defaultValue:
+                                "tools: {{tools}} • resources: {{resources}} • templates: {{templates}} • prompts: {{prompts}}",
+                              tools: it.tools?.items?.length ?? 0,
+                              resources: it.resources?.items?.length ?? 0,
+                              templates:
+                                it.resource_templates?.items?.length ?? 0,
+                              prompts: it.prompts?.items?.length ?? 0,
+                            })}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                {importPreviewData.summary?.errors ? (
+                  <details>
+                    <summary className="text-xs text-slate-500 cursor-pointer">
+                      {t("detail.importPreview.sections.errors", {
+                        defaultValue: "Errors",
+                      })}
+                    </summary>
+                    <pre className="text-xs bg-slate-50 dark:bg-slate-900 p-2 rounded overflow-auto max-h-[26vh]">
+                      {JSON.stringify(
+                        importPreviewData.summary.errors,
+                        null,
+                        2,
+                      )}
+                    </pre>
+                  </details>
+                ) : null}
+                {(importPreviewData.summary?.skipped_count ?? 0) > 0 &&
+                importPreviewData.summary?.skipped_servers?.length ? (
+                  <details className="mt-2">
+                    <summary className="text-xs text-slate-500 cursor-pointer">
+                      {importPreviewData.summary.skipped_count === 1
+                        ? t(
+                            "detail.importPreview.sections.skippedDetailsSingle",
+                            {
+                              defaultValue: "Skip details ({{count}} server)",
+                              count: importPreviewData.summary.skipped_count,
+                            },
+                          )
+                        : t(
+                            "detail.importPreview.sections.skippedDetailsPlural",
+                            {
+                              defaultValue: "Skip details ({{count}} servers)",
+                              count: importPreviewData.summary.skipped_count,
+                            },
+                          )}
+                    </summary>
+                    <ul className="mt-2 space-y-2">
+                      {importPreviewData.summary.skipped_servers.map(
+                        (s, idx) => {
+                          const reasonLabel = getSkippedReasonLabel(s.reason, t);
+                          const existingQueryLabel =
+                            getSkippedQueryFieldLabel("existing", t);
+                          const incomingQueryLabel =
+                            getSkippedQueryFieldLabel("incoming", t);
+                          return (
+                            <li
+                              key={`skipped-${idx}-${s.name}`}
+                              className="text-xs p-2 bg-slate-50 dark:bg-slate-900 rounded"
+                            >
+                              <span className="font-medium">{s.name}</span>
+                              <span className="text-slate-500 ml-2">
+                                &mdash;{" "}
+                                {reasonLabel}
+                              </span>
+                              {s.existing_query && (
+                                <div className="mt-1 text-slate-400 overflow-x-auto break-all">
+                                  {existingQueryLabel}
+                                  : {s.existing_query}
+                                </div>
+                              )}
+                              {s.incoming_query && (
+                                <div className="mt-1 text-slate-400 overflow-x-auto break-all">
+                                  {incomingQueryLabel}
+                                  : {s.incoming_query}
+                                </div>
+                              )}
+                            </li>
+                          );
+                        },
+                      )}
+                    </ul>
+                  </details>
+                ) : null}
+                <details className="mt-2 flex-1 min-h-0">
+                  <summary className="text-xs text-slate-500 cursor-pointer">
+                    {t("detail.importPreview.sections.raw", {
+                      defaultValue: "Raw preview JSON",
+                    })}
+                  </summary>
+                  <pre className="text-xs bg-slate-50 dark:bg-slate-900 p-2 rounded overflow-auto flex-1 min-h-0 max-h-[40vh]">
+                    {JSON.stringify(importPreviewData, null, 2)}
+                  </pre>
+                </details>
+              </div>
+            ) : (
+              <div className="text-slate-500">
+                {t("detail.importPreview.noPreview", {
+                  defaultValue: "No preview data.",
+                })}
+              </div>
+            )}
+          </div>
+          <DrawerFooter>
+            <div className="flex w-full items-center justify-between">
+              <Button
+                variant="outline"
+                onClick={() => setImportPreviewOpen(false)}
+              >
+                {t("detail.importPreview.buttons.close", {
+                  defaultValue: "Close",
+                })}
+              </Button>
+              {importPreviewData ? (
+                (importPreviewData?.summary?.imported_count ?? 0) > 0 ? (
+                  <Button
+                    onClick={() => importMutation.mutate()}
+                    disabled={importMutation.isPending}
+                  >
+                    {t("detail.importPreview.buttons.apply", {
+                      defaultValue: "Apply Import",
+                    })}
+                  </Button>
+                ) : (
+                  <div className="text-xs text-slate-500">
+                    {t("detail.importPreview.states.noImportNeeded", {
+                      defaultValue: "No import needed",
+                    })}
+                  </div>
+                )
+              ) : (
+                <Button
+                  onClick={() => importPreviewMutation.mutate()}
+                  disabled={importPreviewMutation.isPending}
+                >
+                  {t("detail.importPreview.buttons.preview", {
+                    defaultValue: "Preview",
+                  })}
+                </Button>
+              )}
+            </div>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+      <ClientFormDrawer
+        open={isClientFormOpen}
+        onOpenChange={setIsClientFormOpen}
+        mode="edit"
+        client={(currentClient as ClientInfo | undefined) ?? null}
+        onSuccess={() => {
+          void refetchDetails();
+          qc.invalidateQueries({ queryKey: ["clients"] });
+        }}
+        onDeleteSuccess={() => {
+          navigate("/clients");
+        }}
+      />
+    </div>
+  );
 }
 
 export default ClientDetailPage;

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -3350,6 +3350,43 @@ export function ClientDetailPage() {
 										</pre>
 									</details>
 								) : null}
+								{(importPreviewData.summary?.skipped_count ?? 0) > 0 &&
+								importPreviewData.summary?.skipped_servers?.length ? (
+									<details className="mt-2">
+										<summary className="text-xs text-slate-500 cursor-pointer">
+											{t("detail.importPreview.sections.skippedDetails", {
+												defaultValue:
+													"Skip details ({{count}} servers)",
+												count: importPreviewData.summary.skipped_count,
+											})}
+										</summary>
+										<ul className="mt-2 space-y-2">
+											{importPreviewData.summary.skipped_servers.map(
+												(s, idx) => (
+													<li
+														key={`skipped-${idx}-${s.name}`}
+														className="text-xs p-2 bg-slate-50 dark:bg-slate-900 rounded"
+													>
+														<span className="font-medium">{s.name}</span>
+														<span className="text-slate-500 ml-2">
+															&mdash; {s.reason}
+														</span>
+														{s.existing_query && (
+															<div className="mt-1 text-slate-400">
+																existing query: {s.existing_query}
+															</div>
+														)}
+														{s.incoming_query && (
+															<div className="mt-1 text-slate-400">
+																incoming query: {s.incoming_query}
+															</div>
+														)}
+													</li>
+												),
+											)}
+										</ul>
+									</details>
+								) : null}
 								<details className="mt-2 flex-1 min-h-0">
 									<summary className="text-xs text-slate-500 cursor-pointer">
 										{t("detail.importPreview.sections.raw", {

--- a/board/src/pages/clients/i18n/index.ts
+++ b/board/src/pages/clients/i18n/index.ts
@@ -1,2272 +1,2475 @@
 export const clientsTranslations = {
-    en: {
-        title: "Discover and manage client connections and visibility",
-		toolbar: {
-			search: {
-				placeholder: "Search clients...",
-				fields: {
-					displayName: "Display Name",
-					identifier: "Identifier",
-					description: "Description",
-				},
-			},
-			filters: {
-				title: "Filter",
-				options: {
-					all: "All",
-					allowed: "Allowed",
-					pending: "Pending",
-					denied: "Denied",
-				},
-			},
-			sort: {
-				options: {
-					displayName: "Name",
-					approvalStatus: "Governance Status",
-					managed: "Management Status",
-				},
-			},
-			actions: {
-				refresh: {
-					title: "Refresh",
-					notificationTitle: "Refresh triggered",
-					notificationMessage: "Latest client state will sync to the list",
-				},
-				add: {
-					title: "Add Client",
-					notificationTitle: "Feature in Development",
-					notificationMessage:
-						"This feature is being implemented, please stay tuned",
-				},
-			},
-		},
-		statsCards: {
-			total: {
-				title: "Total Clients",
-				description: "discovered",
-			},
-			detected: {
-				title: "Detected",
-				description: "installed",
-			},
-			approved: {
-				title: "Approved",
-				description: "governance allowed",
-			},
-			pending: {
-				title: "Pending",
-				description: "awaiting review",
-			},
-		},
-		notifications: {
-			managementUpdated: {
-				title: "Updated",
-				message: "Client management state updated",
-			},
-			operationFailed: {
-				title: "Operation failed",
-			},
-		},
-		entity: {
-			fallbackName: "Client",
-			stats: {
-				config: "Config",
-				servers: "Servers",
-				managed: "Managed",
-				governance: "Governance",
-				detected: "Detected",
-				attachment: "Attachment",
-			},
-			config: {
-				notConfigured: "Not configured",
-			},
-			bottomTags: {
-				servers: "Servers: {{count}}",
-			},
-			status: {
-				detected: "Detected",
-				notDetected: "Not Detected",
-			},
-			badge: {
-				detected: "Detected",
-				notDetected: "Not Detected",
-				allowed: "Allowed",
-				pending: "Pending",
-				denied: "Denied",
-				defaultPolicy: "Default Policy",
-				explicitRecord: "Explicit Record",
-				writableConfig: "Writable",
-			},
-			attachment: {
-				attached: "Attached",
-				detached: "Detached",
-				notApplicable: "Config N/A",
-			},
-			tooltip: {
-				attachmentState: "Attachment: {{status}}",
-				attachmentUnavailable: "Attachment: N/A",
-				defaultPolicy: "Default policy: {{answer}}",
-				explicitRecord: "Explicit record: {{answer}}",
-				writableConfig: "Writable config: {{answer}}",
-			},
-		},
-		states: {
-			on: "On",
-			off: "Off",
-			yes: "Yes",
-			no: "No",
-			present: "Present",
-			missing: "Missing",
-		},
-		emptyState: {
-			title: "No clients found",
-			description:
-				"Make sure MCPMate backend is running and detection is enabled",
-		},
-		detail: {
-			noIdentifier: "No client identifier provided.",
-			badges: {
-				managed: "Managed",
-				unmanaged: "Unmanaged",
-			},
-			tabs: {
-				overview: "Overview",
-				configuration: "Configuration",
-				backups: "Backups",
-				logs: "Logs",
-			},
-			directExposure: {
-				title: "Capability Level",
-				badge: "Direct Exposure",
-				description:
-					"Adjust which capabilities from this server should be exposed directly to the current client.",
-				serverDescriptionFallback:
-					"Choose which capabilities from this server should be exposed directly to the client.",
-				toolsTitle: "Tools",
-				toolsSummary: "{{enabled}} / {{total}} capabilities exposed directly",
-				tabs: {
-					tools: "Tools",
-					prompts: "Prompts",
-					resources: "Resources",
-					templates: "Templates",
-					toolsWithCounts: "Tools ({{enabled}}/{{total}})",
-					promptsWithCounts: "Prompts ({{enabled}}/{{total}})",
-					resourcesWithCounts: "Resources ({{enabled}}/{{total}})",
-					templatesWithCounts: "Templates ({{enabled}}/{{total}})",
-				},
-				searchPlaceholders: {
-					tools: "Search tools...",
-					prompts: "Search prompts...",
-					resources: "Search resources...",
-					templates: "Search templates...",
-				},
-				empty: {
-					tools: "No tools found for this server.",
-					prompts: "No prompts found for this server.",
-					resources: "No resources found for this server.",
-					templates: "No templates found for this server.",
-				},
-				statusPlaceholder: "Status",
-				filters: {
-					status: {
-						all: "All",
-						enabled: "Enabled",
-						disabled: "Disabled",
-					},
-				},
-				buttons: {
-					selectAll: "Select all",
-					clearSelection: "Clear",
-					enable: "Enable",
-					disable: "Disable",
-				},
-				notifications: {
-					savedTitle: "Direct capabilities updated",
-					savedMessage: "The direct capability exposure settings have been updated.",
-					saveFailedTitle: "Unable to update direct capabilities",
-				},
-			},
-				overview: {
-					labels: {
-					configPath: "Config Path",
-					lastModified: "Last Modified",
-					supportedTransports: "Supported Transports",
-					homepage: "Homepage",
-					docs: "Docs",
-					support: "Support",
-				},
-				buttons: {
-					edit: "Edit",
-					refresh: "Refresh",
-					enable: "Enable",
-					disable: "Disable",
-					approve: "Approve",
-					reject: "Reject",
-					allow: "Allow",
-					deny: "Deny",
-					detach: "Detach",
-					attach: "Attach",
-				},
-				noDetails: "No details available",
-					currentServers: {
-						title: "Current Servers",
-						import: "Import from Config",
-						configuredLabel: "configured",
-						empty: "No servers extracted from current config.",
-					},
-				},
-				form: {
-					titleCreate: "Add Client Record",
-					titleEdit: "Edit Client Record",
-					descriptionCreate: "Create a client record with its management shape and metadata.",
-					descriptionEdit: "Update this client record and its management settings.",
-					tabs: { basic: "Basic", meta: "Meta" },
-					connectionShape: {
-						label: "Client Shape",
-						description:
-							"Choose whether this client has a writable local config file or is a non-writable remote/unknown client.",
-						options: {
-							localWithConfig: "Local + Config",
-							localWithoutConfig: "Local / Unknown Config",
-							remoteHttp: "Remote HTTP",
-						},
-					},
-					transportSupport: {
-						label: "Transport Support",
-						placeholder: "Select supported transports",
-						empty: "No transports found.",
-						description:
-							"Choose which runtime transports this client supports. This array is the only source used to constrain hosted/unify transport selection.",
-						validation: {
-							required: "Select at least one supported transport before saving.",
-						},
-						options: {
-							stdio: "STDIO",
-							streamableHttpLegacy: "Streamable HTTP",
-							sseLegacy: "SSE (Legacy)",
-						},
-					},
-					transportRules: {
-						label: "Transport Rules",
-						suggestedVariants: "Suggested variants",
-						empty: "Select at least one transport to edit its write rules.",
-						stdioDescription: "Define the field names used to write command-based MCP servers for this client.",
-						httpDescription: "Define the field names used to write URL-based MCP servers for this client.",
-						commandField: "Command Field",
-						argsField: "Args Field",
-						envField: "Env Field",
-						urlField: "URL Field",
-						headersField: "Headers Field",
-						includeType: "Include type field",
-						typeValue: "Type Value",
-						extraFields: "Extra Fields",
-						addExtraField: "Add field",
-						extraFieldKeyPlaceholder: "enabled",
-						extraFieldValuePlaceholder: 'true or "custom"',
-						presets: {
-							common: "Common",
-							withType: "With type",
-							zedStyle: "Zed-style",
-						},
-						help: {
-							summary: "These fields describe the target client's config keys, not MCPMate's own protocol fields.",
-							docs: "If you are unsure which keys a client expects, check that client's official documentation or an existing working config file first.",
-							presets: "Use the suggested variants below as a starting point, then verify the result against the client's real config structure.",
-							openDocs: "Open client documentation",
-						},
-						validation: {
-							commandRequired: "STDIO requires a command field.",
-							urlRequired: "HTTP-based transports require a URL field.",
-							typeValueRequired: "Type value is required when including the type field.",
-						},
-					},
-					fields: {
-						displayName: { label: "Client Name", placeholder: "Cursor Desktop" },
-						identifier: {
-							label: "Client ID",
-							placeholder: "cursor-desktop",
-							description:
-								"Spaces and casing are normalized automatically when creating a new record.",
-						},
-						clientVersion: { label: "Client Version", placeholder: "optional" },
-						configPath: {
-							label: "Config File Path",
-							placeholder: "~/.cursor/mcp.json",
-							description:
-								"A writable local config path enables MCPMate to manage this client through file-based configuration operations.",
-							browse: "Choose…",
-							browseAria: "Browse for configuration file on disk",
-							dialogTitle: "Select configuration file",
-							pickFailedTitle: "Unable to read selected file",
-							webPickInfoTitle: "Browser file access",
-							webPickInfoDescription:
-								"Your browser cannot read the absolute path automatically. Please paste it manually if needed.",
-						},
-						configFileParse: {
-							label: "Parse Rules",
-							formatLabel: "Config Format",
-							containerTypeLabel: "Container Type",
-							containerKeysLabel: "Config Nodes",
-							containerKeysPlaceholder: "mcpServers, context_servers",
-							showAdvanced: "Show details",
-							hideAdvanced: "Hide details",
-							validationTitle: "File association check",
-							validationSuccess: "The selected file matches the current parse rules.",
-							validationHint: "Pick a config file and MCPMate will validate whether these rules can find MCP server entries.",
-							detectedFormat: "Detected format",
-							containerMatch: "Container",
-							serverCount: "Servers",
-							matchYes: "Found",
-							matchNo: "Missing",
-							summaryViewButton: "Summary view",
-							codeViewButton: "Code preview",
-							keysRequired: "Add at least one config node path before saving parse rules.",
-							containerTypeOptions: {
-								standard: "Object Map",
-								array: "Array",
-							},
-							format: { label: "Format" },
-							containerType: { label: "Container Type" },
-							containerKeys: { label: "Container Keys (JSON Path)" },
-							validation: {
-								formatMatch: "Format matches",
-								formatMismatch: "Format mismatch",
-								containerFound: "Container found",
-								containerMissing: "Container missing",
-								serversDetected: "{{count}} server(s) detected",
-								noServers: "No servers detected",
-								checking: "Inspecting..."
-							},
-							preview: "Preview",
-							previewTitle: "Config Preview",
-							autoDetect: "Auto-Detect Rules",
-							applyDetected: "Apply Detected Rules"
-						},
-						formatRulesJsonText: {
-							label: "Format Rules (JSON)",
-							placeholder: "Paste JSON format rules here",
-							description: "Advanced: Fine-grained transport format rules as JSON. Leave empty to reset to defaults.",
-						},
-						logoUrl: { label: "Logo URL", placeholder: "https://example.com/logo.png" },
-						homepageUrl: { label: "Homepage URL", placeholder: "https://example.com" },
-						docsUrl: { label: "Docs URL", placeholder: "https://docs.example.com" },
-						supportUrl: { label: "Support URL", placeholder: "https://support.example.com" },
-						description: {
-							label: "Description",
-							placeholder: "A short summary of this client.",
-							description:
-								"These meta fields are stored for display and guidance; the old template files remain only as compatibility seeds.",
-						},
-					},
-					buttons: { cancel: "Cancel", create: "Create Record", save: "Save Changes", delete: "Delete" },
-					confirmDelete: {
-						title: "Delete Client Record",
-						description: "Are you sure you want to delete this client record? This action cannot be undone.",
-						confirm: "Delete",
-						cancel: "Cancel",
-					},
-					notifications: {
-						createSuccess: { title: "Client record created", message: "The client record has been created." },
-						editSuccess: { title: "Client record updated", message: "The client record has been updated." },
-						deleteSuccess: { title: "Client record deleted", message: "The client record has been deleted." },
-						createBackupPolicyFailed: {
-							message:
-								"Client record was created, but applying initial backup policy failed. You can retry in Backup settings.",
-						},
-						formatRulesJsonParseError: "Failed to parse format rules JSON. Please check the syntax and try again.",
-						saveFailed: { title: "Unable to save client record" },
-						deleteFailed: {
-							title: "Unable to delete client record",
-							messageMissingIdentifier: "Client identifier is missing.",
-						},
-					},
-				},
-				configuration: {
-				title: "Configuration Mode",
-				description:
-					"If you don't understand what this means, please don't make any changes and keep the current settings.",
-					warnings: {
-						mixedRouting: "Mixed routing: splitting stateful workflows may cause issues.",
-					},
-				errors: {
-					customProfileMissing:
-						"The client-specific custom workspace is missing. Create it again before applying configuration.",
-				},
-				writeTargetRequiredReason:
-					"Applying governance to the client configuration requires a verified writable local MCP config file.",
-				applyRequiresApprovedReason:
-					"Applying client configuration requires an approved governance state and a verified local config target.",
-				managementSettingsPendingReason:
-					"Save management settings after this client leaves pending approval.",
-				apply: "Apply",
-				reapply: "Re-apply",
-				sections: {
-					mode: {
-						title: "1. Management Mode",
-						descriptions: {
-						unify:
-							"Unify starts with builtin MCP tools only and works with capabilities from globally enabled servers during the current session.",
-							hosted:
-								"Hosted keeps a durable managed configuration for this client and remembers the selected working state.",
-							transparent:
-								"MCPMate writes the selected profile servers directly into this client's MCP configuration and does not preserve capability-level controls.",
-						},
-						managedDisabledReason:
-							"Hosted and Unify require at least one supported transport.",
-						transparentDisabledReason:
-							"Transparent requires a writable local config path.",
-						options: {
-						unify: "Unify",
-							hosted: "Hosted Mode",
-							transparent: "Transparent",
-						},
-					},
-					source: {
-						title: "2. Configuration",
-						titleTransparent: "2. Configuration",
-						unifyRouteModes: {
-							broker_only: "Broker Only",
-							server_level: "Server Level",
-							capability_level: "Capability Level",
-						},
-						descriptions: {
-						unify:
-							"Unify does not use dashboard profile selection. Use the builtin UCAN tools during the session to browse and call capabilities from globally enabled servers.",
-							unify_broker_only:
-								"All capabilities are kept behind the UCAN broker catalog. Builtin MCP tools will browse and call capabilities from globally enabled servers.",
-							unify_server_level:
-								"Directly expose all capabilities from selected eligible servers to this client. Exposed capabilities are excluded from the UCAN catalog.",
-							unify_capability_level:
-								"Directly expose only selected capabilities (tools, prompts, resources, templates) from eligible servers to this client. (Advanced)",
-							default: "Review the profiles that are currently active for this client runtime.",
-							profile: "Browse the shared scene library and choose the exact working set for this client.",
-						custom: "Create client-specific adjustments on top of the current unify-mode working state.",
-							transparentDefault:
-								"Write the servers from all currently activated profiles directly into this client's MCP configuration.",
-							transparentProfile:
-								"Write the servers from the selected shared profiles directly into this client's MCP configuration.",
-							transparentCustom:
-								"Write the servers from the client-specific custom profile directly into this client's MCP configuration.",
-						},
-					options: {
-						default: "Active",
-						profile: "Profiles",
-						custom: "Customized",
-					},
-						statusLabel: {
-							default: "",
-							profile: "",
-							custom: "",
-						},
-					},
-					profiles: {
-					title: "3. Profiles",
-						descriptions: {
-						unify:
-							"Unify does not maintain a profile working set here. Use profiles for Hosted Mode or Transparent Mode workflows instead.",
-							default:
-								"Review the profiles that are already active for this client runtime. This view is read-only to keep the active scene set consistent.",
-							profile:
-								"Choose the reusable shared profiles that define this client's working set.",
-							custom:
-								"Create and maintain client-specific overrides for the current working state.",
-							transparentDefault:
-								"Transparent mode will write the enabled servers from all currently activated profiles directly into this client's MCP configuration.",
-							transparentProfile:
-								"Select which shared profiles contribute enabled servers to this client's MCP configuration in transparent mode.",
-							transparentCustom:
-								"Transparent mode uses only the enabled servers from this client-specific custom profile when writing the MCP configuration.",
-						},
-						empty: {
-							active: "No active profiles found",
-							shared: "No shared profiles found",
-						},
-						ghost: {
-							titleCustom: "Customize current state",
-							titleDefault: "Open profiles library",
-							subtitleCustom: "Create and manage client-specific overrides for the current workspace",
-							subtitleCustomTransparent:
-								"Configure which servers should be written into this client directly.",
-							subtitleDefault: "Browse reusable shared scenes and edit them from the profiles page",
-						},
-					},
-					unify: {
-						title: "2. Configuration",
-						description:
-							"Unify starts with builtin MCP tools only. It uses session-local builtin tooling to browse capabilities from globally enabled servers and resets when the session ends.",
-						items: {
-							builtinOnly: "Builtin tools only",
-							sessionScoped: "Session-local builtin flow",
-							noFurtherSetup: "No further setup in the dashboard",
-						},
-					},
-					exposure: {
-						title: "3. Direct Exposure",
-						descriptions: {
-							broker_only:
-								"All enabled MCP servers, including servers marked for direct exposure, remain reachable through the builtin UCAN tools in Broker Only mode.",
-							server_level:
-								"Select the eligible servers whose tools, prompts, resources, and resource templates should be exposed directly to the client.",
-							capability_level:
-								"Select eligible servers and configure direct exposure at capability level across tools, prompts, resources, and templates. (Advanced)",
-						},
-						labels: {
-							ucanRoutingDescription:
-								"In Broker Only mode, all enabled MCP servers — including servers marked for direct exposure — are still accessed through the UCAN catalog and call tools.",
-						},
-						empty: {
-							no_eligible:
-								"No eligible servers found. Enable Unify Direct Exposure on a server first.",
-						},
-					},
-				},
-			labels: {
-				noDescription: "No description",
-				openProfileDetail: "Open profile details",
-				servers: "Servers",
-				tools: "Tools",
-				resources: "Resources",
-				prompts: "Prompts",
-				resourceTemplates: "Resource templates",
-				toolsExposed: "tools exposed",
-				capabilitiesExposed: "capabilities exposed",
-			},
-			nonWritableReason: "This record is currently non-writable.",
-			transportOptions: {
-				auto: "Auto",
-				stdio: "STDIO",
-				streamableHttp: "Streamable HTTP",
-				streamableHttpLegacy: "Streamable HTTP",
-				sseLegacy: "SSE (Legacy)",
-			},
-			form: {
-				fields: {
-					configPath: {
-						placeholder: "~/.cursor/mcp.json",
-					},
-					logoUrl: {
-						placeholder: "https://example.com/logo.png",
-					},
-					homepageUrl: {
-						placeholder: "https://example.com",
-					},
-					docsUrl: {
-						placeholder: "https://docs.example.com",
-					},
-					supportUrl: {
-						placeholder: "https://support.example.com",
-					},
-				},
-			},
-		},
-			backups: {
-				title: "Backups",
-				description: "Restore or delete configuration snapshots.",
-				buttons: {
-					refresh: "Refresh",
-					selectAll: "Select all",
-					clear: "Clear",
-					deleteSelected: "Delete selected ({{count}})",
-					restore: "Restore",
-					delete: "Delete",
-				},
-				empty: "No backups.",
-				emptyDisabledByPolicy: "Backups are currently disabled by system policy.",
-				bulk: {
-					title: "Delete Selected Backups",
-					description:
-						"Are you sure you want to delete {{count}} backup(s)? This action cannot be undone.",
-				},
-			},
-			logs: {
-				title: "Logs",
-				description: "Runtime warnings and backend notes for this client.",
-				searchPlaceholder: "Search logs...",
-				refresh: "Refresh Logs",
-				expand: "Expand Logs",
-				collapse: "Collapse Logs",
-				loading: "Loading logs...",
-				headers: {
-					timestamp: "Timestamp",
-					action: "Action",
-					category: "Category",
-					status: "Status",
-					target: "Target",
-				},
-				empty: "No log entries recorded for this client yet.",
-			},
-			confirm: {
-				deleteTitle: "Delete Backup",
-				restoreTitle: "Restore Backup",
-				deleteDescription:
-					"Are you sure you want to delete this backup? This action cannot be undone.",
-				restoreDescription:
-					"Restore the local client configuration file from the selected backup? MCPMate management mode and capability settings stay unchanged.",
-				deleteLabel: "Delete",
-				restoreLabel: "Restore",
-				cancelLabel: "Cancel",
-				detachTitle: "Detach MCPMate from client config?",
-				detachDescription:
-					"This removes the MCPMate server entry from the client configuration file. Running MCP connections for that client may break until you attach again; confirm before continuing.",
-				detachLabel: "Detach",
-				attachTitle: "Attach MCPMate to client config?",
-				attachDescription:
-					"This writes the MCPMate server entry back into the client configuration file. The client's MCP session may restart or reconnect; confirm before continuing.",
-				attachLabel: "Attach",
-			},
-			policy: {
-				title: "Backup Policy",
-				fields: {
-					policy: "Policy",
-					policyDescription:
-						'Backup retention strategy. For now, only "keep_n" is supported, which keeps at most N recent backups and prunes older ones.',
-					options: {
-						keepN: "keep_n",
-					},
-					limit: "Limit",
-					limitDescription:
-						"Maximum number of backups to keep for this client. Set to 0 for no limit.",
-				},
-				buttons: {
-					save: "Save Policy",
-				},
-			},
-			importPreview: {
-				title: "Import Preview",
-				description: "Summary of servers detected from current client config.",
-				fields: {
-					attempted: "Attempted",
-					imported: "Imported",
-					skipped: "Skipped",
-					failed: "Failed",
-				},
-				noPreview: "No preview data.",
-				sections: {
-					servers: "Servers to import",
-					errors: "Errors",
-					raw: "Raw preview JSON",
-					stats:
-						"tools: {{tools}} • resources: {{resources}} • templates: {{templates}} • prompts: {{prompts}}",
-				},
-				buttons: {
-					close: "Close",
-					apply: "Apply Import",
-					preview: "Preview",
-				},
-				states: {
-					noImportNeeded: "No import needed",
-				},
-			},
-				notifications: {
-					reviewSuccess: {
-						title: "Success",
-						messageApproved: "Record approved successfully.",
-						messageSuspended: "Record suspended successfully.",
-					},
-					reviewFailed: {
-						title: "Review failed",
-					},
-					previewReady: {
-						title: "Preview ready",
-						message: "Review the diff before applying.",
-					noChanges: "No changes detected in this configuration.",
-				},
-				applied: {
-					title: "Applied",
-					message: "Configuration applied",
-				},
-				managementSaved: {
-					title: "Saved",
-					message:
-						"Management settings were saved in MCPMate. Local client configuration was not updated.",
-				},
-				applyFailed: {
-					title: "Apply failed",
-				},
-				imported: {
-					title: "Imported",
-					message: "{{count}} server(s) imported successfully",
-				},
-				nothingToImport: {
-					title: "Nothing to import",
-					message: "All entries were skipped or no importable servers found.",
-				},
-				importFailed: {
-					title: "Import failed",
-				},
-				refreshed: {
-					title: "Refreshed",
-					message: "Detection refreshed",
-				},
-				refreshFailed: {
-					title: "Refresh failed",
-				},
-				managedUpdated: {
-					title: "Updated",
-					message: "Managed state changed",
-				},
-				managedFailed: {
-					title: "Update failed",
-				},
-					governanceUpdated: {
-						title: "Updated",
-						message: "Client governance state changed",
-					},
-				governanceFailed: {
-					title: "Update failed",
-				},
-				governanceAllowed: {
-					title: "Updated",
-					message: "Client governance is now allowed.",
-				},
-				governanceDenied: {
-					title: "Updated",
-					message: "Client governance is now denied.",
-				},
-				detachSuccess: {
-					title: "Detached",
-					message: "MCPMate was removed from the client configuration file.",
-				},
-				detachFailed: {
-					title: "Detach failed",
-				},
-				attachSuccess: {
-					title: "Attached",
-					message: "MCPMate was written back to the client configuration.",
-				},
-				attachFailed: {
-					title: "Attach failed",
-				},
-				previewFailed: {
-					title: "Preview failed",
-				},
-				restored: {
-					title: "Restored",
-					message: "Configuration restored from backup",
-				},
-				restoreFailed: {
-					title: "Restore failed",
-				},
-				deleted: {
-					title: "Deleted",
-					message: "Backup deleted",
-				},
-				deleteFailed: {
-					title: "Delete failed",
-				},
-				bulkDeleted: {
-					title: "Deleted",
-					message: "Selected backups have been deleted",
-				},
-				bulkDeleteFailed: {
-					title: "Bulk delete failed",
-				},
-				saved: {
-					title: "Saved",
-					message: "Backup policy updated",
-				},
-				saveFailed: {
-					title: "Save failed",
-				},
-			},
-		},
-	},
-    "zh-CN": {
-        title: "发现并管理客户端连接与可见性",
-		toolbar: {
-			search: {
-				placeholder: "搜索客户端...",
-				fields: {
-					displayName: "显示名称",
-					identifier: "标识符",
-					description: "描述",
-				},
-			},
-			filters: {
-				title: "筛选",
-				options: {
-					all: "全部",
-					allowed: "已允许",
-					pending: "待审批",
-					denied: "已拒绝",
-				},
-			},
-			sort: {
-				options: {
-					displayName: "名称",
-					approvalStatus: "审批状态",
-					managed: "管理状态",
-				},
-			},
-			actions: {
-				refresh: {
-					title: "刷新",
-					notificationTitle: "已触发刷新",
-					notificationMessage: "将同步最新客户端状态",
-				},
-				add: {
-					title: "新增客户端",
-					notificationTitle: "功能开发中",
-					notificationMessage: "该功能正在实现，敬请期待",
-				},
-			},
-		},
-		statsCards: {
-			total: {
-				title: "客户端总数",
-				description: "已发现",
-			},
-			detected: {
-				title: "已检测",
-				description: "已安装",
-			},
-			approved: {
-				title: "已允许",
-				description: "治理已放行",
-			},
-			pending: {
-				title: "待审批",
-				description: "等待审核",
-			},
-		},
-		notifications: {
-			managementUpdated: {
-				title: "已更新",
-				message: "客户端管理状态已更新",
-			},
-			operationFailed: {
-				title: "操作失败",
-			},
-		},
-		entity: {
-			fallbackName: "客户端",
-			stats: {
-				config: "配置",
-				servers: "服务器",
-				managed: "管理",
-				governance: "治理",
-				detected: "检测",
-				attachment: "接入",
-			},
-			config: {
-				notConfigured: "未配置",
-			},
-			bottomTags: {
-				servers: "服务器：{{count}}",
-			},
-			status: {
-				detected: "已检测",
-				notDetected: "未检测",
-			},
-			badge: {
-				detected: "已检测",
-				notDetected: "未检测",
-				allowed: "已允许",
-				pending: "待审批",
-				denied: "已拒绝",
-				defaultPolicy: "默认策略",
-				explicitRecord: "显式记录",
-				writableConfig: "可写配置",
-			},
-			attachment: {
-				attached: "已接入",
-				detached: "已断开",
-				notApplicable: "配置不可用",
-			},
-			tooltip: {
-				attachmentState: "接入状态：{{status}}",
-				attachmentUnavailable: "接入状态：N/A",
-				defaultPolicy: "默认策略：{{answer}}",
-				explicitRecord: "显式记录：{{answer}}",
-				writableConfig: "配置可写：{{answer}}",
-			},
-		},
-		states: {
-			on: "开启",
-			off: "关闭",
-			yes: "是",
-			no: "否",
-			present: "存在",
-			missing: "缺失",
-		},
-		emptyState: {
-			title: "未找到任何客户端",
-			description: "请确认 MCPMate 后端已运行并开启检测",
-		},
-		detail: {
-			noIdentifier: "未提供客户端标识符。",
-			badges: {
-				managed: "管理中",
-				unmanaged: "未管理",
-			},
-			tabs: {
-				overview: "概览",
-				configuration: "配置",
-				backups: "备份",
-				logs: "日志",
-			},
-			directExposure: {
-				title: "能力级直达",
-				badge: "直达暴露",
-				description: "调整本服务器有哪些能力应直接暴露给当前客户端。",
-				serverDescriptionFallback: "选择本服务器中应直接暴露给客户端的能力。",
-				toolsTitle: "工具",
-				toolsSummary: "已直达 {{enabled}} / {{total}} 个能力",
-				tabs: {
-					tools: "工具",
-					prompts: "提示",
-					resources: "资源",
-					templates: "模板",
-					toolsWithCounts: "工具（{{enabled}}/{{total}}）",
-					promptsWithCounts: "提示（{{enabled}}/{{total}}）",
-					resourcesWithCounts: "资源（{{enabled}}/{{total}}）",
-					templatesWithCounts: "模板（{{enabled}}/{{total}}）",
-				},
-				searchPlaceholders: {
-					tools: "搜索工具…",
-					prompts: "搜索提示…",
-					resources: "搜索资源…",
-					templates: "搜索模板…",
-				},
-				empty: {
-					tools: "未找到该服务器的工具。",
-					prompts: "未找到该服务器的提示。",
-					resources: "未找到该服务器的资源。",
-					templates: "未找到该服务器的模板。",
-				},
-				statusPlaceholder: "状态",
-				filters: {
-					status: {
-						all: "全部",
-						enabled: "已启用",
-						disabled: "已停用",
-					},
-				},
-				buttons: {
-					selectAll: "全选",
-					clearSelection: "清空",
-					enable: "启用",
-					disable: "停用",
-				},
-				notifications: {
-					savedTitle: "直达能力已更新",
-					savedMessage: "直达能力暴露配置已更新。",
-					saveFailedTitle: "无法更新直达能力",
-				},
-			},
-			overview: {
-				labels: {
-					configPath: "配置路径",
-					lastModified: "最近修改",
-					supportedTransports: "传输协议",
-					homepage: "主页",
-					docs: "文档",
-					support: "支持",
-				},
-				buttons: {
-					edit: "编辑",
-					refresh: "刷新",
-					enable: "启用",
-					disable: "停用",
-					approve: "批准",
-					reject: "拒绝",
-					allow: "允许",
-					deny: "拒绝治理",
-					detach: "断开",
-					attach: "接入",
-				},
-				noDetails: "暂无详细信息",
-					currentServers: {
-						title: "当前服务器",
-						import: "从配置导入",
-						configuredLabel: "已配置",
-						empty: "未从当前配置解析到服务器。",
-					},
-				},
-				form: {
-					titleCreate: "新增客户端记录",
-					titleEdit: "编辑客户端记录",
-					descriptionCreate: "创建一个带有管理形态与元数据的客户端记录。",
-					descriptionEdit: "更新该客户端记录及其管理设置。",
-					tabs: { basic: "基础", meta: "元数据" },
-					connectionShape: {
-						label: "客户端形态",
-						description: "选择该客户端是否具备可写本地配置文件，或属于不可写的远程/未知客户端。",
-						options: {
-							localWithConfig: "本地 + 配置文件",
-							localWithoutConfig: "本地 / 未知配置",
-							remoteHttp: "远程 HTTP",
-						},
-					},
-					transportSupport: {
-						label: "传输支持",
-						placeholder: "选择支持的传输方式",
-						empty: "未找到传输方式。",
-						description: "选择该客户端支持的运行时传输方式。该数组会作为 hosted / unify 传输选择的唯一约束来源。",
-						validation: {
-							required: "保存前请至少选择一种支持的传输方式。",
-						},
-						options: {
-							stdio: "STDIO",
-							streamableHttpLegacy: "Streamable HTTP",
-							sseLegacy: "SSE（旧版兼容）",
-						},
-					},
-					transportRules: {
-						label: "传输规则",
-						suggestedVariants: "推荐变体",
-						empty: "请先选择至少一种传输方式，再编辑对应写入规则。",
-						stdioDescription: "定义该客户端写入命令型 MCP 服务器时使用的字段名。",
-						httpDescription: "定义该客户端写入 URL 型 MCP 服务器时使用的字段名。",
-						commandField: "命令字段",
-						argsField: "参数字段",
-						envField: "环境变量字段",
-						urlField: "URL 字段",
-						headersField: "请求头字段",
-						includeType: "写入 type 字段",
-						typeValue: "Type 值",
-						extraFields: "额外字段",
-						addExtraField: "添加字段",
-						extraFieldKeyPlaceholder: "enabled",
-						extraFieldValuePlaceholder: 'true 或 "custom"',
-						presets: {
-							common: "常用",
-							withType: "带 type",
-							zedStyle: "Zed 风格",
-						},
-						help: {
-							summary: "这些字段表示目标客户端配置里的键名，不是 MCPMate 自己的协议字段。",
-							docs: "如果不确定客户端期望哪些键，请优先查看该客户端官方文档，或参考一份已正常工作的现有配置。",
-							presets: "下方推荐变体可作为起点，但仍应根据该客户端的真实配置结构进行核对。",
-							openDocs: "打开客户端文档",
-						},
-						validation: {
-							commandRequired: "STDIO 必须指定命令字段。",
-							urlRequired: "HTTP 类传输必须指定 URL 字段。",
-							typeValueRequired: "启用 type 字段时必须填写对应的 type 值。",
-						},
-					},
-					fields: {
-						displayName: { label: "客户端名称", placeholder: "Cursor Desktop" },
-						identifier: { label: "客户端 ID", placeholder: "cursor-desktop", description: "创建新记录时，空格和大小写会自动规范化。" },
-						clientVersion: { label: "客户端版本", placeholder: "可选" },
-						configPath: {
-							label: "配置文件路径",
-							placeholder: "~/.cursor/mcp.json",
-							description: "可写的本地配置路径会让 MCPMate 能通过文件配置操作来管理该客户端。",
-							browse: "选择…",
-							browseAria: "从磁盘选择配置文件",
-							dialogTitle: "选择配置文件",
-							pickFailedTitle: "无法读取所选文件",
-							webPickInfoTitle: "浏览器文件访问",
-							webPickInfoDescription: "浏览器无法自动读取绝对路径，如有需要请手动粘贴。",
-						},
-						configFileParse: {
-							label: "解析规则",
-							formatLabel: "配置格式",
-							containerTypeLabel: "容器类型",
-							containerKeysLabel: "配置节点",
-							containerKeysPlaceholder: "mcpServers, context_servers",
-							showAdvanced: "显示详情",
-							hideAdvanced: "隐藏详情",
-							validationTitle: "文件关联检查",
-							validationSuccess: "所选文件与当前解析规则匹配。",
-							validationHint: "选择一个配置文件后，MCPMate 会验证这些规则是否能定位到 MCP server 条目。",
-							detectedFormat: "检测到的格式",
-							containerMatch: "容器",
-							serverCount: "服务器",
-							matchYes: "已找到",
-							matchNo: "缺失",
-							summaryViewButton: "摘要视图",
-							codeViewButton: "代码预览",
-							keysRequired: "保存解析规则前，至少添加一个配置节点路径。",
-							containerTypeOptions: {
-								standard: "对象映射",
-								array: "数组",
-							},
-							format: { label: "文件格式" },
-							containerType: { label: "容器类型" },
-							containerKeys: { label: "容器键名 (JSON Path)" },
-							validation: {
-								formatMatch: "格式匹配",
-								formatMismatch: "格式不匹配",
-								containerFound: "找到容器",
-								containerMissing: "未找到容器",
-								serversDetected: "检测到 {{count}} 个服务器",
-								noServers: "未检测到服务器",
-								checking: "检查中..."
-							},
-							preview: "预览",
-							previewTitle: "配置预览",
-							autoDetect: "自动检测规则",
-							applyDetected: "应用检测到的规则"
-						},
-						formatRulesJsonText: {
-							label: "格式规则（JSON）",
-							placeholder: "在此粘贴 JSON 格式规则",
-							description: "高级：为传输格式定义细粒度规则（JSON 格式）。留空将重置为默认值。",
-						},
-						logoUrl: { label: "Logo 地址", placeholder: "https://example.com/logo.png" },
-						homepageUrl: { label: "主页地址", placeholder: "https://example.com" },
-						docsUrl: { label: "文档地址", placeholder: "https://docs.example.com" },
-						supportUrl: { label: "支持地址", placeholder: "https://support.example.com" },
-						description: {
-							label: "描述",
-							placeholder: "简要描述这个客户端。",
-							description: "这些元数据字段仅用于展示与提示；旧模板文件现在只保留兼容性 seed 作用。",
-						},
-					},
-					buttons: { cancel: "取消", create: "创建记录", save: "保存更改", delete: "删除" },
-					confirmDelete: {
-						title: "删除客户端记录",
-						description: "确定要删除这条客户端记录吗？此操作不可撤销。",
-						confirm: "删除",
-						cancel: "取消",
-					},
-					notifications: {
-						createSuccess: { title: "客户端记录已创建", message: "客户端记录已创建。" },
-						editSuccess: { title: "客户端记录已更新", message: "客户端记录已更新。" },
-						deleteSuccess: { title: "客户端记录已删除", message: "客户端记录已删除。" },
-						createBackupPolicyFailed: {
-							message: "客户端记录已创建，但初始化备份策略失败。你可以稍后在备份设置中重试。",
-						},
-						formatRulesJsonParseError: "格式规则 JSON 解析失败。请检查语法后重试。",
-						saveFailed: { title: "无法保存客户端记录" },
-						deleteFailed: {
-							title: "无法删除客户端记录",
-							messageMissingIdentifier: "缺少客户端标识符。",
-						},
-					},
-				},
-				configuration: {
-				title: "配置模式",
-				description: "若不清楚含义，请勿修改并保持现有设置。",
-					warnings: {
-						mixedRouting: "混合路由：若把有状态工作流拆成代理与直连调用，可能出现问题。",
-					},
-				errors: {
-					customProfileMissing: "该客户端的专属自定义工作区已缺失，请先重新创建后再应用配置。",
-				},
-				writeTargetRequiredReason: "要把治理配置真正应用到客户端配置文件，必须先确认一个已验证且可写的本地 MCP 配置文件。",
-				applyRequiresApprovedReason: "要把客户端配置真正应用落盘，必须先处于已允许治理状态，并且拥有一个已验证的本地配置目标。",
-				managementSettingsPendingReason: "请在该客户端结束待审批状态后再保存管理设置。",
-				apply: "应用",
-				reapply: "重新应用",
-				sections: {
-					mode: {
-						title: "1. 管理模式",
-						descriptions: {
-						unify:
-							"统一模式初始仅提供内建 MCP 工具，并在当前会话中面向全局启用服务器的能力工作。",
-							hosted:
-								"托管模式会为该客户端保留持久化托管配置，并记住当前选择的工作状态。",
-							transparent:
-								"MCPMate 会将所选配置集中的服务器直接写入该客户端的 MCP 配置，且不会保留能力层级的控制。",
-						},
-						managedDisabledReason: "托管模式与统一模式至少需要一种后端已声明支持的传输方式。",
-						transparentDisabledReason: "透明模式需要可写的本地配置文件路径。",
-						options: {
-						unify: "统一模式",
-							hosted: "托管模式",
-							transparent: "透明模式",
-						},
-					},
-					source: {
-						title: "2. 配置详情",
-						titleTransparent: "2. 配置详情",
-						unifyRouteModes: {
-						broker_only: "全部代理",
-						server_level: "服务器级直达",
-						capability_level: "能力级直达",
-						},
-						descriptions: {
-						unify: "统一模式不使用仪表板中的配置集选择。请在当前会话内通过内建 UCAN 工具浏览并调用来自全局启用服务器的能力。",
-							unify_broker_only:
-								"所有能力均通过 UCAN 代理目录访问。内建 MCP 工具会浏览并调用来自全局启用服务器的能力。",
-							unify_server_level:
-								"将所选符合条件的服务器的全部能力直接暴露给该客户端。已暴露的能力不会出现在 UCAN 目录中。",
-							unify_capability_level:
-								"仅从符合条件的服务器中选择部分能力（工具、提示、资源、模板）直接暴露给该客户端。（进阶）",
-							default: "查看当前已对该客户端运行态生效的配置集。",
-							profile: "浏览共享场景库，并为该客户端选择精确的工作集。",
-						custom: "在当前统一模式工作状态之上创建客户端专属调整。",
-						transparentDefault:
-							"将当前所有已激活配置集中的服务器直接写入该客户端的 MCP 配置。",
-						transparentProfile:
-							"将所选共享配置集中的服务器直接写入该客户端的 MCP 配置。",
-						transparentCustom:
-							"将该客户端专属自定义配置集中的服务器直接写入该客户端的 MCP 配置。",
-						},
-					options: {
-						default: "当前生效",
-						profile: "配置集库",
-						custom: "自定义工作区",
-					},
-					statusLabel: {
-						default: "",
-						profile: "",
-						custom: "",
-					},
-				},
-					profiles: {
-					title: "3. 配置集",
-						descriptions: {
-						unify: "统一模式不会在这里维护配置集工作集。配置集仅用于托管模式或透明模式工作流。",
-							default:
-								"查看当前已对该客户端运行态生效的配置集。为保持场景一致性，此视图为只读。",
-							profile: "选择定义该客户端工作集的可复用共享配置集。",
-							custom: "为当前工作状态创建并维护客户端专属覆盖项。",
-							transparentDefault:
-								"透明模式会将当前所有已激活配置集中已启用的服务器直接写入该客户端的 MCP 配置。",
-							transparentProfile:
-								"选择哪些共享配置集为透明模式下该客户端的 MCP 配置提供已启用服务器。",
-							transparentCustom:
-								"透明模式在写入 MCP 配置时，仅使用该客户端专属自定义配置集中已启用的服务器。",
-						},
-						empty: {
-							active: "未找到已激活的配置集",
-							shared: "未找到共享配置集",
-						},
-				ghost: {
-					titleCustom: "自定义当前状态",
-					titleDefault: "打开配置集库",
-					subtitleCustom: "为当前工作集创建并管理客户端专属覆盖项",
-					subtitleCustomTransparent: "配置哪些服务器会被直接写入当前客户端。",
-					subtitleDefault: "浏览可复用共享场景，并在配置集页面中维护它们",
-				},
-			},
-					unify: {
-						title: "2. 配置详情",
-						description:
-							"统一模式初始仅提供内建 MCP 工具。它会在当前 MCP 会话中通过会话内建工具浏览全局启用服务器的 capabilities，并在会话结束后自动重置。",
-						items: {
-							builtinOnly: "仅内建工具",
-							sessionScoped: "会话内建流程",
-							noFurtherSetup: "仪表板中无需进一步设置",
-						},
-					},
-					exposure: {
-						title: "3. 直达暴露",
-						descriptions: {
-							broker_only:
-								"在仅代理路由模式下，包括标记为直达暴露在内的所有已启用 MCP 服务器，仍通过内建 UCAN 工具访问。",
-							server_level:
-								"选择应将工具、提示、资源与资源模板直接暴露给该客户端的符合条件服务器。",
-							capability_level:
-								"选择符合条件的服务器，并在工具、提示、资源、模板四类能力上进行能力级直达配置。（进阶）",
-						},
-						labels: {
-							ucanRoutingDescription:
-								"在仅代理路由模式下，包括标记为直达暴露的服务器在内，所有已启用的 MCP 服务器仍通过 UCAN 目录与工具调用访问。",
-						},
-						empty: {
-							no_eligible: "暂无可选符合条件服务器。请先在服务器详情中启用统一模式直达暴露。",
-						},
-					},
-				},
-			labels: {
-				noDescription: "暂无描述",
-				openProfileDetail: "打开配置集详情",
-				servers: "服务器",
-				tools: "工具",
-				resources: "资源",
-				prompts: "提示",
-				resourceTemplates: "资源模板",
-				toolsExposed: "个工具已直达",
-				capabilitiesExposed: "项能力已直达",
-			},
-			nonWritableReason: "该记录当前不可写。",
-			transportOptions: {
-				auto: "自动",
-				stdio: "STDIO",
-				streamableHttp: "Streamable HTTP",
-				streamableHttpLegacy: "Streamable HTTP",
-				sseLegacy: "SSE（旧版兼容）",
-			},
-			form: {
-				fields: {
-					configPath: {
-						placeholder: "~/.cursor/mcp.json",
-					},
-					logoUrl: {
-						placeholder: "https://example.com/logo.png",
-					},
-					homepageUrl: {
-						placeholder: "https://example.com",
-					},
-					docsUrl: {
-						placeholder: "https://docs.example.com",
-					},
-					supportUrl: {
-						placeholder: "https://support.example.com",
-					},
-				},
-			},
-		},
-			backups: {
-				title: "备份",
-				description: "恢复或删除配置快照。",
-				buttons: {
-					refresh: "刷新",
-					selectAll: "全选",
-					clear: "清空",
-					deleteSelected: "删除（{{count}}）",
-					restore: "恢复",
-					delete: "删除",
-				},
-				empty: "暂无备份。",
-				emptyDisabledByPolicy: "系统策略当前已禁用备份。",
-				bulk: {
-					title: "删除备份",
-					description: "确定要删除 {{count}} 个备份吗？该操作不可撤销。",
-				},
-			},
-			logs: {
-				title: "日志",
-				description: "展示该客户端关联的运行日志与审计事件。",
-				searchPlaceholder: "搜索日志...",
-				refresh: "刷新日志",
-				expand: "展开日志",
-				collapse: "收起日志",
-				loading: "正在加载日志...",
-				headers: {
-					timestamp: "时间",
-					action: "动作",
-					category: "类别",
-					status: "状态",
-					target: "目标",
-				},
-				empty: "暂未记录任何日志。",
-			},
-			confirm: {
-				deleteTitle: "删除备份",
-				restoreTitle: "恢复备份",
-				deleteDescription: "确定要删除该备份吗？此操作不可撤销。",
-				restoreDescription:
-					"要从选定备份恢复本地客户端配置文件吗？MCPMate 的管理模式与能力设置不会改变。",
-				deleteLabel: "删除",
-				restoreLabel: "恢复",
-				cancelLabel: "取消",
-				detachTitle: "从客户端配置中移除 MCPMate？",
-				detachDescription:
-					"将从客户端配置文件中移除 MCPMate 服务器条目。该客户端正在运行的 MCP 连接可能会中断，直到再次接入；请确认后继续。",
-				detachLabel: "断开",
-				attachTitle: "将 MCPMate 写回客户端配置？",
-				attachDescription:
-					"将把 MCPMate 服务器条目写回客户端配置文件，客户端的 MCP 会话可能会重连；请确认后继续。",
-				attachLabel: "接入",
-			},
-			policy: {
-				title: "备份策略",
-				fields: {
-					policy: "策略",
-					policyDescription:
-						"备份保留策略。目前仅支持“keep_n”，会保留最近 N 个备份并清理更早的备份。",
-					options: {
-						keepN: "keep_n",
-					},
-					limit: "上限",
-					limitDescription: "该客户端保留的备份数量上限，设置为 0 表示不限。",
-				},
-				buttons: {
-					save: "保存策略",
-				},
-			},
-			importPreview: {
-				title: "导入预览",
-				description: "概览当前客户端配置中检测到的服务器。",
-				fields: {
-					attempted: "已尝试",
-					imported: "已导入",
-					skipped: "已跳过",
-					failed: "失败",
-				},
-				noPreview: "暂无预览数据。",
-				sections: {
-					servers: "待导入服务器",
-					errors: "错误信息",
-					raw: "原始预览 JSON",
-					stats:
-						"工具：{{tools}} • 资源：{{resources}} • 模板：{{templates}} • 提示：{{prompts}}",
-				},
-				buttons: {
-					close: "关闭",
-					apply: "应用导入",
-					preview: "生成预览",
-				},
-				states: {
-					noImportNeeded: "无需导入",
-				},
-			},
-				notifications: {
-					reviewSuccess: {
-						title: "成功",
-						messageApproved: "记录已成功批准。",
-						messageSuspended: "记录已成功暂停。",
-					},
-					reviewFailed: {
-						title: "审批失败",
-					},
-					previewReady: {
-						title: "预览已就绪",
-						message: "请在应用前先查看差异。",
-					noChanges: "当前配置未产生任何变化。",
-				},
-				applied: {
-					title: "已应用",
-					message: "配置已应用",
-				},
-				managementSaved: {
-					title: "已保存",
-					message: "管理设置已保存到 MCPMate，本地客户端配置未更新。",
-				},
-				applyFailed: {
-					title: "应用失败",
-				},
-				imported: {
-					title: "导入完成",
-					message: "成功导入 {{count}} 个服务器",
-				},
-				nothingToImport: {
-					title: "无需导入",
-					message: "所有条目已跳过或没有可导入的服务器。",
-				},
-				importFailed: {
-					title: "导入失败",
-				},
-				refreshed: {
-					title: "已刷新",
-					message: "检测状态已刷新",
-				},
-				refreshFailed: {
-					title: "刷新失败",
-				},
-				managedUpdated: {
-					title: "已更新",
-					message: "托管状态已变更",
-				},
-				managedFailed: {
-					title: "更新失败",
-				},
-					governanceUpdated: {
-						title: "已更新",
-						message: "客户端治理状态已变更",
-					},
-				governanceFailed: {
-					title: "更新失败",
-				},
-				governanceAllowed: {
-					title: "已更新",
-					message: "该客户端现已允许。",
-				},
-				governanceDenied: {
-					title: "已更新",
-					message: "该客户端现已禁行。",
-				},
-				detachSuccess: {
-					title: "已断开",
-					message: "已从客户端配置中移除 MCPMate 条目。",
-				},
-				detachFailed: {
-					title: "断开失败",
-				},
-				attachSuccess: {
-					title: "已接入",
-					message: "已将 MCPMate 写回客户端配置文件。",
-				},
-				attachFailed: {
-					title: "接入失败",
-				},
-				previewFailed: {
-					title: "预览失败",
-				},
-				restored: {
-					title: "恢复完成",
-					message: "已从备份恢复配置",
-				},
-				restoreFailed: {
-					title: "恢复失败",
-				},
-				deleted: {
-					title: "删除完成",
-					message: "备份已删除",
-				},
-				deleteFailed: {
-					title: "删除失败",
-				},
-				bulkDeleted: {
-					title: "删除完成",
-					message: "已删除所选备份",
-				},
-				bulkDeleteFailed: {
-					title: "批量删除失败",
-				},
-				saved: {
-					title: "已保存",
-					message: "备份策略已更新",
-				},
-				saveFailed: {
-					title: "保存失败",
-				},
-			},
-		},
-	},
-    "ja-JP": {
-        title: "クライアント接続と可視性の管理",
-		toolbar: {
-			search: {
-				placeholder: "クライアントを検索...",
-				fields: {
-					displayName: "表示名",
-					identifier: "識別子",
-					description: "説明",
-				},
-			},
-			filters: {
-				title: "フィルター",
-				options: {
-					all: "すべて",
-					allowed: "許可済み",
-					pending: "承認待ち",
-					denied: "拒否",
-				},
-			},
-			sort: {
-				options: {
-					displayName: "名前",
-					approvalStatus: "承認状態",
-					managed: "管理状況",
-				},
-			},
-			actions: {
-				refresh: {
-					title: "更新",
-					notificationTitle: "更新を開始しました",
-					notificationMessage: "最新のクライアント状態を同期します",
-				},
-				add: {
-					title: "クライアントを追加",
-					notificationTitle: "開発中の機能",
-					notificationMessage: "機能を開発中です。しばらくお待ちください",
-				},
-			},
-		},
-		statsCards: {
-			total: {
-				title: "クライアント総数",
-				description: "検出済み",
-			},
-			detected: {
-				title: "検出",
-				description: "インストール済み",
-			},
-			approved: {
-				title: "許可済み",
-				description: "ガバナンス許可済み",
-			},
-			pending: {
-				title: "承認待ち",
-				description: "レビュー待ち",
-			},
-		},
-		notifications: {
-			managementUpdated: {
-				title: "更新しました",
-				message: "クライアントの管理状態を更新しました",
-			},
-			operationFailed: {
-				title: "操作に失敗しました",
-			},
-		},
-		entity: {
-			fallbackName: "クライアント",
-			stats: {
-				config: "設定",
-				servers: "サーバー",
-				managed: "管理",
-				governance: "ガバナンス",
-				detected: "検出",
-				attachment: "接続",
-			},
-			config: {
-				notConfigured: "未設定",
-			},
-			bottomTags: {
-				servers: "サーバー: {{count}}",
-			},
-			status: {
-				detected: "検出済み",
-				notDetected: "未検出",
-			},
-			badge: {
-				detected: "検出済み",
-				notDetected: "未検出",
-				allowed: "許可済み",
-				pending: "承認待ち",
-				denied: "拒否済み",
-				defaultPolicy: "デフォルトポリシー",
-				explicitRecord: "明示レコード",
-				writableConfig: "書き込み可能",
-			},
-			attachment: {
-				attached: "接続済み",
-				detached: "切り離し済み",
-				notApplicable: "設定 N/A",
-			},
-			tooltip: {
-				attachmentState: "接続状態: {{status}}",
-				attachmentUnavailable: "接続状態: N/A",
-				defaultPolicy: "デフォルトポリシー: {{answer}}",
-				explicitRecord: "明示レコード: {{answer}}",
-				writableConfig: "設定を書き込み可能: {{answer}}",
-			},
-		},
-		states: {
-			on: "オン",
-			off: "オフ",
-			yes: "はい",
-			no: "いいえ",
-			present: "あり",
-			missing: "なし",
-		},
-		emptyState: {
-			title: "クライアントが見つかりません",
-			description: "MCPMate バックエンドが動作し検出が有効か確認してください",
-		},
-		detail: {
-			noIdentifier: "クライアント識別子が指定されていません。",
-			badges: {
-				managed: "管理中",
-				unmanaged: "未管理",
-			},
-			tabs: {
-				overview: "概要",
-				configuration: "設定",
-				backups: "バックアップ",
-				logs: "ログ",
-			},
-			directExposure: {
-				title: "能力レベル直達",
-				badge: "直接公開",
-				description:
-					"このサーバーのどのケイパビリティを現在のクライアントへ直接公開するかを調整します。",
-				serverDescriptionFallback:
-					"このサーバーからクライアントへ直接公開するケイパビリティを選択します。",
-				toolsTitle: "ツール",
-				toolsSummary: "直接公開 {{enabled}} / {{total}} ケイパビリティ",
-				tabs: {
-					tools: "ツール",
-					prompts: "プロンプト",
-					resources: "リソース",
-					templates: "テンプレート",
-					toolsWithCounts: "ツール（{{enabled}}/{{total}}）",
-					promptsWithCounts: "プロンプト（{{enabled}}/{{total}}）",
-					resourcesWithCounts: "リソース（{{enabled}}/{{total}}）",
-					templatesWithCounts: "テンプレート（{{enabled}}/{{total}}）",
-				},
-				searchPlaceholders: {
-					tools: "ツールを検索…",
-					prompts: "プロンプトを検索…",
-					resources: "リソースを検索…",
-					templates: "テンプレートを検索…",
-				},
-				empty: {
-					tools: "このサーバーにツールが見つかりません。",
-					prompts: "このサーバーにプロンプトが見つかりません。",
-					resources: "このサーバーにリソースが見つかりません。",
-					templates: "このサーバーにテンプレートが見つかりません。",
-				},
-				statusPlaceholder: "状態",
-				filters: {
-					status: {
-						all: "すべて",
-						enabled: "有効",
-						disabled: "無効",
-					},
-				},
-				buttons: {
-					selectAll: "すべて選択",
-					clearSelection: "クリア",
-					enable: "有効化",
-					disable: "無効化",
-				},
-				notifications: {
-					savedTitle: "直接公開ケイパビリティを更新しました",
-					savedMessage: "直接公開するケイパビリティ設定を更新しました。",
-					saveFailedTitle: "直接公開ケイパビリティを更新できません",
-				},
-			},
-			overview: {
-				labels: {
-					configPath: "設定パス",
-					lastModified: "最終更新",
-					supportedTransports: "対応トランスポート",
-					homepage: "ホームページ",
-					docs: "ドキュメント",
-					support: "サポート",
-				},
-				buttons: {
-					edit: "編集",
-					refresh: "更新",
-					enable: "有効化",
-					disable: "無効化",
-					approve: "承認",
-					reject: "拒否",
-					allow: "許可",
-					deny: "拒否",
-					detach: "切り離す",
-					attach: "再接続",
-				},
-				noDetails: "詳細情報がありません",
-					currentServers: {
-						title: "現在のサーバー",
-						import: "設定からインポート",
-						configuredLabel: "設定済み",
-						empty: "現在の設定からサーバーを取得できませんでした。",
-					},
-				},
-				form: {
-					titleCreate: "クライアントレコードを追加",
-					titleEdit: "クライアントレコードを編集",
-					descriptionCreate: "管理形態とメタデータを含むクライアントレコードを作成します。",
-					descriptionEdit: "このクライアントレコードと管理設定を更新します。",
-					tabs: { basic: "基本", meta: "メタデータ" },
-					connectionShape: {
-						label: "クライアント形態",
-						description: "このクライアントが書き込み可能なローカル設定ファイルを持つか、書き込み不可のリモート/未知クライアントかを選択します。",
-						options: {
-							localWithConfig: "ローカル + 設定ファイル",
-							localWithoutConfig: "ローカル / 不明な設定",
-							remoteHttp: "リモート HTTP",
-						},
-					},
-					transportSupport: {
-						label: "対応トランスポート",
-						placeholder: "対応するトランスポートを選択",
-						empty: "トランスポートが見つかりません。",
-						description: "このクライアントが対応するランタイムトランスポートを選択します。この配列は hosted / unify のトランスポート選択を制約する唯一の情報源です。",
-						validation: {
-							required: "保存する前に、少なくとも 1 つの対応トランスポートを選択してください。",
-						},
-						options: {
-							stdio: "STDIO",
-							streamableHttpLegacy: "ストリーミング HTTP",
-							sseLegacy: "SSE（レガシー互換）",
-						},
-					},
-					transportRules: {
-						label: "トランスポートルール",
-						suggestedVariants: "推奨バリアント",
-						empty: "少なくとも 1 つのトランスポートを選択してから書き込みルールを編集してください。",
-						stdioDescription: "このクライアントへコマンド型 MCP サーバーを書き込む際のフィールド名を定義します。",
-						httpDescription: "このクライアントへ URL 型 MCP サーバーを書き込む際のフィールド名を定義します。",
-						commandField: "コマンドフィールド",
-						argsField: "引数フィールド",
-						envField: "環境変数フィールド",
-						urlField: "URL フィールド",
-						headersField: "ヘッダーフィールド",
-						includeType: "type フィールドを含める",
-						typeValue: "Type 値",
-						extraFields: "追加フィールド",
-						addExtraField: "フィールドを追加",
-						extraFieldKeyPlaceholder: "enabled",
-						extraFieldValuePlaceholder: 'true または "custom"',
-						presets: {
-							common: "一般的",
-							withType: "type 付き",
-							zedStyle: "Zed スタイル",
-						},
-						help: {
-							summary: "これらのフィールドは、MCPMate 自身のプロトコル項目ではなく、対象クライアント設定内のキー名を表します。",
-							docs: "クライアントが期待するキー名に迷った場合は、まずそのクライアントの公式ドキュメントまたは既存の正常な設定を確認してください。",
-							presets: "下の推奨バリアントは出発点として使えますが、最終的にはそのクライアントの実際の設定構造に合わせて確認してください。",
-							openDocs: "クライアントのドキュメントを開く",
-						},
-						validation: {
-							commandRequired: "STDIO では command フィールドが必要です。",
-							urlRequired: "HTTP 系トランスポートでは URL フィールドが必要です。",
-							typeValueRequired: "type フィールドを含める場合は type 値が必要です。",
-						},
-					},
-					fields: {
-						displayName: { label: "クライアント名", placeholder: "Cursor Desktop" },
-						identifier: { label: "クライアント ID", placeholder: "cursor-desktop", description: "新規レコード作成時は、スペースと大文字小文字が自動で正規化されます。" },
-						clientVersion: { label: "クライアントバージョン", placeholder: "任意" },
-						configPath: {
-							label: "設定ファイルパス",
-							placeholder: "~/.cursor/mcp.json",
-							description: "書き込み可能なローカル設定パスがある場合、MCPMate はファイルベースの設定操作でこのクライアントを管理できます。",
-							browse: "選択…",
-							browseAria: "ディスク上の設定ファイルを選択",
-							dialogTitle: "設定ファイルを選択",
-							pickFailedTitle: "選択したファイルを読み取れませんでした",
-							webPickInfoTitle: "ブラウザのファイルアクセス",
-							webPickInfoDescription: "ブラウザは絶対パスを自動取得できません。必要なら手動で貼り付けてください。",
-						},
-						configFileParse: {
-							label: "解析ルール",
-							formatLabel: "設定フォーマット",
-							containerTypeLabel: "コンテナタイプ",
-							containerKeysLabel: "設定ノード",
-							containerKeysPlaceholder: "mcpServers, context_servers",
-							showAdvanced: "詳細を表示",
-							hideAdvanced: "詳細を非表示",
-							validationTitle: "ファイル関連付けチェック",
-							validationSuccess: "選択したファイルは現在の解析ルールに一致しています。",
-							validationHint: "設定ファイルを選択すると、MCPMate がこれらのルールで MCP server エントリを見つけられるか検証します。",
-							detectedFormat: "検出フォーマット",
-							containerMatch: "コンテナ",
-							serverCount: "サーバー",
-							matchYes: "見つかりました",
-							matchNo: "見つかりません",
-							summaryViewButton: "サマリー表示",
-							codeViewButton: "コードプレビュー",
-							keysRequired: "解析ルールを保存する前に、設定ノードパスを少なくとも1つ追加してください。",
-							containerTypeOptions: {
-								standard: "オブジェクトマップ",
-								array: "配列",
-							},
-							format: { label: "フォーマット" },
-							containerType: { label: "コンテナタイプ" },
-							containerKeys: { label: "コンテナキー (JSON Path)" },
-							validation: {
-								formatMatch: "フォーマット一致",
-								formatMismatch: "フォーマット不一致",
-								containerFound: "コンテナ検出",
-								containerMissing: "コンテナ未検出",
-								serversDetected: "{{count}}個のサーバーを検出",
-								noServers: "サーバー未検出",
-								checking: "検査中..."
-							},
-							preview: "プレビュー",
-							previewTitle: "設定プレビュー",
-							autoDetect: "ルール自動検出",
-							applyDetected: "検出ルールを適用"
-						},
-						formatRulesJsonText: {
-							label: "フォーマットルール（JSON）",
-							placeholder: "JSON フォーマットルールをここに貼り付けてください",
-							description: "高度な設定：トランスポート形式の細粒度ルールを JSON で定義します。空にするとデフォルト値にリセットされます。",
-						},
-						logoUrl: { label: "ロゴ URL", placeholder: "https://example.com/logo.png" },
-						homepageUrl: { label: "ホームページ URL", placeholder: "https://example.com" },
-						docsUrl: { label: "ドキュメント URL", placeholder: "https://docs.example.com" },
-						supportUrl: { label: "サポート URL", placeholder: "https://support.example.com" },
-						description: {
-							label: "説明",
-							placeholder: "このクライアントの概要を入力してください。",
-							description: "これらのメタデータは表示とガイダンスのために保存されます。旧テンプレートファイルは互換性 seed としてのみ残ります。",
-						},
-					},
-					buttons: { cancel: "キャンセル", create: "レコードを作成", save: "変更を保存", delete: "削除" },
-					confirmDelete: {
-						title: "クライアントレコードを削除",
-						description: "このクライアントレコードを削除してもよろしいですか？この操作は元に戻せません。",
-						confirm: "削除",
-						cancel: "キャンセル",
-					},
-					notifications: {
-						createSuccess: { title: "クライアントレコードを作成しました", message: "クライアントレコードを作成しました。" },
-						editSuccess: { title: "クライアントレコードを更新しました", message: "クライアントレコードを更新しました。" },
-						deleteSuccess: { title: "クライアントレコードを削除しました", message: "クライアントレコードを削除しました。" },
-						createBackupPolicyFailed: {
-							message:
-								"クライアントレコードは作成されましたが、初期バックアップポリシーの適用に失敗しました。後でバックアップ設定から再試行できます。",
-						},
-						formatRulesJsonParseError: "フォーマットルール JSON の解析に失敗しました。構文を確認して再度お試しください。",
-						saveFailed: { title: "クライアントレコードを保存できませんでした" },
-						deleteFailed: {
-							title: "クライアントレコードを削除できません",
-							messageMissingIdentifier: "クライアント識別子がありません。",
-						},
-					},
-				},
-				configuration: {
-				title: "設定モード",
-				description: "意味が不明な場合は変更せず現状の設定を維持してください。",
-					warnings: {
-						mixedRouting: "混合ルーティング: ステートフルな手順を分割すると問題が起きる可能性があります。",
-					},
-				errors: {
-					customProfileMissing:
-						"このクライアント専用のカスタムワークスペースが見つかりません。設定を適用する前に再作成してください。",
-				},
-				writeTargetRequiredReason:
-					"クライアント設定ファイルへガバナンスを適用するには、検証済みで書き込み可能なローカル MCP 設定ファイルが必要です。",
-				applyRequiresApprovedReason:
-					"クライアント設定を適用するには、許可済みのガバナンス状態と検証済みのローカル設定対象が必要です。",
-				managementSettingsPendingReason:
-					"このクライアントが承認待ち状態を抜けてから管理設定を保存してください。",
-				apply: "適用",
-				reapply: "再適用",
-				sections: {
-					mode: {
-						title: "1. 管理モード",
-						descriptions: {
-						unify:
-							"統一モードは内蔵 MCP ツールのみで開始し、現在のセッションではグローバルに有効なサーバーのケイパビリティを扱います。",
-							hosted:
-								"ホスト型モードはこのクライアントの持続的な管理設定を保持し、現在のワーク状態を記憶します。",
-							transparent:
-								"MCPMate は選択したプロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込み、ケイパビリティ単位の制御は保持しません。",
-						},
-						managedDisabledReason:
-							"ホスト型モードと統一モードを使うには、少なくとも 1 つのサポート対象トランスポートが必要です。",
-						transparentDisabledReason:
-							"トランスペアレントモードには、書き込み可能なローカル設定ファイルのパスが必要です。",
-						options: {
-						unify: "統一モード",
-							hosted: "ホスト型モード",
-							transparent: "トランスペアレントモード",
-						},
-					},
-					source: {
-						title: "2. 設定",
-						titleTransparent: "2. 設定",
-						unifyRouteModes: {
-							broker_only: "ブローカーのみ",
-							server_level: "サーバーレベル",
-							capability_level: "能力レベル直達",
-						},
-						descriptions: {
-						unify:
-							"統一モードではダッシュボード上のプロファイル選択を使いません。現在のセッションでは、内蔵 UCAN ツールでグローバルに有効なサーバーのケイパビリティを参照・呼び出します。",
-							unify_broker_only:
-								"すべてのケイパビリティは UCAN ブローカーカタログ越しに提供されます。内蔵 MCP ツールがグローバルに有効なサーバーのケイパビリティを参照・呼び出します。",
-							unify_server_level:
-								"選択した対象サーバーから、このクライアントへケイパビリティを直接公開します。公開されたケイパビリティは UCAN カタログには載りません。",
-							unify_capability_level:
-								"対象サーバーから選択したケイパビリティ（ツール、プロンプト、リソース、テンプレート）のみをこのクライアントへ直接公開します。（上級）",
-							default: "このクライアントの実行時に現在有効なプロファイルを確認します。",
-							profile: "共有シーンライブラリを参照し、このクライアントの正確なワークセットを選択します。",
-						custom: "現在の統一モードのワーク状態の上にクライアント専用の調整を作成します。",
-						transparentDefault:
-							"現在有効なすべてのプロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
-						transparentProfile:
-							"選択した共有プロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
-						transparentCustom:
-							"このクライアント専用のカスタムプロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
-						},
-					options: {
-						default: "有効なプロファイル",
-						profile: "プロファイルライブラリ",
-						custom: "カスタムワークスペース",
-					},
-					statusLabel: {
-						default: "",
-						profile: "",
-						custom: "",
-					},
-				},
-					profiles: {
-					title: "3. プロファイル",
-						descriptions: {
-						unify:
-							"統一モードではここでプロファイルのワークセットを維持しません。プロファイルはホスト型モードまたはトランスペアレントモードのワークフローで使用します。",
-							default:
-								"このクライアントの実行時にすでに有効なプロファイルを確認します。シーンの一貫性を保つため、このビューは読み取り専用です。",
-							profile: "このクライアントのワークセットを定義する再利用可能な共有プロファイルを選択します。",
-							custom: "現在のワーク状態に対するクライアント専用オーバーライドを作成・維持します。",
-							transparentDefault:
-								"トランスペアレントモードでは、現在有効なすべてのプロファイルの有効化されたサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
-							transparentProfile:
-								"トランスペアレントモードでこのクライアントの MCP 設定に有効化されたサーバーを提供する共有プロファイルを選択します。",
-							transparentCustom:
-								"トランスペアレントモードで MCP 設定を書き込む際は、このクライアント専用カスタムプロファイルの有効化されたサーバーのみを使用します。",
-						},
-						empty: {
-							active: "有効なプロファイルが見つかりません",
-							shared: "共有プロファイルが見つかりません",
-						},
-						ghost: {
-							titleCustom: "現在の状態をカスタマイズ",
-							titleDefault: "プロファイルライブラリを開く",
-							subtitleCustom: "現在のワークスペースに対するクライアント専用オーバーライドを作成・管理",
-							subtitleCustomTransparent:
-								"このクライアントへ直接書き込むサーバーを設定します。",
-							subtitleDefault: "再利用可能な共有シーンを参照し、プロファイルページで編集します",
-						},
-					},
-					unify: {
-						title: "2. 設定",
-						description:
-							"統一モードは内蔵 MCP ツールのみで開始します。現在の MCP セッションでは、セッション内の内蔵フローでグローバルに有効なサーバーのケイパビリティを参照し、終了時に自動的にリセットされます。",
-						items: {
-							builtinOnly: "内蔵ツールのみ",
-							sessionScoped: "セッション内の内蔵フロー",
-							noFurtherSetup: "ダッシュボードで追加設定は不要",
-						},
-					},
-					exposure: {
-						title: "3. 直接公開",
-						descriptions: {
-							broker_only:
-								"ブローカーのみモードでは、直接公開対象としてマークされたサーバーを含む、有効な MCP サーバーはすべて内蔵 UCAN ツール経由で利用できます。",
-							server_level:
-								"ツール、プロンプト、リソース、リソーステンプレートをこのクライアントへ直接公開する対象サーバーを選択します。",
-							capability_level:
-								"対象サーバーを選び、ツール、プロンプト、リソース、テンプレートを能力単位で直接公開する設定を行います。（上級）",
-						},
-						labels: {
-							ucanRoutingDescription:
-								"ブローカーのみモードでは、直接公開としてマークされたサーバーを含め、有効な MCP サーバーはすべて UCAN カタログとツール呼び出し経由でアクセスされます。",
-						},
-						empty: {
-							no_eligible:
-								"対象となるサーバーがありません。先にサーバー詳細で Unify の直接公開を有効にしてください。",
-						},
-					},
-				},
-			labels: {
-				noDescription: "説明なし",
-				openProfileDetail: "プロファイルの詳細を開く",
-				servers: "サーバー",
-				tools: "ツール",
-				resources: "リソース",
-				prompts: "プロンプト",
-				resourceTemplates: "リソーステンプレート",
-				toolsExposed: "個のツールを直接公開",
-				capabilitiesExposed: "個のケイパビリティを直接公開",
-			},
-			nonWritableReason: "このレコードは現在書き込みできません。",
-			transportOptions: {
-				auto: "自動",
-				stdio: "STDIO",
-				streamableHttp: "ストリーミング HTTP",
-				streamableHttpLegacy: "ストリーミング HTTP",
-				sseLegacy: "SSE（レガシー互換）",
-			},
-			form: {
-				fields: {
-					configPath: {
-						placeholder: "~/.cursor/mcp.json",
-					},
-					logoUrl: {
-						placeholder: "https://example.com/logo.png",
-					},
-					homepageUrl: {
-						placeholder: "https://example.com",
-					},
-					docsUrl: {
-						placeholder: "https://docs.example.com",
-					},
-					supportUrl: {
-						placeholder: "https://support.example.com",
-					},
-				},
-			},
-		},
-			backups: {
-				title: "バックアップ",
-				description: "設定スナップショットの復元・削除を行います。",
-				buttons: {
-					refresh: "更新",
-					selectAll: "すべて選択",
-					clear: "クリア",
-					deleteSelected: "選択した項目を削除（{{count}}）",
-					restore: "復元",
-					delete: "削除",
-				},
-				empty: "バックアップはありません。",
-				emptyDisabledByPolicy: "システムポリシーにより現在バックアップは無効です。",
-				bulk: {
-					title: "選択したバックアップを削除",
-					description:
-						"{{count}} 件のバックアップを削除しますか？この操作は元に戻せません。",
-				},
-			},
-			logs: {
-				title: "ログ",
-				description:
-					"このクライアントに関連する実行ログと監査イベントを表示します。",
-				searchPlaceholder: "ログを検索...",
-				refresh: "ログを更新",
-				expand: "ログを展開",
-				collapse: "ログを折りたたむ",
-				loading: "ログを読み込み中...",
-				headers: {
-					timestamp: "時刻",
-					action: "アクション",
-					category: "カテゴリ",
-					status: "ステータス",
-					target: "対象",
-				},
-				empty: "まだログが記録されていません。",
-			},
-			confirm: {
-				deleteTitle: "バックアップを削除",
-				restoreTitle: "バックアップを復元",
-				deleteDescription:
-					"このバックアップを削除しますか？この操作は元に戻せません。",
-				restoreDescription:
-					"選択したバックアップからローカルのクライアント設定ファイルを復元しますか？MCPMate の管理モードと能力設定は変更されません。",
-				deleteLabel: "削除",
-				restoreLabel: "復元",
-				cancelLabel: "キャンセル",
-				detachTitle: "クライアント設定から MCPMate を切り離しますか？",
-				detachDescription:
-					"MCPMate のサーバー定義をクライアント設定ファイルから削除します。実行中の MCP 接続は再接続まで利用できない場合があります。続行する前に確認してください。",
-				detachLabel: "切り離す",
-				attachTitle: "クライアント設定に MCPMate を書き戻しますか？",
-				attachDescription:
-					"MCPMate のサーバー定義をクライアント設定ファイルに再度書き込みます。MCP セッションが再接続する場合があります。続行する前に確認してください。",
-				attachLabel: "再接続",
-			},
-			policy: {
-				title: "バックアップポリシー",
-				fields: {
-					policy: "ポリシー",
-					policyDescription:
-						'バックアップ保持方針です。現在は "keep_n" のみ対応し、最新 N 件を保持して古いものを削除します。',
-					options: {
-						keepN: "keep_n",
-					},
-					limit: "上限",
-					limitDescription:
-						"このクライアントで保持するバックアップ数の上限です。0 にすると無制限です。",
-				},
-				buttons: {
-					save: "ポリシーを保存",
-				},
-			},
-			importPreview: {
-				title: "インポートプレビュー",
-				description: "現在の設定から検出したサーバーの概要です。",
-				fields: {
-					attempted: "試行",
-					imported: "インポート済み",
-					skipped: "スキップ",
-					failed: "失敗",
-				},
-				noPreview: "プレビューはありません。",
-				sections: {
-					servers: "インポート対象サーバー",
-					errors: "エラー",
-					raw: "プレビュー JSON",
-					stats:
-						"ツール: {{tools}} • リソース: {{resources}} • テンプレート: {{templates}} • プロンプト: {{prompts}}",
-				},
-				buttons: {
-					close: "閉じる",
-					apply: "インポートを適用",
-					preview: "プレビュー",
-				},
-				states: {
-					noImportNeeded: "インポート不要",
-				},
-			},
-				notifications: {
-					reviewSuccess: {
-						title: "成功",
-						messageApproved: "レコードを承認しました。",
-						messageSuspended: "レコードを停止しました。",
-					},
-					reviewFailed: {
-						title: "レビューに失敗しました",
-					},
-					previewReady: {
-						title: "プレビュー準備完了",
-						message: "適用前に差分を確認してください。",
-					noChanges: "この設定では変更はありませんでした。",
-				},
-				applied: {
-					title: "適用しました",
-					message: "設定を適用しました",
-				},
-				managementSaved: {
-					title: "保存しました",
-					message: "管理設定を MCPMate に保存しました。ローカルのクライアント設定は更新していません。",
-				},
-				applyFailed: {
-					title: "適用に失敗しました",
-				},
-				imported: {
-					title: "インポート完了",
-					message: "{{count}} 件のサーバーをインポートしました",
-				},
-				nothingToImport: {
-					title: "インポート不要",
-					message:
-						"すべての項目がスキップされたか、インポート可能なサーバーがありません。",
-				},
-				importFailed: {
-					title: "インポートに失敗しました",
-				},
-				refreshed: {
-					title: "更新しました",
-					message: "検出状態を更新しました",
-				},
-				refreshFailed: {
-					title: "更新に失敗しました",
-				},
-				managedUpdated: {
-					title: "更新しました",
-					message: "管理状態が変更されました",
-				},
-				managedFailed: {
-					title: "更新に失敗しました",
-				},
-					governanceUpdated: {
-						title: "更新しました",
-						message: "クライアントのガバナンス状態を変更しました",
-					},
-				governanceFailed: {
-					title: "更新に失敗しました",
-				},
-				governanceAllowed: {
-					title: "更新しました",
-					message: "このクライアントは許可状態になりました。",
-				},
-				governanceDenied: {
-					title: "更新しました",
-					message: "このクライアントは拒否状態になりました。",
-				},
-				detachSuccess: {
-					title: "切り離しました",
-					message: "クライアント設定から MCPMate エントリを削除しました。",
-				},
-				detachFailed: {
-					title: "切り離しに失敗しました",
-				},
-				attachSuccess: {
-					title: "再接続しました",
-					message: "クライアント設定に MCPMate を書き戻しました。",
-				},
-				attachFailed: {
-					title: "再接続に失敗しました",
-				},
-				previewFailed: {
-					title: "プレビューに失敗しました",
-				},
-				restored: {
-					title: "復元しました",
-					message: "バックアップから設定を復元しました",
-				},
-				restoreFailed: {
-					title: "復元に失敗しました",
-				},
-				deleted: {
-					title: "削除しました",
-					message: "バックアップを削除しました",
-				},
-				deleteFailed: {
-					title: "削除に失敗しました",
-				},
-				bulkDeleted: {
-					title: "削除しました",
-					message: "選択したバックアップを削除しました",
-				},
-				bulkDeleteFailed: {
-					title: "一括削除に失敗しました",
-				},
-				saved: {
-					title: "保存しました",
-					message: "バックアップポリシーを更新しました",
-				},
-				saveFailed: {
-					title: "保存に失敗しました",
-				},
-			},
-		},
-	},
+  en: {
+    title: "Discover and manage client connections and visibility",
+    toolbar: {
+      search: {
+        placeholder: "Search clients...",
+        fields: {
+          displayName: "Display Name",
+          identifier: "Identifier",
+          description: "Description",
+        },
+      },
+      filters: {
+        title: "Filter",
+        options: {
+          all: "All",
+          allowed: "Allowed",
+          pending: "Pending",
+          denied: "Denied",
+        },
+      },
+      sort: {
+        options: {
+          displayName: "Name",
+          approvalStatus: "Governance Status",
+          managed: "Management Status",
+        },
+      },
+      actions: {
+        refresh: {
+          title: "Refresh",
+          notificationTitle: "Refresh triggered",
+          notificationMessage: "Latest client state will sync to the list",
+        },
+        add: {
+          title: "Add Client",
+          notificationTitle: "Feature in Development",
+          notificationMessage:
+            "This feature is being implemented, please stay tuned",
+        },
+      },
+    },
+    statsCards: {
+      total: {
+        title: "Total Clients",
+        description: "discovered",
+      },
+      detected: {
+        title: "Detected",
+        description: "installed",
+      },
+      approved: {
+        title: "Approved",
+        description: "governance allowed",
+      },
+      pending: {
+        title: "Pending",
+        description: "awaiting review",
+      },
+    },
+    notifications: {
+      managementUpdated: {
+        title: "Updated",
+        message: "Client management state updated",
+      },
+      operationFailed: {
+        title: "Operation failed",
+      },
+    },
+    entity: {
+      fallbackName: "Client",
+      stats: {
+        config: "Config",
+        servers: "Servers",
+        managed: "Managed",
+        governance: "Governance",
+        detected: "Detected",
+        attachment: "Attachment",
+      },
+      config: {
+        notConfigured: "Not configured",
+      },
+      bottomTags: {
+        servers: "Servers: {{count}}",
+      },
+      status: {
+        detected: "Detected",
+        notDetected: "Not Detected",
+      },
+      badge: {
+        detected: "Detected",
+        notDetected: "Not Detected",
+        allowed: "Allowed",
+        pending: "Pending",
+        denied: "Denied",
+        defaultPolicy: "Default Policy",
+        explicitRecord: "Explicit Record",
+        writableConfig: "Writable",
+      },
+      attachment: {
+        attached: "Attached",
+        detached: "Detached",
+        notApplicable: "Config N/A",
+      },
+      tooltip: {
+        attachmentState: "Attachment: {{status}}",
+        attachmentUnavailable: "Attachment: N/A",
+        defaultPolicy: "Default policy: {{answer}}",
+        explicitRecord: "Explicit record: {{answer}}",
+        writableConfig: "Writable config: {{answer}}",
+      },
+    },
+    states: {
+      on: "On",
+      off: "Off",
+      yes: "Yes",
+      no: "No",
+      present: "Present",
+      missing: "Missing",
+    },
+    emptyState: {
+      title: "No clients found",
+      description:
+        "Make sure MCPMate backend is running and detection is enabled",
+    },
+    detail: {
+      noIdentifier: "No client identifier provided.",
+      badges: {
+        managed: "Managed",
+        unmanaged: "Unmanaged",
+      },
+      tabs: {
+        overview: "Overview",
+        configuration: "Configuration",
+        backups: "Backups",
+        logs: "Logs",
+      },
+      directExposure: {
+        title: "Capability Level",
+        badge: "Direct Exposure",
+        description:
+          "Adjust which capabilities from this server should be exposed directly to the current client.",
+        serverDescriptionFallback:
+          "Choose which capabilities from this server should be exposed directly to the client.",
+        toolsTitle: "Tools",
+        toolsSummary: "{{enabled}} / {{total}} capabilities exposed directly",
+        tabs: {
+          tools: "Tools",
+          prompts: "Prompts",
+          resources: "Resources",
+          templates: "Templates",
+          toolsWithCounts: "Tools ({{enabled}}/{{total}})",
+          promptsWithCounts: "Prompts ({{enabled}}/{{total}})",
+          resourcesWithCounts: "Resources ({{enabled}}/{{total}})",
+          templatesWithCounts: "Templates ({{enabled}}/{{total}})",
+        },
+        searchPlaceholders: {
+          tools: "Search tools...",
+          prompts: "Search prompts...",
+          resources: "Search resources...",
+          templates: "Search templates...",
+        },
+        empty: {
+          tools: "No tools found for this server.",
+          prompts: "No prompts found for this server.",
+          resources: "No resources found for this server.",
+          templates: "No templates found for this server.",
+        },
+        statusPlaceholder: "Status",
+        filters: {
+          status: {
+            all: "All",
+            enabled: "Enabled",
+            disabled: "Disabled",
+          },
+        },
+        buttons: {
+          selectAll: "Select all",
+          clearSelection: "Clear",
+          enable: "Enable",
+          disable: "Disable",
+        },
+        notifications: {
+          savedTitle: "Direct capabilities updated",
+          savedMessage:
+            "The direct capability exposure settings have been updated.",
+          saveFailedTitle: "Unable to update direct capabilities",
+        },
+      },
+      overview: {
+        labels: {
+          configPath: "Config Path",
+          lastModified: "Last Modified",
+          supportedTransports: "Supported Transports",
+          homepage: "Homepage",
+          docs: "Docs",
+          support: "Support",
+        },
+        buttons: {
+          edit: "Edit",
+          refresh: "Refresh",
+          enable: "Enable",
+          disable: "Disable",
+          approve: "Approve",
+          reject: "Reject",
+          allow: "Allow",
+          deny: "Deny",
+          detach: "Detach",
+          attach: "Attach",
+        },
+        noDetails: "No details available",
+        currentServers: {
+          title: "Current Servers",
+          import: "Import from Config",
+          configuredLabel: "configured",
+          empty: "No servers extracted from current config.",
+        },
+      },
+      form: {
+        titleCreate: "Add Client Record",
+        titleEdit: "Edit Client Record",
+        descriptionCreate:
+          "Create a client record with its management shape and metadata.",
+        descriptionEdit:
+          "Update this client record and its management settings.",
+        tabs: { basic: "Basic", meta: "Meta" },
+        connectionShape: {
+          label: "Client Shape",
+          description:
+            "Choose whether this client has a writable local config file or is a non-writable remote/unknown client.",
+          options: {
+            localWithConfig: "Local + Config",
+            localWithoutConfig: "Local / Unknown Config",
+            remoteHttp: "Remote HTTP",
+          },
+        },
+        transportSupport: {
+          label: "Transport Support",
+          placeholder: "Select supported transports",
+          empty: "No transports found.",
+          description:
+            "Choose which runtime transports this client supports. This array is the only source used to constrain hosted/unify transport selection.",
+          validation: {
+            required: "Select at least one supported transport before saving.",
+          },
+          options: {
+            stdio: "STDIO",
+            streamableHttpLegacy: "Streamable HTTP",
+            sseLegacy: "SSE (Legacy)",
+          },
+        },
+        transportRules: {
+          label: "Transport Rules",
+          suggestedVariants: "Suggested variants",
+          empty: "Select at least one transport to edit its write rules.",
+          stdioDescription:
+            "Define the field names used to write command-based MCP servers for this client.",
+          httpDescription:
+            "Define the field names used to write URL-based MCP servers for this client.",
+          commandField: "Command Field",
+          argsField: "Args Field",
+          envField: "Env Field",
+          urlField: "URL Field",
+          headersField: "Headers Field",
+          includeType: "Include type field",
+          typeValue: "Type Value",
+          extraFields: "Extra Fields",
+          addExtraField: "Add field",
+          extraFieldKeyPlaceholder: "enabled",
+          extraFieldValuePlaceholder: 'true or "custom"',
+          presets: {
+            common: "Common",
+            withType: "With type",
+            zedStyle: "Zed-style",
+          },
+          help: {
+            summary:
+              "These fields describe the target client's config keys, not MCPMate's own protocol fields.",
+            docs: "If you are unsure which keys a client expects, check that client's official documentation or an existing working config file first.",
+            presets:
+              "Use the suggested variants below as a starting point, then verify the result against the client's real config structure.",
+            openDocs: "Open client documentation",
+          },
+          validation: {
+            commandRequired: "STDIO requires a command field.",
+            urlRequired: "HTTP-based transports require a URL field.",
+            typeValueRequired:
+              "Type value is required when including the type field.",
+          },
+        },
+        fields: {
+          displayName: { label: "Client Name", placeholder: "Cursor Desktop" },
+          identifier: {
+            label: "Client ID",
+            placeholder: "cursor-desktop",
+            description:
+              "Spaces and casing are normalized automatically when creating a new record.",
+          },
+          clientVersion: { label: "Client Version", placeholder: "optional" },
+          configPath: {
+            label: "Config File Path",
+            placeholder: "~/.cursor/mcp.json",
+            description:
+              "A writable local config path enables MCPMate to manage this client through file-based configuration operations.",
+            browse: "Choose…",
+            browseAria: "Browse for configuration file on disk",
+            dialogTitle: "Select configuration file",
+            pickFailedTitle: "Unable to read selected file",
+            webPickInfoTitle: "Browser file access",
+            webPickInfoDescription:
+              "Your browser cannot read the absolute path automatically. Please paste it manually if needed.",
+          },
+          configFileParse: {
+            label: "Parse Rules",
+            formatLabel: "Config Format",
+            containerTypeLabel: "Container Type",
+            containerKeysLabel: "Config Nodes",
+            containerKeysPlaceholder: "mcpServers, context_servers",
+            showAdvanced: "Show details",
+            hideAdvanced: "Hide details",
+            validationTitle: "File association check",
+            validationSuccess:
+              "The selected file matches the current parse rules.",
+            validationHint:
+              "Pick a config file and MCPMate will validate whether these rules can find MCP server entries.",
+            detectedFormat: "Detected format",
+            containerMatch: "Container",
+            serverCount: "Servers",
+            matchYes: "Found",
+            matchNo: "Missing",
+            summaryViewButton: "Summary view",
+            codeViewButton: "Code preview",
+            keysRequired:
+              "Add at least one config node path before saving parse rules.",
+            containerTypeOptions: {
+              standard: "Object Map",
+              array: "Array",
+            },
+            format: { label: "Format" },
+            containerType: { label: "Container Type" },
+            containerKeys: { label: "Container Keys (JSON Path)" },
+            validation: {
+              formatMatch: "Format matches",
+              formatMismatch: "Format mismatch",
+              containerFound: "Container found",
+              containerMissing: "Container missing",
+              serversDetected: "{{count}} server(s) detected",
+              noServers: "No servers detected",
+              checking: "Inspecting...",
+            },
+            preview: "Preview",
+            previewTitle: "Config Preview",
+            autoDetect: "Auto-Detect Rules",
+            applyDetected: "Apply Detected Rules",
+          },
+          formatRulesJsonText: {
+            label: "Format Rules (JSON)",
+            placeholder: "Paste JSON format rules here",
+            description:
+              "Advanced: Fine-grained transport format rules as JSON. Leave empty to reset to defaults.",
+          },
+          logoUrl: {
+            label: "Logo URL",
+            placeholder: "https://example.com/logo.png",
+          },
+          homepageUrl: {
+            label: "Homepage URL",
+            placeholder: "https://example.com",
+          },
+          docsUrl: {
+            label: "Docs URL",
+            placeholder: "https://docs.example.com",
+          },
+          supportUrl: {
+            label: "Support URL",
+            placeholder: "https://support.example.com",
+          },
+          description: {
+            label: "Description",
+            placeholder: "A short summary of this client.",
+            description:
+              "These meta fields are stored for display and guidance; the old template files remain only as compatibility seeds.",
+          },
+        },
+        buttons: {
+          cancel: "Cancel",
+          create: "Create Record",
+          save: "Save Changes",
+          delete: "Delete",
+        },
+        confirmDelete: {
+          title: "Delete Client Record",
+          description:
+            "Are you sure you want to delete this client record? This action cannot be undone.",
+          confirm: "Delete",
+          cancel: "Cancel",
+        },
+        notifications: {
+          createSuccess: {
+            title: "Client record created",
+            message: "The client record has been created.",
+          },
+          editSuccess: {
+            title: "Client record updated",
+            message: "The client record has been updated.",
+          },
+          deleteSuccess: {
+            title: "Client record deleted",
+            message: "The client record has been deleted.",
+          },
+          createBackupPolicyFailed: {
+            message:
+              "Client record was created, but applying initial backup policy failed. You can retry in Backup settings.",
+          },
+          formatRulesJsonParseError:
+            "Failed to parse format rules JSON. Please check the syntax and try again.",
+          saveFailed: { title: "Unable to save client record" },
+          deleteFailed: {
+            title: "Unable to delete client record",
+            messageMissingIdentifier: "Client identifier is missing.",
+          },
+        },
+      },
+      configuration: {
+        title: "Configuration Mode",
+        description:
+          "If you don't understand what this means, please don't make any changes and keep the current settings.",
+        warnings: {
+          mixedRouting:
+            "Mixed routing: splitting stateful workflows may cause issues.",
+        },
+        errors: {
+          customProfileMissing:
+            "The client-specific custom workspace is missing. Create it again before applying configuration.",
+        },
+        writeTargetRequiredReason:
+          "Applying governance to the client configuration requires a verified writable local MCP config file.",
+        applyRequiresApprovedReason:
+          "Applying client configuration requires an approved governance state and a verified local config target.",
+        managementSettingsPendingReason:
+          "Save management settings after this client leaves pending approval.",
+        apply: "Apply",
+        reapply: "Re-apply",
+        sections: {
+          mode: {
+            title: "1. Management Mode",
+            descriptions: {
+              unify:
+                "Unify starts with builtin MCP tools only and works with capabilities from globally enabled servers during the current session.",
+              hosted:
+                "Hosted keeps a durable managed configuration for this client and remembers the selected working state.",
+              transparent:
+                "MCPMate writes the selected profile servers directly into this client's MCP configuration and does not preserve capability-level controls.",
+            },
+            managedDisabledReason:
+              "Hosted and Unify require at least one supported transport.",
+            transparentDisabledReason:
+              "Transparent requires a writable local config path.",
+            options: {
+              unify: "Unify",
+              hosted: "Hosted Mode",
+              transparent: "Transparent",
+            },
+          },
+          source: {
+            title: "2. Configuration",
+            titleTransparent: "2. Configuration",
+            unifyRouteModes: {
+              broker_only: "Broker Only",
+              server_level: "Server Level",
+              capability_level: "Capability Level",
+            },
+            descriptions: {
+              unify:
+                "Unify does not use dashboard profile selection. Use the builtin UCAN tools during the session to browse and call capabilities from globally enabled servers.",
+              unify_broker_only:
+                "All capabilities are kept behind the UCAN broker catalog. Builtin MCP tools will browse and call capabilities from globally enabled servers.",
+              unify_server_level:
+                "Directly expose all capabilities from selected eligible servers to this client. Exposed capabilities are excluded from the UCAN catalog.",
+              unify_capability_level:
+                "Directly expose only selected capabilities (tools, prompts, resources, templates) from eligible servers to this client. (Advanced)",
+              default:
+                "Review the profiles that are currently active for this client runtime.",
+              profile:
+                "Browse the shared scene library and choose the exact working set for this client.",
+              custom:
+                "Create client-specific adjustments on top of the current unify-mode working state.",
+              transparentDefault:
+                "Write the servers from all currently activated profiles directly into this client's MCP configuration.",
+              transparentProfile:
+                "Write the servers from the selected shared profiles directly into this client's MCP configuration.",
+              transparentCustom:
+                "Write the servers from the client-specific custom profile directly into this client's MCP configuration.",
+            },
+            options: {
+              default: "Active",
+              profile: "Profiles",
+              custom: "Customized",
+            },
+            statusLabel: {
+              default: "",
+              profile: "",
+              custom: "",
+            },
+          },
+          profiles: {
+            title: "3. Profiles",
+            descriptions: {
+              unify:
+                "Unify does not maintain a profile working set here. Use profiles for Hosted Mode or Transparent Mode workflows instead.",
+              default:
+                "Review the profiles that are already active for this client runtime. This view is read-only to keep the active scene set consistent.",
+              profile:
+                "Choose the reusable shared profiles that define this client's working set.",
+              custom:
+                "Create and maintain client-specific overrides for the current working state.",
+              transparentDefault:
+                "Transparent mode will write the enabled servers from all currently activated profiles directly into this client's MCP configuration.",
+              transparentProfile:
+                "Select which shared profiles contribute enabled servers to this client's MCP configuration in transparent mode.",
+              transparentCustom:
+                "Transparent mode uses only the enabled servers from this client-specific custom profile when writing the MCP configuration.",
+            },
+            empty: {
+              active: "No active profiles found",
+              shared: "No shared profiles found",
+            },
+            ghost: {
+              titleCustom: "Customize current state",
+              titleDefault: "Open profiles library",
+              subtitleCustom:
+                "Create and manage client-specific overrides for the current workspace",
+              subtitleCustomTransparent:
+                "Configure which servers should be written into this client directly.",
+              subtitleDefault:
+                "Browse reusable shared scenes and edit them from the profiles page",
+            },
+          },
+          unify: {
+            title: "2. Configuration",
+            description:
+              "Unify starts with builtin MCP tools only. It uses session-local builtin tooling to browse capabilities from globally enabled servers and resets when the session ends.",
+            items: {
+              builtinOnly: "Builtin tools only",
+              sessionScoped: "Session-local builtin flow",
+              noFurtherSetup: "No further setup in the dashboard",
+            },
+          },
+          exposure: {
+            title: "3. Direct Exposure",
+            descriptions: {
+              broker_only:
+                "All enabled MCP servers, including servers marked for direct exposure, remain reachable through the builtin UCAN tools in Broker Only mode.",
+              server_level:
+                "Select the eligible servers whose tools, prompts, resources, and resource templates should be exposed directly to the client.",
+              capability_level:
+                "Select eligible servers and configure direct exposure at capability level across tools, prompts, resources, and templates. (Advanced)",
+            },
+            labels: {
+              ucanRoutingDescription:
+                "In Broker Only mode, all enabled MCP servers — including servers marked for direct exposure — are still accessed through the UCAN catalog and call tools.",
+            },
+            empty: {
+              no_eligible:
+                "No eligible servers found. Enable Unify Direct Exposure on a server first.",
+            },
+          },
+        },
+        labels: {
+          noDescription: "No description",
+          openProfileDetail: "Open profile details",
+          servers: "Servers",
+          tools: "Tools",
+          resources: "Resources",
+          prompts: "Prompts",
+          resourceTemplates: "Resource templates",
+          toolsExposed: "tools exposed",
+          capabilitiesExposed: "capabilities exposed",
+        },
+        nonWritableReason: "This record is currently non-writable.",
+        transportOptions: {
+          auto: "Auto",
+          stdio: "STDIO",
+          streamableHttp: "Streamable HTTP",
+          streamableHttpLegacy: "Streamable HTTP",
+          sseLegacy: "SSE (Legacy)",
+        },
+        form: {
+          fields: {
+            configPath: {
+              placeholder: "~/.cursor/mcp.json",
+            },
+            logoUrl: {
+              placeholder: "https://example.com/logo.png",
+            },
+            homepageUrl: {
+              placeholder: "https://example.com",
+            },
+            docsUrl: {
+              placeholder: "https://docs.example.com",
+            },
+            supportUrl: {
+              placeholder: "https://support.example.com",
+            },
+          },
+        },
+      },
+      backups: {
+        title: "Backups",
+        description: "Restore or delete configuration snapshots.",
+        buttons: {
+          refresh: "Refresh",
+          selectAll: "Select all",
+          clear: "Clear",
+          deleteSelected: "Delete selected ({{count}})",
+          restore: "Restore",
+          delete: "Delete",
+        },
+        empty: "No backups.",
+        emptyDisabledByPolicy:
+          "Backups are currently disabled by system policy.",
+        bulk: {
+          title: "Delete Selected Backups",
+          description:
+            "Are you sure you want to delete {{count}} backup(s)? This action cannot be undone.",
+        },
+      },
+      logs: {
+        title: "Logs",
+        description: "Runtime warnings and backend notes for this client.",
+        searchPlaceholder: "Search logs...",
+        refresh: "Refresh Logs",
+        expand: "Expand Logs",
+        collapse: "Collapse Logs",
+        loading: "Loading logs...",
+        headers: {
+          timestamp: "Timestamp",
+          action: "Action",
+          category: "Category",
+          status: "Status",
+          target: "Target",
+        },
+        empty: "No log entries recorded for this client yet.",
+      },
+      confirm: {
+        deleteTitle: "Delete Backup",
+        restoreTitle: "Restore Backup",
+        deleteDescription:
+          "Are you sure you want to delete this backup? This action cannot be undone.",
+        restoreDescription:
+          "Restore the local client configuration file from the selected backup? MCPMate management mode and capability settings stay unchanged.",
+        deleteLabel: "Delete",
+        restoreLabel: "Restore",
+        cancelLabel: "Cancel",
+        detachTitle: "Detach MCPMate from client config?",
+        detachDescription:
+          "This removes the MCPMate server entry from the client configuration file. Running MCP connections for that client may break until you attach again; confirm before continuing.",
+        detachLabel: "Detach",
+        attachTitle: "Attach MCPMate to client config?",
+        attachDescription:
+          "This writes the MCPMate server entry back into the client configuration file. The client's MCP session may restart or reconnect; confirm before continuing.",
+        attachLabel: "Attach",
+      },
+      policy: {
+        title: "Backup Policy",
+        fields: {
+          policy: "Policy",
+          policyDescription:
+            'Backup retention strategy. For now, only "keep_n" is supported, which keeps at most N recent backups and prunes older ones.',
+          options: {
+            keepN: "keep_n",
+          },
+          limit: "Limit",
+          limitDescription:
+            "Maximum number of backups to keep for this client. Set to 0 for no limit.",
+        },
+        buttons: {
+          save: "Save Policy",
+        },
+      },
+      importPreview: {
+        title: "Import Preview",
+        description: "Summary of servers detected from current client config.",
+        fields: {
+          attempted: "Attempted",
+          imported: "Imported",
+          skipped: "Skipped",
+          failed: "Failed",
+        },
+        noPreview: "No preview data.",
+        sections: {
+          servers: "Servers to import",
+          errors: "Errors",
+          skippedDetailsSingle: "Skip details ({{count}} server)",
+          skippedDetailsPlural: "Skip details ({{count}} servers)",
+          raw: "Raw preview JSON",
+          stats:
+            "tools: {{tools}} • resources: {{resources}} • templates: {{templates}} • prompts: {{prompts}}",
+        },
+        queryLabels: {
+          existing: "Existing query",
+          incoming: "Incoming query",
+        },
+        skippedReasons: {
+          duplicateName: "Duplicate name",
+          duplicateFingerprint: "Duplicate fingerprint",
+          urlQueryMismatch: "URL query mismatch",
+          unknown: "Unknown reason",
+        },
+        buttons: {
+          close: "Close",
+          apply: "Apply Import",
+          preview: "Preview",
+        },
+        states: {
+          noImportNeeded: "No import needed",
+        },
+      },
+      notifications: {
+        reviewSuccess: {
+          title: "Success",
+          messageApproved: "Record approved successfully.",
+          messageSuspended: "Record suspended successfully.",
+        },
+        reviewFailed: {
+          title: "Review failed",
+        },
+        previewReady: {
+          title: "Preview ready",
+          message: "Review the diff before applying.",
+          noChanges: "No changes detected in this configuration.",
+        },
+        applied: {
+          title: "Applied",
+          message: "Configuration applied",
+        },
+        managementSaved: {
+          title: "Saved",
+          message:
+            "Management settings were saved in MCPMate. Local client configuration was not updated.",
+        },
+        applyFailed: {
+          title: "Apply failed",
+        },
+        imported: {
+          title: "Imported",
+          messageSingle: "{{count}} server imported successfully",
+          messagePlural: "{{count}} servers imported successfully",
+        },
+        nothingToImport: {
+          title: "Nothing to import",
+          message: "All entries were skipped or no importable servers found.",
+        },
+        importFailed: {
+          title: "Import failed",
+        },
+        refreshed: {
+          title: "Refreshed",
+          message: "Detection refreshed",
+        },
+        refreshFailed: {
+          title: "Refresh failed",
+        },
+        managedUpdated: {
+          title: "Updated",
+          message: "Managed state changed",
+        },
+        managedFailed: {
+          title: "Update failed",
+        },
+        governanceUpdated: {
+          title: "Updated",
+          message: "Client governance state changed",
+        },
+        governanceFailed: {
+          title: "Update failed",
+        },
+        governanceAllowed: {
+          title: "Updated",
+          message: "Client governance is now allowed.",
+        },
+        governanceDenied: {
+          title: "Updated",
+          message: "Client governance is now denied.",
+        },
+        detachSuccess: {
+          title: "Detached",
+          message: "MCPMate was removed from the client configuration file.",
+        },
+        detachFailed: {
+          title: "Detach failed",
+        },
+        attachSuccess: {
+          title: "Attached",
+          message: "MCPMate was written back to the client configuration.",
+        },
+        attachFailed: {
+          title: "Attach failed",
+        },
+        previewFailed: {
+          title: "Preview failed",
+        },
+        restored: {
+          title: "Restored",
+          message: "Configuration restored from backup",
+        },
+        restoreFailed: {
+          title: "Restore failed",
+        },
+        deleted: {
+          title: "Deleted",
+          message: "Backup deleted",
+        },
+        deleteFailed: {
+          title: "Delete failed",
+        },
+        bulkDeleted: {
+          title: "Deleted",
+          message: "Selected backups have been deleted",
+        },
+        bulkDeleteFailed: {
+          title: "Bulk delete failed",
+        },
+        saved: {
+          title: "Saved",
+          message: "Backup policy updated",
+        },
+        saveFailed: {
+          title: "Save failed",
+        },
+      },
+    },
+  },
+  "zh-CN": {
+    title: "发现并管理客户端连接与可见性",
+    toolbar: {
+      search: {
+        placeholder: "搜索客户端...",
+        fields: {
+          displayName: "显示名称",
+          identifier: "标识符",
+          description: "描述",
+        },
+      },
+      filters: {
+        title: "筛选",
+        options: {
+          all: "全部",
+          allowed: "已允许",
+          pending: "待审批",
+          denied: "已拒绝",
+        },
+      },
+      sort: {
+        options: {
+          displayName: "名称",
+          approvalStatus: "审批状态",
+          managed: "管理状态",
+        },
+      },
+      actions: {
+        refresh: {
+          title: "刷新",
+          notificationTitle: "已触发刷新",
+          notificationMessage: "将同步最新客户端状态",
+        },
+        add: {
+          title: "新增客户端",
+          notificationTitle: "功能开发中",
+          notificationMessage: "该功能正在实现，敬请期待",
+        },
+      },
+    },
+    statsCards: {
+      total: {
+        title: "客户端总数",
+        description: "已发现",
+      },
+      detected: {
+        title: "已检测",
+        description: "已安装",
+      },
+      approved: {
+        title: "已允许",
+        description: "治理已放行",
+      },
+      pending: {
+        title: "待审批",
+        description: "等待审核",
+      },
+    },
+    notifications: {
+      managementUpdated: {
+        title: "已更新",
+        message: "客户端管理状态已更新",
+      },
+      operationFailed: {
+        title: "操作失败",
+      },
+    },
+    entity: {
+      fallbackName: "客户端",
+      stats: {
+        config: "配置",
+        servers: "服务器",
+        managed: "管理",
+        governance: "治理",
+        detected: "检测",
+        attachment: "接入",
+      },
+      config: {
+        notConfigured: "未配置",
+      },
+      bottomTags: {
+        servers: "服务器：{{count}}",
+      },
+      status: {
+        detected: "已检测",
+        notDetected: "未检测",
+      },
+      badge: {
+        detected: "已检测",
+        notDetected: "未检测",
+        allowed: "已允许",
+        pending: "待审批",
+        denied: "已拒绝",
+        defaultPolicy: "默认策略",
+        explicitRecord: "显式记录",
+        writableConfig: "可写配置",
+      },
+      attachment: {
+        attached: "已接入",
+        detached: "已断开",
+        notApplicable: "配置不可用",
+      },
+      tooltip: {
+        attachmentState: "接入状态：{{status}}",
+        attachmentUnavailable: "接入状态：N/A",
+        defaultPolicy: "默认策略：{{answer}}",
+        explicitRecord: "显式记录：{{answer}}",
+        writableConfig: "配置可写：{{answer}}",
+      },
+    },
+    states: {
+      on: "开启",
+      off: "关闭",
+      yes: "是",
+      no: "否",
+      present: "存在",
+      missing: "缺失",
+    },
+    emptyState: {
+      title: "未找到任何客户端",
+      description: "请确认 MCPMate 后端已运行并开启检测",
+    },
+    detail: {
+      noIdentifier: "未提供客户端标识符。",
+      badges: {
+        managed: "管理中",
+        unmanaged: "未管理",
+      },
+      tabs: {
+        overview: "概览",
+        configuration: "配置",
+        backups: "备份",
+        logs: "日志",
+      },
+      directExposure: {
+        title: "能力级直达",
+        badge: "直达暴露",
+        description: "调整本服务器有哪些能力应直接暴露给当前客户端。",
+        serverDescriptionFallback: "选择本服务器中应直接暴露给客户端的能力。",
+        toolsTitle: "工具",
+        toolsSummary: "已直达 {{enabled}} / {{total}} 个能力",
+        tabs: {
+          tools: "工具",
+          prompts: "提示",
+          resources: "资源",
+          templates: "模板",
+          toolsWithCounts: "工具（{{enabled}}/{{total}}）",
+          promptsWithCounts: "提示（{{enabled}}/{{total}}）",
+          resourcesWithCounts: "资源（{{enabled}}/{{total}}）",
+          templatesWithCounts: "模板（{{enabled}}/{{total}}）",
+        },
+        searchPlaceholders: {
+          tools: "搜索工具…",
+          prompts: "搜索提示…",
+          resources: "搜索资源…",
+          templates: "搜索模板…",
+        },
+        empty: {
+          tools: "未找到该服务器的工具。",
+          prompts: "未找到该服务器的提示。",
+          resources: "未找到该服务器的资源。",
+          templates: "未找到该服务器的模板。",
+        },
+        statusPlaceholder: "状态",
+        filters: {
+          status: {
+            all: "全部",
+            enabled: "已启用",
+            disabled: "已停用",
+          },
+        },
+        buttons: {
+          selectAll: "全选",
+          clearSelection: "清空",
+          enable: "启用",
+          disable: "停用",
+        },
+        notifications: {
+          savedTitle: "直达能力已更新",
+          savedMessage: "直达能力暴露配置已更新。",
+          saveFailedTitle: "无法更新直达能力",
+        },
+      },
+      overview: {
+        labels: {
+          configPath: "配置路径",
+          lastModified: "最近修改",
+          supportedTransports: "传输协议",
+          homepage: "主页",
+          docs: "文档",
+          support: "支持",
+        },
+        buttons: {
+          edit: "编辑",
+          refresh: "刷新",
+          enable: "启用",
+          disable: "停用",
+          approve: "批准",
+          reject: "拒绝",
+          allow: "允许",
+          deny: "拒绝治理",
+          detach: "断开",
+          attach: "接入",
+        },
+        noDetails: "暂无详细信息",
+        currentServers: {
+          title: "当前服务器",
+          import: "从配置导入",
+          configuredLabel: "已配置",
+          empty: "未从当前配置解析到服务器。",
+        },
+      },
+      form: {
+        titleCreate: "新增客户端记录",
+        titleEdit: "编辑客户端记录",
+        descriptionCreate: "创建一个带有管理形态与元数据的客户端记录。",
+        descriptionEdit: "更新该客户端记录及其管理设置。",
+        tabs: { basic: "基础", meta: "元数据" },
+        connectionShape: {
+          label: "客户端形态",
+          description:
+            "选择该客户端是否具备可写本地配置文件，或属于不可写的远程/未知客户端。",
+          options: {
+            localWithConfig: "本地 + 配置文件",
+            localWithoutConfig: "本地 / 未知配置",
+            remoteHttp: "远程 HTTP",
+          },
+        },
+        transportSupport: {
+          label: "传输支持",
+          placeholder: "选择支持的传输方式",
+          empty: "未找到传输方式。",
+          description:
+            "选择该客户端支持的运行时传输方式。该数组会作为 hosted / unify 传输选择的唯一约束来源。",
+          validation: {
+            required: "保存前请至少选择一种支持的传输方式。",
+          },
+          options: {
+            stdio: "STDIO",
+            streamableHttpLegacy: "Streamable HTTP",
+            sseLegacy: "SSE（旧版兼容）",
+          },
+        },
+        transportRules: {
+          label: "传输规则",
+          suggestedVariants: "推荐变体",
+          empty: "请先选择至少一种传输方式，再编辑对应写入规则。",
+          stdioDescription: "定义该客户端写入命令型 MCP 服务器时使用的字段名。",
+          httpDescription: "定义该客户端写入 URL 型 MCP 服务器时使用的字段名。",
+          commandField: "命令字段",
+          argsField: "参数字段",
+          envField: "环境变量字段",
+          urlField: "URL 字段",
+          headersField: "请求头字段",
+          includeType: "写入 type 字段",
+          typeValue: "Type 值",
+          extraFields: "额外字段",
+          addExtraField: "添加字段",
+          extraFieldKeyPlaceholder: "enabled",
+          extraFieldValuePlaceholder: 'true 或 "custom"',
+          presets: {
+            common: "常用",
+            withType: "带 type",
+            zedStyle: "Zed 风格",
+          },
+          help: {
+            summary:
+              "这些字段表示目标客户端配置里的键名，不是 MCPMate 自己的协议字段。",
+            docs: "如果不确定客户端期望哪些键，请优先查看该客户端官方文档，或参考一份已正常工作的现有配置。",
+            presets:
+              "下方推荐变体可作为起点，但仍应根据该客户端的真实配置结构进行核对。",
+            openDocs: "打开客户端文档",
+          },
+          validation: {
+            commandRequired: "STDIO 必须指定命令字段。",
+            urlRequired: "HTTP 类传输必须指定 URL 字段。",
+            typeValueRequired: "启用 type 字段时必须填写对应的 type 值。",
+          },
+        },
+        fields: {
+          displayName: { label: "客户端名称", placeholder: "Cursor Desktop" },
+          identifier: {
+            label: "客户端 ID",
+            placeholder: "cursor-desktop",
+            description: "创建新记录时，空格和大小写会自动规范化。",
+          },
+          clientVersion: { label: "客户端版本", placeholder: "可选" },
+          configPath: {
+            label: "配置文件路径",
+            placeholder: "~/.cursor/mcp.json",
+            description:
+              "可写的本地配置路径会让 MCPMate 能通过文件配置操作来管理该客户端。",
+            browse: "选择…",
+            browseAria: "从磁盘选择配置文件",
+            dialogTitle: "选择配置文件",
+            pickFailedTitle: "无法读取所选文件",
+            webPickInfoTitle: "浏览器文件访问",
+            webPickInfoDescription:
+              "浏览器无法自动读取绝对路径，如有需要请手动粘贴。",
+          },
+          configFileParse: {
+            label: "解析规则",
+            formatLabel: "配置格式",
+            containerTypeLabel: "容器类型",
+            containerKeysLabel: "配置节点",
+            containerKeysPlaceholder: "mcpServers, context_servers",
+            showAdvanced: "显示详情",
+            hideAdvanced: "隐藏详情",
+            validationTitle: "文件关联检查",
+            validationSuccess: "所选文件与当前解析规则匹配。",
+            validationHint:
+              "选择一个配置文件后，MCPMate 会验证这些规则是否能定位到 MCP server 条目。",
+            detectedFormat: "检测到的格式",
+            containerMatch: "容器",
+            serverCount: "服务器",
+            matchYes: "已找到",
+            matchNo: "缺失",
+            summaryViewButton: "摘要视图",
+            codeViewButton: "代码预览",
+            keysRequired: "保存解析规则前，至少添加一个配置节点路径。",
+            containerTypeOptions: {
+              standard: "对象映射",
+              array: "数组",
+            },
+            format: { label: "文件格式" },
+            containerType: { label: "容器类型" },
+            containerKeys: { label: "容器键名 (JSON Path)" },
+            validation: {
+              formatMatch: "格式匹配",
+              formatMismatch: "格式不匹配",
+              containerFound: "找到容器",
+              containerMissing: "未找到容器",
+              serversDetected: "检测到 {{count}} 个服务器",
+              noServers: "未检测到服务器",
+              checking: "检查中...",
+            },
+            preview: "预览",
+            previewTitle: "配置预览",
+            autoDetect: "自动检测规则",
+            applyDetected: "应用检测到的规则",
+          },
+          formatRulesJsonText: {
+            label: "格式规则（JSON）",
+            placeholder: "在此粘贴 JSON 格式规则",
+            description:
+              "高级：为传输格式定义细粒度规则（JSON 格式）。留空将重置为默认值。",
+          },
+          logoUrl: {
+            label: "Logo 地址",
+            placeholder: "https://example.com/logo.png",
+          },
+          homepageUrl: {
+            label: "主页地址",
+            placeholder: "https://example.com",
+          },
+          docsUrl: {
+            label: "文档地址",
+            placeholder: "https://docs.example.com",
+          },
+          supportUrl: {
+            label: "支持地址",
+            placeholder: "https://support.example.com",
+          },
+          description: {
+            label: "描述",
+            placeholder: "简要描述这个客户端。",
+            description:
+              "这些元数据字段仅用于展示与提示；旧模板文件现在只保留兼容性 seed 作用。",
+          },
+        },
+        buttons: {
+          cancel: "取消",
+          create: "创建记录",
+          save: "保存更改",
+          delete: "删除",
+        },
+        confirmDelete: {
+          title: "删除客户端记录",
+          description: "确定要删除这条客户端记录吗？此操作不可撤销。",
+          confirm: "删除",
+          cancel: "取消",
+        },
+        notifications: {
+          createSuccess: {
+            title: "客户端记录已创建",
+            message: "客户端记录已创建。",
+          },
+          editSuccess: {
+            title: "客户端记录已更新",
+            message: "客户端记录已更新。",
+          },
+          deleteSuccess: {
+            title: "客户端记录已删除",
+            message: "客户端记录已删除。",
+          },
+          createBackupPolicyFailed: {
+            message:
+              "客户端记录已创建，但初始化备份策略失败。你可以稍后在备份设置中重试。",
+          },
+          formatRulesJsonParseError:
+            "格式规则 JSON 解析失败。请检查语法后重试。",
+          saveFailed: { title: "无法保存客户端记录" },
+          deleteFailed: {
+            title: "无法删除客户端记录",
+            messageMissingIdentifier: "缺少客户端标识符。",
+          },
+        },
+      },
+      configuration: {
+        title: "配置模式",
+        description: "若不清楚含义，请勿修改并保持现有设置。",
+        warnings: {
+          mixedRouting:
+            "混合路由：若把有状态工作流拆成代理与直连调用，可能出现问题。",
+        },
+        errors: {
+          customProfileMissing:
+            "该客户端的专属自定义工作区已缺失，请先重新创建后再应用配置。",
+        },
+        writeTargetRequiredReason:
+          "要把治理配置真正应用到客户端配置文件，必须先确认一个已验证且可写的本地 MCP 配置文件。",
+        applyRequiresApprovedReason:
+          "要把客户端配置真正应用落盘，必须先处于已允许治理状态，并且拥有一个已验证的本地配置目标。",
+        managementSettingsPendingReason:
+          "请在该客户端结束待审批状态后再保存管理设置。",
+        apply: "应用",
+        reapply: "重新应用",
+        sections: {
+          mode: {
+            title: "1. 管理模式",
+            descriptions: {
+              unify:
+                "统一模式初始仅提供内建 MCP 工具，并在当前会话中面向全局启用服务器的能力工作。",
+              hosted:
+                "托管模式会为该客户端保留持久化托管配置，并记住当前选择的工作状态。",
+              transparent:
+                "MCPMate 会将所选配置集中的服务器直接写入该客户端的 MCP 配置，且不会保留能力层级的控制。",
+            },
+            managedDisabledReason:
+              "托管模式与统一模式至少需要一种后端已声明支持的传输方式。",
+            transparentDisabledReason: "透明模式需要可写的本地配置文件路径。",
+            options: {
+              unify: "统一模式",
+              hosted: "托管模式",
+              transparent: "透明模式",
+            },
+          },
+          source: {
+            title: "2. 配置详情",
+            titleTransparent: "2. 配置详情",
+            unifyRouteModes: {
+              broker_only: "全部代理",
+              server_level: "服务器级直达",
+              capability_level: "能力级直达",
+            },
+            descriptions: {
+              unify:
+                "统一模式不使用仪表板中的配置集选择。请在当前会话内通过内建 UCAN 工具浏览并调用来自全局启用服务器的能力。",
+              unify_broker_only:
+                "所有能力均通过 UCAN 代理目录访问。内建 MCP 工具会浏览并调用来自全局启用服务器的能力。",
+              unify_server_level:
+                "将所选符合条件的服务器的全部能力直接暴露给该客户端。已暴露的能力不会出现在 UCAN 目录中。",
+              unify_capability_level:
+                "仅从符合条件的服务器中选择部分能力（工具、提示、资源、模板）直接暴露给该客户端。（进阶）",
+              default: "查看当前已对该客户端运行态生效的配置集。",
+              profile: "浏览共享场景库，并为该客户端选择精确的工作集。",
+              custom: "在当前统一模式工作状态之上创建客户端专属调整。",
+              transparentDefault:
+                "将当前所有已激活配置集中的服务器直接写入该客户端的 MCP 配置。",
+              transparentProfile:
+                "将所选共享配置集中的服务器直接写入该客户端的 MCP 配置。",
+              transparentCustom:
+                "将该客户端专属自定义配置集中的服务器直接写入该客户端的 MCP 配置。",
+            },
+            options: {
+              default: "当前生效",
+              profile: "配置集库",
+              custom: "自定义工作区",
+            },
+            statusLabel: {
+              default: "",
+              profile: "",
+              custom: "",
+            },
+          },
+          profiles: {
+            title: "3. 配置集",
+            descriptions: {
+              unify:
+                "统一模式不会在这里维护配置集工作集。配置集仅用于托管模式或透明模式工作流。",
+              default:
+                "查看当前已对该客户端运行态生效的配置集。为保持场景一致性，此视图为只读。",
+              profile: "选择定义该客户端工作集的可复用共享配置集。",
+              custom: "为当前工作状态创建并维护客户端专属覆盖项。",
+              transparentDefault:
+                "透明模式会将当前所有已激活配置集中已启用的服务器直接写入该客户端的 MCP 配置。",
+              transparentProfile:
+                "选择哪些共享配置集为透明模式下该客户端的 MCP 配置提供已启用服务器。",
+              transparentCustom:
+                "透明模式在写入 MCP 配置时，仅使用该客户端专属自定义配置集中已启用的服务器。",
+            },
+            empty: {
+              active: "未找到已激活的配置集",
+              shared: "未找到共享配置集",
+            },
+            ghost: {
+              titleCustom: "自定义当前状态",
+              titleDefault: "打开配置集库",
+              subtitleCustom: "为当前工作集创建并管理客户端专属覆盖项",
+              subtitleCustomTransparent:
+                "配置哪些服务器会被直接写入当前客户端。",
+              subtitleDefault: "浏览可复用共享场景，并在配置集页面中维护它们",
+            },
+          },
+          unify: {
+            title: "2. 配置详情",
+            description:
+              "统一模式初始仅提供内建 MCP 工具。它会在当前 MCP 会话中通过会话内建工具浏览全局启用服务器的 capabilities，并在会话结束后自动重置。",
+            items: {
+              builtinOnly: "仅内建工具",
+              sessionScoped: "会话内建流程",
+              noFurtherSetup: "仪表板中无需进一步设置",
+            },
+          },
+          exposure: {
+            title: "3. 直达暴露",
+            descriptions: {
+              broker_only:
+                "在仅代理路由模式下，包括标记为直达暴露在内的所有已启用 MCP 服务器，仍通过内建 UCAN 工具访问。",
+              server_level:
+                "选择应将工具、提示、资源与资源模板直接暴露给该客户端的符合条件服务器。",
+              capability_level:
+                "选择符合条件的服务器，并在工具、提示、资源、模板四类能力上进行能力级直达配置。（进阶）",
+            },
+            labels: {
+              ucanRoutingDescription:
+                "在仅代理路由模式下，包括标记为直达暴露的服务器在内，所有已启用的 MCP 服务器仍通过 UCAN 目录与工具调用访问。",
+            },
+            empty: {
+              no_eligible:
+                "暂无可选符合条件服务器。请先在服务器详情中启用统一模式直达暴露。",
+            },
+          },
+        },
+        labels: {
+          noDescription: "暂无描述",
+          openProfileDetail: "打开配置集详情",
+          servers: "服务器",
+          tools: "工具",
+          resources: "资源",
+          prompts: "提示",
+          resourceTemplates: "资源模板",
+          toolsExposed: "个工具已直达",
+          capabilitiesExposed: "项能力已直达",
+        },
+        nonWritableReason: "该记录当前不可写。",
+        transportOptions: {
+          auto: "自动",
+          stdio: "STDIO",
+          streamableHttp: "Streamable HTTP",
+          streamableHttpLegacy: "Streamable HTTP",
+          sseLegacy: "SSE（旧版兼容）",
+        },
+        form: {
+          fields: {
+            configPath: {
+              placeholder: "~/.cursor/mcp.json",
+            },
+            logoUrl: {
+              placeholder: "https://example.com/logo.png",
+            },
+            homepageUrl: {
+              placeholder: "https://example.com",
+            },
+            docsUrl: {
+              placeholder: "https://docs.example.com",
+            },
+            supportUrl: {
+              placeholder: "https://support.example.com",
+            },
+          },
+        },
+      },
+      backups: {
+        title: "备份",
+        description: "恢复或删除配置快照。",
+        buttons: {
+          refresh: "刷新",
+          selectAll: "全选",
+          clear: "清空",
+          deleteSelected: "删除（{{count}}）",
+          restore: "恢复",
+          delete: "删除",
+        },
+        empty: "暂无备份。",
+        emptyDisabledByPolicy: "系统策略当前已禁用备份。",
+        bulk: {
+          title: "删除备份",
+          description: "确定要删除 {{count}} 个备份吗？该操作不可撤销。",
+        },
+      },
+      logs: {
+        title: "日志",
+        description: "展示该客户端关联的运行日志与审计事件。",
+        searchPlaceholder: "搜索日志...",
+        refresh: "刷新日志",
+        expand: "展开日志",
+        collapse: "收起日志",
+        loading: "正在加载日志...",
+        headers: {
+          timestamp: "时间",
+          action: "动作",
+          category: "类别",
+          status: "状态",
+          target: "目标",
+        },
+        empty: "暂未记录任何日志。",
+      },
+      confirm: {
+        deleteTitle: "删除备份",
+        restoreTitle: "恢复备份",
+        deleteDescription: "确定要删除该备份吗？此操作不可撤销。",
+        restoreDescription:
+          "要从选定备份恢复本地客户端配置文件吗？MCPMate 的管理模式与能力设置不会改变。",
+        deleteLabel: "删除",
+        restoreLabel: "恢复",
+        cancelLabel: "取消",
+        detachTitle: "从客户端配置中移除 MCPMate？",
+        detachDescription:
+          "将从客户端配置文件中移除 MCPMate 服务器条目。该客户端正在运行的 MCP 连接可能会中断，直到再次接入；请确认后继续。",
+        detachLabel: "断开",
+        attachTitle: "将 MCPMate 写回客户端配置？",
+        attachDescription:
+          "将把 MCPMate 服务器条目写回客户端配置文件，客户端的 MCP 会话可能会重连；请确认后继续。",
+        attachLabel: "接入",
+      },
+      policy: {
+        title: "备份策略",
+        fields: {
+          policy: "策略",
+          policyDescription:
+            "备份保留策略。目前仅支持“keep_n”，会保留最近 N 个备份并清理更早的备份。",
+          options: {
+            keepN: "keep_n",
+          },
+          limit: "上限",
+          limitDescription: "该客户端保留的备份数量上限，设置为 0 表示不限。",
+        },
+        buttons: {
+          save: "保存策略",
+        },
+      },
+      importPreview: {
+        title: "导入预览",
+        description: "概览当前客户端配置中检测到的服务器。",
+        fields: {
+          attempted: "已尝试",
+          imported: "已导入",
+          skipped: "已跳过",
+          failed: "失败",
+        },
+        noPreview: "暂无预览数据。",
+        sections: {
+          servers: "待导入服务器",
+          errors: "错误信息",
+          skippedDetailsSingle: "跳过详情（{{count}} 个服务器）",
+          skippedDetailsPlural: "跳过详情（{{count}} 个服务器）",
+          raw: "原始预览 JSON",
+          stats:
+            "工具：{{tools}} • 资源：{{resources}} • 模板：{{templates}} • 提示：{{prompts}}",
+        },
+        queryLabels: {
+          existing: "现有查询参数",
+          incoming: "传入查询参数",
+        },
+        skippedReasons: {
+          duplicateName: "名称重复",
+          duplicateFingerprint: "指纹重复",
+          urlQueryMismatch: "URL 查询参数不匹配",
+          unknown: "未知原因",
+        },
+        buttons: {
+          close: "关闭",
+          apply: "应用导入",
+          preview: "生成预览",
+        },
+        states: {
+          noImportNeeded: "无需导入",
+        },
+      },
+      notifications: {
+        reviewSuccess: {
+          title: "成功",
+          messageApproved: "记录已成功批准。",
+          messageSuspended: "记录已成功暂停。",
+        },
+        reviewFailed: {
+          title: "审批失败",
+        },
+        previewReady: {
+          title: "预览已就绪",
+          message: "请在应用前先查看差异。",
+          noChanges: "当前配置未产生任何变化。",
+        },
+        applied: {
+          title: "已应用",
+          message: "配置已应用",
+        },
+        managementSaved: {
+          title: "已保存",
+          message: "管理设置已保存到 MCPMate，本地客户端配置未更新。",
+        },
+        applyFailed: {
+          title: "应用失败",
+        },
+        imported: {
+          title: "导入完成",
+          messageSingle: "成功导入 {{count}} 个服务器",
+          messagePlural: "成功导入 {{count}} 个服务器",
+        },
+        nothingToImport: {
+          title: "无需导入",
+          message: "所有条目已跳过或没有可导入的服务器。",
+        },
+        importFailed: {
+          title: "导入失败",
+        },
+        refreshed: {
+          title: "已刷新",
+          message: "检测状态已刷新",
+        },
+        refreshFailed: {
+          title: "刷新失败",
+        },
+        managedUpdated: {
+          title: "已更新",
+          message: "托管状态已变更",
+        },
+        managedFailed: {
+          title: "更新失败",
+        },
+        governanceUpdated: {
+          title: "已更新",
+          message: "客户端治理状态已变更",
+        },
+        governanceFailed: {
+          title: "更新失败",
+        },
+        governanceAllowed: {
+          title: "已更新",
+          message: "该客户端现已允许。",
+        },
+        governanceDenied: {
+          title: "已更新",
+          message: "该客户端现已禁行。",
+        },
+        detachSuccess: {
+          title: "已断开",
+          message: "已从客户端配置中移除 MCPMate 条目。",
+        },
+        detachFailed: {
+          title: "断开失败",
+        },
+        attachSuccess: {
+          title: "已接入",
+          message: "已将 MCPMate 写回客户端配置文件。",
+        },
+        attachFailed: {
+          title: "接入失败",
+        },
+        previewFailed: {
+          title: "预览失败",
+        },
+        restored: {
+          title: "恢复完成",
+          message: "已从备份恢复配置",
+        },
+        restoreFailed: {
+          title: "恢复失败",
+        },
+        deleted: {
+          title: "删除完成",
+          message: "备份已删除",
+        },
+        deleteFailed: {
+          title: "删除失败",
+        },
+        bulkDeleted: {
+          title: "删除完成",
+          message: "已删除所选备份",
+        },
+        bulkDeleteFailed: {
+          title: "批量删除失败",
+        },
+        saved: {
+          title: "已保存",
+          message: "备份策略已更新",
+        },
+        saveFailed: {
+          title: "保存失败",
+        },
+      },
+    },
+  },
+  "ja-JP": {
+    title: "クライアント接続と可視性の管理",
+    toolbar: {
+      search: {
+        placeholder: "クライアントを検索...",
+        fields: {
+          displayName: "表示名",
+          identifier: "識別子",
+          description: "説明",
+        },
+      },
+      filters: {
+        title: "フィルター",
+        options: {
+          all: "すべて",
+          allowed: "許可済み",
+          pending: "承認待ち",
+          denied: "拒否",
+        },
+      },
+      sort: {
+        options: {
+          displayName: "名前",
+          approvalStatus: "承認状態",
+          managed: "管理状況",
+        },
+      },
+      actions: {
+        refresh: {
+          title: "更新",
+          notificationTitle: "更新を開始しました",
+          notificationMessage: "最新のクライアント状態を同期します",
+        },
+        add: {
+          title: "クライアントを追加",
+          notificationTitle: "開発中の機能",
+          notificationMessage: "機能を開発中です。しばらくお待ちください",
+        },
+      },
+    },
+    statsCards: {
+      total: {
+        title: "クライアント総数",
+        description: "検出済み",
+      },
+      detected: {
+        title: "検出",
+        description: "インストール済み",
+      },
+      approved: {
+        title: "許可済み",
+        description: "ガバナンス許可済み",
+      },
+      pending: {
+        title: "承認待ち",
+        description: "レビュー待ち",
+      },
+    },
+    notifications: {
+      managementUpdated: {
+        title: "更新しました",
+        message: "クライアントの管理状態を更新しました",
+      },
+      operationFailed: {
+        title: "操作に失敗しました",
+      },
+    },
+    entity: {
+      fallbackName: "クライアント",
+      stats: {
+        config: "設定",
+        servers: "サーバー",
+        managed: "管理",
+        governance: "ガバナンス",
+        detected: "検出",
+        attachment: "接続",
+      },
+      config: {
+        notConfigured: "未設定",
+      },
+      bottomTags: {
+        servers: "サーバー: {{count}}",
+      },
+      status: {
+        detected: "検出済み",
+        notDetected: "未検出",
+      },
+      badge: {
+        detected: "検出済み",
+        notDetected: "未検出",
+        allowed: "許可済み",
+        pending: "承認待ち",
+        denied: "拒否済み",
+        defaultPolicy: "デフォルトポリシー",
+        explicitRecord: "明示レコード",
+        writableConfig: "書き込み可能",
+      },
+      attachment: {
+        attached: "接続済み",
+        detached: "切り離し済み",
+        notApplicable: "設定 N/A",
+      },
+      tooltip: {
+        attachmentState: "接続状態: {{status}}",
+        attachmentUnavailable: "接続状態: N/A",
+        defaultPolicy: "デフォルトポリシー: {{answer}}",
+        explicitRecord: "明示レコード: {{answer}}",
+        writableConfig: "設定を書き込み可能: {{answer}}",
+      },
+    },
+    states: {
+      on: "オン",
+      off: "オフ",
+      yes: "はい",
+      no: "いいえ",
+      present: "あり",
+      missing: "なし",
+    },
+    emptyState: {
+      title: "クライアントが見つかりません",
+      description: "MCPMate バックエンドが動作し検出が有効か確認してください",
+    },
+    detail: {
+      noIdentifier: "クライアント識別子が指定されていません。",
+      badges: {
+        managed: "管理中",
+        unmanaged: "未管理",
+      },
+      tabs: {
+        overview: "概要",
+        configuration: "設定",
+        backups: "バックアップ",
+        logs: "ログ",
+      },
+      directExposure: {
+        title: "能力レベル直達",
+        badge: "直接公開",
+        description:
+          "このサーバーのどのケイパビリティを現在のクライアントへ直接公開するかを調整します。",
+        serverDescriptionFallback:
+          "このサーバーからクライアントへ直接公開するケイパビリティを選択します。",
+        toolsTitle: "ツール",
+        toolsSummary: "直接公開 {{enabled}} / {{total}} ケイパビリティ",
+        tabs: {
+          tools: "ツール",
+          prompts: "プロンプト",
+          resources: "リソース",
+          templates: "テンプレート",
+          toolsWithCounts: "ツール（{{enabled}}/{{total}}）",
+          promptsWithCounts: "プロンプト（{{enabled}}/{{total}}）",
+          resourcesWithCounts: "リソース（{{enabled}}/{{total}}）",
+          templatesWithCounts: "テンプレート（{{enabled}}/{{total}}）",
+        },
+        searchPlaceholders: {
+          tools: "ツールを検索…",
+          prompts: "プロンプトを検索…",
+          resources: "リソースを検索…",
+          templates: "テンプレートを検索…",
+        },
+        empty: {
+          tools: "このサーバーにツールが見つかりません。",
+          prompts: "このサーバーにプロンプトが見つかりません。",
+          resources: "このサーバーにリソースが見つかりません。",
+          templates: "このサーバーにテンプレートが見つかりません。",
+        },
+        statusPlaceholder: "状態",
+        filters: {
+          status: {
+            all: "すべて",
+            enabled: "有効",
+            disabled: "無効",
+          },
+        },
+        buttons: {
+          selectAll: "すべて選択",
+          clearSelection: "クリア",
+          enable: "有効化",
+          disable: "無効化",
+        },
+        notifications: {
+          savedTitle: "直接公開ケイパビリティを更新しました",
+          savedMessage: "直接公開するケイパビリティ設定を更新しました。",
+          saveFailedTitle: "直接公開ケイパビリティを更新できません",
+        },
+      },
+      overview: {
+        labels: {
+          configPath: "設定パス",
+          lastModified: "最終更新",
+          supportedTransports: "対応トランスポート",
+          homepage: "ホームページ",
+          docs: "ドキュメント",
+          support: "サポート",
+        },
+        buttons: {
+          edit: "編集",
+          refresh: "更新",
+          enable: "有効化",
+          disable: "無効化",
+          approve: "承認",
+          reject: "拒否",
+          allow: "許可",
+          deny: "拒否",
+          detach: "切り離す",
+          attach: "再接続",
+        },
+        noDetails: "詳細情報がありません",
+        currentServers: {
+          title: "現在のサーバー",
+          import: "設定からインポート",
+          configuredLabel: "設定済み",
+          empty: "現在の設定からサーバーを取得できませんでした。",
+        },
+      },
+      form: {
+        titleCreate: "クライアントレコードを追加",
+        titleEdit: "クライアントレコードを編集",
+        descriptionCreate:
+          "管理形態とメタデータを含むクライアントレコードを作成します。",
+        descriptionEdit: "このクライアントレコードと管理設定を更新します。",
+        tabs: { basic: "基本", meta: "メタデータ" },
+        connectionShape: {
+          label: "クライアント形態",
+          description:
+            "このクライアントが書き込み可能なローカル設定ファイルを持つか、書き込み不可のリモート/未知クライアントかを選択します。",
+          options: {
+            localWithConfig: "ローカル + 設定ファイル",
+            localWithoutConfig: "ローカル / 不明な設定",
+            remoteHttp: "リモート HTTP",
+          },
+        },
+        transportSupport: {
+          label: "対応トランスポート",
+          placeholder: "対応するトランスポートを選択",
+          empty: "トランスポートが見つかりません。",
+          description:
+            "このクライアントが対応するランタイムトランスポートを選択します。この配列は hosted / unify のトランスポート選択を制約する唯一の情報源です。",
+          validation: {
+            required:
+              "保存する前に、少なくとも 1 つの対応トランスポートを選択してください。",
+          },
+          options: {
+            stdio: "STDIO",
+            streamableHttpLegacy: "ストリーミング HTTP",
+            sseLegacy: "SSE（レガシー互換）",
+          },
+        },
+        transportRules: {
+          label: "トランスポートルール",
+          suggestedVariants: "推奨バリアント",
+          empty:
+            "少なくとも 1 つのトランスポートを選択してから書き込みルールを編集してください。",
+          stdioDescription:
+            "このクライアントへコマンド型 MCP サーバーを書き込む際のフィールド名を定義します。",
+          httpDescription:
+            "このクライアントへ URL 型 MCP サーバーを書き込む際のフィールド名を定義します。",
+          commandField: "コマンドフィールド",
+          argsField: "引数フィールド",
+          envField: "環境変数フィールド",
+          urlField: "URL フィールド",
+          headersField: "ヘッダーフィールド",
+          includeType: "type フィールドを含める",
+          typeValue: "Type 値",
+          extraFields: "追加フィールド",
+          addExtraField: "フィールドを追加",
+          extraFieldKeyPlaceholder: "enabled",
+          extraFieldValuePlaceholder: 'true または "custom"',
+          presets: {
+            common: "一般的",
+            withType: "type 付き",
+            zedStyle: "Zed スタイル",
+          },
+          help: {
+            summary:
+              "これらのフィールドは、MCPMate 自身のプロトコル項目ではなく、対象クライアント設定内のキー名を表します。",
+            docs: "クライアントが期待するキー名に迷った場合は、まずそのクライアントの公式ドキュメントまたは既存の正常な設定を確認してください。",
+            presets:
+              "下の推奨バリアントは出発点として使えますが、最終的にはそのクライアントの実際の設定構造に合わせて確認してください。",
+            openDocs: "クライアントのドキュメントを開く",
+          },
+          validation: {
+            commandRequired: "STDIO では command フィールドが必要です。",
+            urlRequired: "HTTP 系トランスポートでは URL フィールドが必要です。",
+            typeValueRequired:
+              "type フィールドを含める場合は type 値が必要です。",
+          },
+        },
+        fields: {
+          displayName: {
+            label: "クライアント名",
+            placeholder: "Cursor Desktop",
+          },
+          identifier: {
+            label: "クライアント ID",
+            placeholder: "cursor-desktop",
+            description:
+              "新規レコード作成時は、スペースと大文字小文字が自動で正規化されます。",
+          },
+          clientVersion: {
+            label: "クライアントバージョン",
+            placeholder: "任意",
+          },
+          configPath: {
+            label: "設定ファイルパス",
+            placeholder: "~/.cursor/mcp.json",
+            description:
+              "書き込み可能なローカル設定パスがある場合、MCPMate はファイルベースの設定操作でこのクライアントを管理できます。",
+            browse: "選択…",
+            browseAria: "ディスク上の設定ファイルを選択",
+            dialogTitle: "設定ファイルを選択",
+            pickFailedTitle: "選択したファイルを読み取れませんでした",
+            webPickInfoTitle: "ブラウザのファイルアクセス",
+            webPickInfoDescription:
+              "ブラウザは絶対パスを自動取得できません。必要なら手動で貼り付けてください。",
+          },
+          configFileParse: {
+            label: "解析ルール",
+            formatLabel: "設定フォーマット",
+            containerTypeLabel: "コンテナタイプ",
+            containerKeysLabel: "設定ノード",
+            containerKeysPlaceholder: "mcpServers, context_servers",
+            showAdvanced: "詳細を表示",
+            hideAdvanced: "詳細を非表示",
+            validationTitle: "ファイル関連付けチェック",
+            validationSuccess:
+              "選択したファイルは現在の解析ルールに一致しています。",
+            validationHint:
+              "設定ファイルを選択すると、MCPMate がこれらのルールで MCP server エントリを見つけられるか検証します。",
+            detectedFormat: "検出フォーマット",
+            containerMatch: "コンテナ",
+            serverCount: "サーバー",
+            matchYes: "見つかりました",
+            matchNo: "見つかりません",
+            summaryViewButton: "サマリー表示",
+            codeViewButton: "コードプレビュー",
+            keysRequired:
+              "解析ルールを保存する前に、設定ノードパスを少なくとも1つ追加してください。",
+            containerTypeOptions: {
+              standard: "オブジェクトマップ",
+              array: "配列",
+            },
+            format: { label: "フォーマット" },
+            containerType: { label: "コンテナタイプ" },
+            containerKeys: { label: "コンテナキー (JSON Path)" },
+            validation: {
+              formatMatch: "フォーマット一致",
+              formatMismatch: "フォーマット不一致",
+              containerFound: "コンテナ検出",
+              containerMissing: "コンテナ未検出",
+              serversDetected: "{{count}}個のサーバーを検出",
+              noServers: "サーバー未検出",
+              checking: "検査中...",
+            },
+            preview: "プレビュー",
+            previewTitle: "設定プレビュー",
+            autoDetect: "ルール自動検出",
+            applyDetected: "検出ルールを適用",
+          },
+          formatRulesJsonText: {
+            label: "フォーマットルール（JSON）",
+            placeholder: "JSON フォーマットルールをここに貼り付けてください",
+            description:
+              "高度な設定：トランスポート形式の細粒度ルールを JSON で定義します。空にするとデフォルト値にリセットされます。",
+          },
+          logoUrl: {
+            label: "ロゴ URL",
+            placeholder: "https://example.com/logo.png",
+          },
+          homepageUrl: {
+            label: "ホームページ URL",
+            placeholder: "https://example.com",
+          },
+          docsUrl: {
+            label: "ドキュメント URL",
+            placeholder: "https://docs.example.com",
+          },
+          supportUrl: {
+            label: "サポート URL",
+            placeholder: "https://support.example.com",
+          },
+          description: {
+            label: "説明",
+            placeholder: "このクライアントの概要を入力してください。",
+            description:
+              "これらのメタデータは表示とガイダンスのために保存されます。旧テンプレートファイルは互換性 seed としてのみ残ります。",
+          },
+        },
+        buttons: {
+          cancel: "キャンセル",
+          create: "レコードを作成",
+          save: "変更を保存",
+          delete: "削除",
+        },
+        confirmDelete: {
+          title: "クライアントレコードを削除",
+          description:
+            "このクライアントレコードを削除してもよろしいですか？この操作は元に戻せません。",
+          confirm: "削除",
+          cancel: "キャンセル",
+        },
+        notifications: {
+          createSuccess: {
+            title: "クライアントレコードを作成しました",
+            message: "クライアントレコードを作成しました。",
+          },
+          editSuccess: {
+            title: "クライアントレコードを更新しました",
+            message: "クライアントレコードを更新しました。",
+          },
+          deleteSuccess: {
+            title: "クライアントレコードを削除しました",
+            message: "クライアントレコードを削除しました。",
+          },
+          createBackupPolicyFailed: {
+            message:
+              "クライアントレコードは作成されましたが、初期バックアップポリシーの適用に失敗しました。後でバックアップ設定から再試行できます。",
+          },
+          formatRulesJsonParseError:
+            "フォーマットルール JSON の解析に失敗しました。構文を確認して再度お試しください。",
+          saveFailed: { title: "クライアントレコードを保存できませんでした" },
+          deleteFailed: {
+            title: "クライアントレコードを削除できません",
+            messageMissingIdentifier: "クライアント識別子がありません。",
+          },
+        },
+      },
+      configuration: {
+        title: "設定モード",
+        description: "意味が不明な場合は変更せず現状の設定を維持してください。",
+        warnings: {
+          mixedRouting:
+            "混合ルーティング: ステートフルな手順を分割すると問題が起きる可能性があります。",
+        },
+        errors: {
+          customProfileMissing:
+            "このクライアント専用のカスタムワークスペースが見つかりません。設定を適用する前に再作成してください。",
+        },
+        writeTargetRequiredReason:
+          "クライアント設定ファイルへガバナンスを適用するには、検証済みで書き込み可能なローカル MCP 設定ファイルが必要です。",
+        applyRequiresApprovedReason:
+          "クライアント設定を適用するには、許可済みのガバナンス状態と検証済みのローカル設定対象が必要です。",
+        managementSettingsPendingReason:
+          "このクライアントが承認待ち状態を抜けてから管理設定を保存してください。",
+        apply: "適用",
+        reapply: "再適用",
+        sections: {
+          mode: {
+            title: "1. 管理モード",
+            descriptions: {
+              unify:
+                "統一モードは内蔵 MCP ツールのみで開始し、現在のセッションではグローバルに有効なサーバーのケイパビリティを扱います。",
+              hosted:
+                "ホスト型モードはこのクライアントの持続的な管理設定を保持し、現在のワーク状態を記憶します。",
+              transparent:
+                "MCPMate は選択したプロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込み、ケイパビリティ単位の制御は保持しません。",
+            },
+            managedDisabledReason:
+              "ホスト型モードと統一モードを使うには、少なくとも 1 つのサポート対象トランスポートが必要です。",
+            transparentDisabledReason:
+              "トランスペアレントモードには、書き込み可能なローカル設定ファイルのパスが必要です。",
+            options: {
+              unify: "統一モード",
+              hosted: "ホスト型モード",
+              transparent: "トランスペアレントモード",
+            },
+          },
+          source: {
+            title: "2. 設定",
+            titleTransparent: "2. 設定",
+            unifyRouteModes: {
+              broker_only: "ブローカーのみ",
+              server_level: "サーバーレベル",
+              capability_level: "能力レベル直達",
+            },
+            descriptions: {
+              unify:
+                "統一モードではダッシュボード上のプロファイル選択を使いません。現在のセッションでは、内蔵 UCAN ツールでグローバルに有効なサーバーのケイパビリティを参照・呼び出します。",
+              unify_broker_only:
+                "すべてのケイパビリティは UCAN ブローカーカタログ越しに提供されます。内蔵 MCP ツールがグローバルに有効なサーバーのケイパビリティを参照・呼び出します。",
+              unify_server_level:
+                "選択した対象サーバーから、このクライアントへケイパビリティを直接公開します。公開されたケイパビリティは UCAN カタログには載りません。",
+              unify_capability_level:
+                "対象サーバーから選択したケイパビリティ（ツール、プロンプト、リソース、テンプレート）のみをこのクライアントへ直接公開します。（上級）",
+              default:
+                "このクライアントの実行時に現在有効なプロファイルを確認します。",
+              profile:
+                "共有シーンライブラリを参照し、このクライアントの正確なワークセットを選択します。",
+              custom:
+                "現在の統一モードのワーク状態の上にクライアント専用の調整を作成します。",
+              transparentDefault:
+                "現在有効なすべてのプロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
+              transparentProfile:
+                "選択した共有プロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
+              transparentCustom:
+                "このクライアント専用のカスタムプロファイルのサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
+            },
+            options: {
+              default: "有効なプロファイル",
+              profile: "プロファイルライブラリ",
+              custom: "カスタムワークスペース",
+            },
+            statusLabel: {
+              default: "",
+              profile: "",
+              custom: "",
+            },
+          },
+          profiles: {
+            title: "3. プロファイル",
+            descriptions: {
+              unify:
+                "統一モードではここでプロファイルのワークセットを維持しません。プロファイルはホスト型モードまたはトランスペアレントモードのワークフローで使用します。",
+              default:
+                "このクライアントの実行時にすでに有効なプロファイルを確認します。シーンの一貫性を保つため、このビューは読み取り専用です。",
+              profile:
+                "このクライアントのワークセットを定義する再利用可能な共有プロファイルを選択します。",
+              custom:
+                "現在のワーク状態に対するクライアント専用オーバーライドを作成・維持します。",
+              transparentDefault:
+                "トランスペアレントモードでは、現在有効なすべてのプロファイルの有効化されたサーバーをこのクライアントの MCP 設定へ直接書き込みます。",
+              transparentProfile:
+                "トランスペアレントモードでこのクライアントの MCP 設定に有効化されたサーバーを提供する共有プロファイルを選択します。",
+              transparentCustom:
+                "トランスペアレントモードで MCP 設定を書き込む際は、このクライアント専用カスタムプロファイルの有効化されたサーバーのみを使用します。",
+            },
+            empty: {
+              active: "有効なプロファイルが見つかりません",
+              shared: "共有プロファイルが見つかりません",
+            },
+            ghost: {
+              titleCustom: "現在の状態をカスタマイズ",
+              titleDefault: "プロファイルライブラリを開く",
+              subtitleCustom:
+                "現在のワークスペースに対するクライアント専用オーバーライドを作成・管理",
+              subtitleCustomTransparent:
+                "このクライアントへ直接書き込むサーバーを設定します。",
+              subtitleDefault:
+                "再利用可能な共有シーンを参照し、プロファイルページで編集します",
+            },
+          },
+          unify: {
+            title: "2. 設定",
+            description:
+              "統一モードは内蔵 MCP ツールのみで開始します。現在の MCP セッションでは、セッション内の内蔵フローでグローバルに有効なサーバーのケイパビリティを参照し、終了時に自動的にリセットされます。",
+            items: {
+              builtinOnly: "内蔵ツールのみ",
+              sessionScoped: "セッション内の内蔵フロー",
+              noFurtherSetup: "ダッシュボードで追加設定は不要",
+            },
+          },
+          exposure: {
+            title: "3. 直接公開",
+            descriptions: {
+              broker_only:
+                "ブローカーのみモードでは、直接公開対象としてマークされたサーバーを含む、有効な MCP サーバーはすべて内蔵 UCAN ツール経由で利用できます。",
+              server_level:
+                "ツール、プロンプト、リソース、リソーステンプレートをこのクライアントへ直接公開する対象サーバーを選択します。",
+              capability_level:
+                "対象サーバーを選び、ツール、プロンプト、リソース、テンプレートを能力単位で直接公開する設定を行います。（上級）",
+            },
+            labels: {
+              ucanRoutingDescription:
+                "ブローカーのみモードでは、直接公開としてマークされたサーバーを含め、有効な MCP サーバーはすべて UCAN カタログとツール呼び出し経由でアクセスされます。",
+            },
+            empty: {
+              no_eligible:
+                "対象となるサーバーがありません。先にサーバー詳細で Unify の直接公開を有効にしてください。",
+            },
+          },
+        },
+        labels: {
+          noDescription: "説明なし",
+          openProfileDetail: "プロファイルの詳細を開く",
+          servers: "サーバー",
+          tools: "ツール",
+          resources: "リソース",
+          prompts: "プロンプト",
+          resourceTemplates: "リソーステンプレート",
+          toolsExposed: "個のツールを直接公開",
+          capabilitiesExposed: "個のケイパビリティを直接公開",
+        },
+        nonWritableReason: "このレコードは現在書き込みできません。",
+        transportOptions: {
+          auto: "自動",
+          stdio: "STDIO",
+          streamableHttp: "ストリーミング HTTP",
+          streamableHttpLegacy: "ストリーミング HTTP",
+          sseLegacy: "SSE（レガシー互換）",
+        },
+        form: {
+          fields: {
+            configPath: {
+              placeholder: "~/.cursor/mcp.json",
+            },
+            logoUrl: {
+              placeholder: "https://example.com/logo.png",
+            },
+            homepageUrl: {
+              placeholder: "https://example.com",
+            },
+            docsUrl: {
+              placeholder: "https://docs.example.com",
+            },
+            supportUrl: {
+              placeholder: "https://support.example.com",
+            },
+          },
+        },
+      },
+      backups: {
+        title: "バックアップ",
+        description: "設定スナップショットの復元・削除を行います。",
+        buttons: {
+          refresh: "更新",
+          selectAll: "すべて選択",
+          clear: "クリア",
+          deleteSelected: "選択した項目を削除（{{count}}）",
+          restore: "復元",
+          delete: "削除",
+        },
+        empty: "バックアップはありません。",
+        emptyDisabledByPolicy:
+          "システムポリシーにより現在バックアップは無効です。",
+        bulk: {
+          title: "選択したバックアップを削除",
+          description:
+            "{{count}} 件のバックアップを削除しますか？この操作は元に戻せません。",
+        },
+      },
+      logs: {
+        title: "ログ",
+        description:
+          "このクライアントに関連する実行ログと監査イベントを表示します。",
+        searchPlaceholder: "ログを検索...",
+        refresh: "ログを更新",
+        expand: "ログを展開",
+        collapse: "ログを折りたたむ",
+        loading: "ログを読み込み中...",
+        headers: {
+          timestamp: "時刻",
+          action: "アクション",
+          category: "カテゴリ",
+          status: "ステータス",
+          target: "対象",
+        },
+        empty: "まだログが記録されていません。",
+      },
+      confirm: {
+        deleteTitle: "バックアップを削除",
+        restoreTitle: "バックアップを復元",
+        deleteDescription:
+          "このバックアップを削除しますか？この操作は元に戻せません。",
+        restoreDescription:
+          "選択したバックアップからローカルのクライアント設定ファイルを復元しますか？MCPMate の管理モードと能力設定は変更されません。",
+        deleteLabel: "削除",
+        restoreLabel: "復元",
+        cancelLabel: "キャンセル",
+        detachTitle: "クライアント設定から MCPMate を切り離しますか？",
+        detachDescription:
+          "MCPMate のサーバー定義をクライアント設定ファイルから削除します。実行中の MCP 接続は再接続まで利用できない場合があります。続行する前に確認してください。",
+        detachLabel: "切り離す",
+        attachTitle: "クライアント設定に MCPMate を書き戻しますか？",
+        attachDescription:
+          "MCPMate のサーバー定義をクライアント設定ファイルに再度書き込みます。MCP セッションが再接続する場合があります。続行する前に確認してください。",
+        attachLabel: "再接続",
+      },
+      policy: {
+        title: "バックアップポリシー",
+        fields: {
+          policy: "ポリシー",
+          policyDescription:
+            'バックアップ保持方針です。現在は "keep_n" のみ対応し、最新 N 件を保持して古いものを削除します。',
+          options: {
+            keepN: "keep_n",
+          },
+          limit: "上限",
+          limitDescription:
+            "このクライアントで保持するバックアップ数の上限です。0 にすると無制限です。",
+        },
+        buttons: {
+          save: "ポリシーを保存",
+        },
+      },
+      importPreview: {
+        title: "インポートプレビュー",
+        description: "現在の設定から検出したサーバーの概要です。",
+        fields: {
+          attempted: "試行",
+          imported: "インポート済み",
+          skipped: "スキップ",
+          failed: "失敗",
+        },
+        noPreview: "プレビューはありません。",
+        sections: {
+          servers: "インポート対象サーバー",
+          errors: "エラー",
+          skippedDetailsSingle: "スキップ詳細（{{count}} 件のサーバー）",
+          skippedDetailsPlural: "スキップ詳細（{{count}} 件のサーバー）",
+          raw: "プレビュー JSON",
+          stats:
+            "ツール: {{tools}} • リソース: {{resources}} • テンプレート: {{templates}} • プロンプト: {{prompts}}",
+        },
+        queryLabels: {
+          existing: "既存のクエリ",
+          incoming: "入力クエリ",
+        },
+        skippedReasons: {
+          duplicateName: "名前の重複",
+          duplicateFingerprint: "フィンガープリントの重複",
+          urlQueryMismatch: "URL クエリ不一致",
+          unknown: "不明な理由",
+        },
+        buttons: {
+          close: "閉じる",
+          apply: "インポートを適用",
+          preview: "プレビュー",
+        },
+        states: {
+          noImportNeeded: "インポート不要",
+        },
+      },
+      notifications: {
+        reviewSuccess: {
+          title: "成功",
+          messageApproved: "レコードを承認しました。",
+          messageSuspended: "レコードを停止しました。",
+        },
+        reviewFailed: {
+          title: "レビューに失敗しました",
+        },
+        previewReady: {
+          title: "プレビュー準備完了",
+          message: "適用前に差分を確認してください。",
+          noChanges: "この設定では変更はありませんでした。",
+        },
+        applied: {
+          title: "適用しました",
+          message: "設定を適用しました",
+        },
+        managementSaved: {
+          title: "保存しました",
+          message:
+            "管理設定を MCPMate に保存しました。ローカルのクライアント設定は更新していません。",
+        },
+        applyFailed: {
+          title: "適用に失敗しました",
+        },
+        imported: {
+          title: "インポート完了",
+          messageSingle: "{{count}} 件のサーバーをインポートしました",
+          messagePlural: "{{count}} 件のサーバーをインポートしました",
+        },
+        nothingToImport: {
+          title: "インポート不要",
+          message:
+            "すべての項目がスキップされたか、インポート可能なサーバーがありません。",
+        },
+        importFailed: {
+          title: "インポートに失敗しました",
+        },
+        refreshed: {
+          title: "更新しました",
+          message: "検出状態を更新しました",
+        },
+        refreshFailed: {
+          title: "更新に失敗しました",
+        },
+        managedUpdated: {
+          title: "更新しました",
+          message: "管理状態が変更されました",
+        },
+        managedFailed: {
+          title: "更新に失敗しました",
+        },
+        governanceUpdated: {
+          title: "更新しました",
+          message: "クライアントのガバナンス状態を変更しました",
+        },
+        governanceFailed: {
+          title: "更新に失敗しました",
+        },
+        governanceAllowed: {
+          title: "更新しました",
+          message: "このクライアントは許可状態になりました。",
+        },
+        governanceDenied: {
+          title: "更新しました",
+          message: "このクライアントは拒否状態になりました。",
+        },
+        detachSuccess: {
+          title: "切り離しました",
+          message: "クライアント設定から MCPMate エントリを削除しました。",
+        },
+        detachFailed: {
+          title: "切り離しに失敗しました",
+        },
+        attachSuccess: {
+          title: "再接続しました",
+          message: "クライアント設定に MCPMate を書き戻しました。",
+        },
+        attachFailed: {
+          title: "再接続に失敗しました",
+        },
+        previewFailed: {
+          title: "プレビューに失敗しました",
+        },
+        restored: {
+          title: "復元しました",
+          message: "バックアップから設定を復元しました",
+        },
+        restoreFailed: {
+          title: "復元に失敗しました",
+        },
+        deleted: {
+          title: "削除しました",
+          message: "バックアップを削除しました",
+        },
+        deleteFailed: {
+          title: "削除に失敗しました",
+        },
+        bulkDeleted: {
+          title: "削除しました",
+          message: "選択したバックアップを削除しました",
+        },
+        bulkDeleteFailed: {
+          title: "一括削除に失敗しました",
+        },
+        saved: {
+          title: "保存しました",
+          message: "バックアップポリシーを更新しました",
+        },
+        saveFailed: {
+          title: "保存に失敗しました",
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- return structured skipped-server details from client config import preview
- include duplicate and URL query mismatch reasons in the API response
- show skip details in the client import preview drawer

## Test plan
- [x] Run `bun run build` in `board`
- [ ] Verify import preview shows skipped reason details for duplicates