### PR TITLE
feat(runtime): add managed Node.js runtime support

### DIFF
--- a/backend/src/api/handlers/runtime.rs
+++ b/backend/src/api/handlers/runtime.rs
@@ -21,7 +21,7 @@ pub async fn install(
     let started_at = std::time::Instant::now();
     let runtime_type = request.runtime_type.clone();
 
-    let result = runtime_install_core(&request, &app_state).await;
+    let result = runtime_install_core(&request).await;
 
     let (audit_status, audit_error) = match &result {
         Ok(resp) => {
@@ -124,66 +124,61 @@ pub async fn reset_cache(
     result.map(Json)
 }
 
-async fn runtime_install_core(
-    request: &RuntimeInstallReq,
-    app_state: &AppState,
-) -> Result<RuntimeInstallResp, StatusCode> {
+async fn runtime_install_core(request: &RuntimeInstallReq) -> Result<RuntimeInstallResp, StatusCode> {
     let runtime_type: RuntimeType = request.runtime_type.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 
     let manager = RuntimeManager::new();
+    let existing_installation = manager.is_installed(runtime_type);
 
-    // Early return if already installed
-    if manager.is_installed(runtime_type) {
-        tracing::info!("Runtime {} already installed", runtime_type);
-
-        return Ok(RuntimeInstallResp::success(RuntimeInstallData {
-            success: true,
-            message: format!("Runtime {} already installed", runtime_type),
-            runtime_type: request.runtime_type.clone(),
-        }));
-    }
-
-    // Proceed with installation
     tracing::info!(
-        "Runtime {} not found, proceeding with download and installation",
-        runtime_type
+        "Runtime {} {}",
+        runtime_type,
+        if existing_installation {
+            "already exists, proceeding with repair/reinstall"
+        } else {
+            "not found, proceeding with download and installation"
+        }
     );
 
-    perform_installation(app_state, request, runtime_type)
-        .await
-        .map(|_| {
-            RuntimeInstallResp::success(RuntimeInstallData {
-                success: true,
-                message: format!("Successfully downloaded and installed {}", request.runtime_type),
-                runtime_type: request.runtime_type.clone(),
-            })
-        })
-        .or_else(|e| {
-            Ok(RuntimeInstallResp::success(RuntimeInstallData {
-                success: false,
-                message: format!("Installation failed: {e:#}"),
-                runtime_type: request.runtime_type.clone(),
-            }))
-        })
+    let install_result = perform_installation(request, runtime_type).await;
+
+    let data = match install_result {
+        Ok(()) => RuntimeInstallData {
+            success: true,
+            message: format!("Successfully downloaded and installed {}", runtime_type),
+            runtime_type: runtime_type.to_string(),
+        },
+        Err(error) => RuntimeInstallData {
+            success: false,
+            message: format!("Installation failed: {error:#}"),
+            runtime_type: runtime_type.to_string(),
+        },
+    };
+
+    Ok(RuntimeInstallResp::success(data))
 }
 
 async fn perform_installation(
-    _state: &AppState,
-    _request: &RuntimeInstallReq,
+    request: &RuntimeInstallReq,
     runtime_type: RuntimeType,
 ) -> Result<(), anyhow::Error> {
-    RuntimeInstaller::new().install_runtime(runtime_type).await.map(|_| ())
+    RuntimeInstaller::new()
+        .install_runtime(runtime_type, request.version.as_deref())
+        .await
+        .map(|_| ())
 }
 
 async fn runtime_status_core(_app_state: &AppState) -> Result<RuntimeStatusResp, StatusCode> {
-    let (uv_status, bun_status) = tokio::join!(
+    let (uv_status, bun_status, node_status) = tokio::join!(
         create_runtime_status(RuntimeType::Uv),
-        create_runtime_status(RuntimeType::Bun)
+        create_runtime_status(RuntimeType::Bun),
+        create_runtime_status(RuntimeType::Node)
     );
 
     Ok(RuntimeStatusResp::success(RuntimeStatusData {
         uv: uv_status,
         bun: bun_status,
+        node: node_status,
     }))
 }
 
@@ -217,15 +212,20 @@ async fn create_runtime_status(runtime_type: RuntimeType) -> RuntimeStatus {
 }
 
 async fn runtime_cache_core(_app_state: &AppState) -> Result<RuntimeCacheResp, StatusCode> {
-    let (uv_cache, bun_cache) = tokio::join!(get_cache_info(RuntimeType::Uv), get_cache_info(RuntimeType::Bun));
+    let (uv_cache, bun_cache, node_cache) = tokio::join!(
+        get_cache_info(RuntimeType::Uv),
+        get_cache_info(RuntimeType::Bun),
+        get_cache_info(RuntimeType::Node)
+    );
 
     Ok(RuntimeCacheResp::success(RuntimeCacheData {
         summary: RuntimeCacheSummary {
-            total_size_bytes: uv_cache.size_bytes + bun_cache.size_bytes,
+            total_size_bytes: uv_cache.size_bytes + bun_cache.size_bytes + node_cache.size_bytes,
             last_cleanup: get_last_cleanup_time(),
         },
         uv: uv_cache,
         bun: bun_cache,
+        node: node_cache,
     }))
 }
 
@@ -256,9 +256,11 @@ async fn reset_cache_core(
     let cache_paths = match request.cache_type.as_str() {
         "uv" => vec![base.join(RuntimeType::Uv.as_str())],
         "bun" => vec![base.join(RuntimeType::Bun.as_str())],
+        "node" => vec![base.join(RuntimeType::Node.as_str())],
         _ => vec![
             base.join(RuntimeType::Uv.as_str()),
             base.join(RuntimeType::Bun.as_str()),
+            base.join(RuntimeType::Node.as_str()),
         ],
     };
 
@@ -300,9 +302,52 @@ async fn get_version_from_exec_async(path: &std::path::Path) -> Option<String> {
 
     output.status.success().then(|| {
         let version_string = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-        (!version_string.is_empty()).then_some(version_string)
+        normalize_version_output(&version_string)
     })?
+}
+
+fn normalize_version_output(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let normalized = trimmed
+        .split_whitespace()
+        .map(|segment| segment.trim_matches(|c: char| matches!(c, ',' | ';' | '(' | ')')))
+        .find_map(|segment| {
+            let candidate = segment.strip_prefix('v').unwrap_or(segment);
+            candidate
+                .chars()
+                .next()
+                .filter(|ch| ch.is_ascii_digit())
+                .map(|_| candidate.to_string())
+        });
+
+    normalized.or_else(|| Some(trimmed.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_version_output;
+
+    #[test]
+    fn normalizes_plain_node_version_output() {
+        assert_eq!(normalize_version_output("v24.15.0"), Some("24.15.0".to_string()));
+    }
+
+    #[test]
+    fn normalizes_bun_version_output() {
+        assert_eq!(normalize_version_output("1.2.15"), Some("1.2.15".to_string()));
+    }
+
+    #[test]
+    fn normalizes_tool_prefixed_version_output() {
+        assert_eq!(
+            normalize_version_output("uv 0.7.13 (Homebrew 2025-01-01)"),
+            Some("0.7.13".to_string())
+        );
+    }
 }
 
 #[derive(Default)]

--- a/backend/src/api/models/runtime.rs
+++ b/backend/src/api/models/runtime.rs
@@ -7,7 +7,7 @@ use crate::macros::resp::api_resp;
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(description = "Request for runtime installation")]
 pub struct RuntimeInstallReq {
-    #[schemars(description = "Runtime type to install (uv or bun)")]
+    #[schemars(description = "Runtime type to install (uv, bun, or node)")]
     pub runtime_type: String,
     #[schemars(description = "Specific version to install (optional)")]
     pub version: Option<String>,
@@ -35,7 +35,7 @@ pub struct RuntimeInstallData {
 #[derive(Debug, Serialize, JsonSchema)]
 #[schemars(description = "Runtime status information")]
 pub struct RuntimeStatus {
-    #[schemars(description = "Runtime type (uv or bun)")]
+    #[schemars(description = "Runtime type (uv, bun, or node)")]
     pub runtime_type: String,
     #[schemars(description = "Whether runtime is available")]
     pub available: bool,
@@ -54,6 +54,8 @@ pub struct RuntimeStatusData {
     pub uv: RuntimeStatus,
     #[schemars(description = "Bun runtime status")]
     pub bun: RuntimeStatus,
+    #[schemars(description = "Node.js runtime status")]
+    pub node: RuntimeStatus,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -87,13 +89,15 @@ pub struct RuntimeCacheData {
     pub uv: RuntimeCacheItem,
     #[schemars(description = "Bun cache details")]
     pub bun: RuntimeCacheItem,
+    #[schemars(description = "Node.js cache details")]
+    pub node: RuntimeCacheItem,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(description = "Request for cache reset operation")]
 pub struct RuntimeCacheResetReq {
     #[serde(default = "super::default_all")]
-    #[schemars(description = "Cache type to reset: all, uv, or bun (default: all)")]
+    #[schemars(description = "Cache type to reset: all, uv, bun, or node (default: all)")]
     pub cache_type: String,
 }
 

--- a/backend/src/api/routes/openapi.rs
+++ b/backend/src/api/routes/openapi.rs
@@ -400,7 +400,7 @@ macro_rules! aide_wrapper_query {
 ///     runtime::install,                                                   // Handler function path
 ///     RuntimeInstallReq,                                                  // Payload body type
 ///     RuntimeInstallResp,                                                 // Response type
-///     "Install runtime package (UV or Bun) with optional configuration"   // Description
+///     "Install runtime package (UV, Bun, or Node.js) with optional configuration"   // Description
 /// );
 /// ```
 #[macro_export]

--- a/backend/src/api/routes/runtime.rs
+++ b/backend/src/api/routes/runtime.rs
@@ -21,11 +21,15 @@ aide_wrapper_payload!(
     runtime::install,
     RuntimeInstallReq,
     RuntimeInstallResp,
-    "Install runtime package (UV or Bun) with optional configuration"
+    "Install runtime package (UV, Bun, or Node.js) with optional configuration"
 );
 
 // Generate aide-compatible wrapper for runtime status (no parameters)
-aide_wrapper!(runtime::status, RuntimeStatusResp, "Get runtime status for UV and Bun");
+aide_wrapper!(
+    runtime::status,
+    RuntimeStatusResp,
+    "Get runtime status for UV, Bun, and Node.js"
+);
 
 // Generate aide-compatible wrapper for runtime cache (no parameters)
 aide_wrapper!(
@@ -39,7 +43,7 @@ aide_wrapper_payload!(
     runtime::reset_cache,
     RuntimeCacheResetReq,
     RuntimeCacheResetResp,
-    "Reset runtime cache. Payload: {cache_type: 'all'|'uv'|'bun'} (default: 'all')"
+    "Reset runtime cache. Payload: {cache_type: 'all'|'uv'|'bun'|'node'} (default: 'all')"
 );
 
 pub fn routes(state: Arc<AppState>) -> ApiRouter {

--- a/backend/src/common/constants.rs
+++ b/backend/src/common/constants.rs
@@ -5,16 +5,28 @@
 
 /// Runtime command constants
 pub mod commands {
+    /// UV runtime command
+    pub const UV: &str = "uv";
+
     /// UV package executor command
     pub const UVX: &str = "uvx";
+
+    /// Bun runtime command
+    pub const BUN: &str = "bun";
 
     /// Bun package executor command
     pub const BUNX: &str = "bunx";
 
+    /// Node.js runtime command
+    pub const NODE: &str = "node";
+
+    /// NPM package manager command
+    pub const NPM: &str = "npm";
+
     /// Docker command
     pub const DOCKER: &str = "docker";
 
-    /// NPX command, only used for npx compatibility
+    /// NPX command
     pub const NPX: &str = "npx";
 }
 
@@ -34,6 +46,9 @@ pub mod env_vars {
 
     /// Bun cache directory
     pub const BUN_INSTALL_CACHE_DIR: &str = "BUN_INSTALL_CACHE_DIR";
+
+    /// Node/NPM cache directory
+    pub const NPM_CONFIG_CACHE: &str = "NPM_CONFIG_CACHE";
 
     /// System PATH environment variable
     pub const PATH: &str = "PATH";

--- a/backend/src/common/env.rs
+++ b/backend/src/common/env.rs
@@ -254,6 +254,29 @@ pub fn create_bun_environment(bin_path: &Path) -> Result<EnvironmentManager> {
     Ok(env)
 }
 
+/// Create runtime-specific environment for Node.js
+pub fn create_node_environment(bin_path: &Path) -> Result<EnvironmentManager> {
+    let paths = global_paths();
+    let mut env = EnvironmentManager::new();
+
+    let bin_dir = bin_path.parent().unwrap_or(bin_path);
+    env.prepend_path(bin_dir);
+
+    let cache_dir = paths.runtime_cache_dir(RuntimeType::Node.as_str());
+    std::fs::create_dir_all(&cache_dir)?;
+
+    env.set_var(constants::NPM_CONFIG_CACHE, cache_dir.to_string_lossy());
+    env.set_var(constants::MCP_RUNTIME_BIN, bin_path.to_string_lossy());
+
+    tracing::debug!(
+        "Created Node.js environment: PATH includes {}, cache at {}",
+        bin_dir.display(),
+        cache_dir.display()
+    );
+
+    Ok(env)
+}
+
 /// Create environment for a specific runtime type
 pub fn create_runtime_environment(
     runtime_type: &str,
@@ -266,6 +289,7 @@ pub fn create_runtime_environment(
         match rt {
             RuntimeType::Uv => create_uv_environment(bin_path),
             RuntimeType::Bun => create_bun_environment(bin_path),
+            RuntimeType::Node => create_node_environment(bin_path),
         }
     } else {
         // Generic runtime environment

--- a/backend/src/common/types.rs
+++ b/backend/src/common/types.rs
@@ -172,8 +172,18 @@ impl fmt::Display for RuntimeType {
 impl FromStr for RuntimeType {
     type Err = RuntimeError;
 
+    /// Parse a runtime type from a canonical name only (`uv`, `bun`, `node`).
+    ///
+    /// Unlike `from_command`, this does NOT accept CLI aliases (`uvx`, `bunx`,
+    /// `npm`, `npx`) since it is used for API input parsing where only the
+    /// canonical runtime name is valid.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_command(s).ok_or_else(|| RuntimeError::UnsupportedRuntimeType(s.to_string()))
+        match s.trim().to_ascii_lowercase().as_str() {
+            "uv" => Ok(RuntimeType::Uv),
+            "bun" => Ok(RuntimeType::Bun),
+            "node" => Ok(RuntimeType::Node),
+            _ => Err(RuntimeError::UnsupportedRuntimeType(s.to_string())),
+        }
     }
 }
 

--- a/backend/src/common/types.rs
+++ b/backend/src/common/types.rs
@@ -69,20 +69,24 @@ impl FromStr for ClientCategory {
 pub enum RuntimeType {
     /// uv runtime (Python package manager and environment manager)
     Uv,
-    /// Bun.js runtime (supports bunx and bun x for npx compatibility)
+    /// Bun.js runtime
     Bun,
+    /// Node.js runtime
+    Node,
 }
 
 impl RuntimeType {
     // Default version constants
     pub const DEFAULT_BUN_VERSION: &'static str = "latest";
     pub const DEFAULT_UV_VERSION: &'static str = "latest";
+    pub const DEFAULT_NODE_VERSION: &'static str = "lts";
 
     /// Get the string representation of the runtime type
     pub fn as_str(&self) -> &'static str {
         match self {
             RuntimeType::Uv => "uv",
             RuntimeType::Bun => "bun",
+            RuntimeType::Node => "node",
         }
     }
 
@@ -91,13 +95,36 @@ impl RuntimeType {
         match self {
             RuntimeType::Uv => Self::DEFAULT_UV_VERSION,
             RuntimeType::Bun => Self::DEFAULT_BUN_VERSION,
+            RuntimeType::Node => Self::DEFAULT_NODE_VERSION,
+        }
+    }
+
+    /// Resolve a runtime type from a command alias or runtime name.
+    pub fn from_command(command: &str) -> Option<Self> {
+        use super::constants::commands;
+
+        match command.trim().to_ascii_lowercase().as_str() {
+            commands::UV | commands::UVX => Some(RuntimeType::Uv),
+            "bunjs" | commands::BUN | commands::BUNX => Some(RuntimeType::Bun),
+            "nodejs" | commands::NODE | commands::NPM | commands::NPX => Some(RuntimeType::Node),
+            _ => None,
+        }
+    }
+
+    /// Get the canonical executable command for the runtime.
+    pub fn canonical_command(&self) -> &'static str {
+        use super::constants::commands;
+
+        match self {
+            RuntimeType::Uv => commands::UV,
+            RuntimeType::Bun => commands::BUN,
+            RuntimeType::Node => commands::NODE,
         }
     }
 
     /// Get the executable name
     pub fn executable_name(&self) -> String {
-        let base_name = self.as_str();
-        format!("{}{}", base_name, Self::executable_extension())
+        self.executable_name_for_command(self.canonical_command())
     }
 
     /// Get the platform-specific executable extension
@@ -112,18 +139,20 @@ impl RuntimeType {
     ) -> String {
         use super::constants::commands;
 
-        let exe_name = match command {
-            commands::UVX => "uvx",
-            commands::BUNX => "bunx",
-            _ => self.as_str(),
-        };
-
-        format!("{}{}", exe_name, Self::executable_extension())
+        match (self, command.trim().to_ascii_lowercase().as_str()) {
+            (RuntimeType::Uv, commands::UVX) => format!("{}{}", commands::UVX, Self::executable_extension()),
+            (RuntimeType::Bun, commands::BUNX) => format!("{}{}", commands::BUNX, Self::executable_extension()),
+            (RuntimeType::Node, commands::NPM) if cfg!(windows) => format!("{}.cmd", commands::NPM),
+            (RuntimeType::Node, commands::NPX) if cfg!(windows) => format!("{}.cmd", commands::NPX),
+            (RuntimeType::Node, commands::NPM) => format!("{}{}", commands::NPM, Self::executable_extension()),
+            (RuntimeType::Node, commands::NPX) => format!("{}{}", commands::NPX, Self::executable_extension()),
+            _ => format!("{}{}", self.canonical_command(), Self::executable_extension()),
+        }
     }
 
     /// Get all supported runtime types
     pub fn all() -> &'static [RuntimeType] {
-        &[RuntimeType::Uv, RuntimeType::Bun]
+        &[RuntimeType::Uv, RuntimeType::Bun, RuntimeType::Node]
     }
 }
 
@@ -135,6 +164,7 @@ impl fmt::Display for RuntimeType {
         match self {
             RuntimeType::Uv => write!(f, "uv"),
             RuntimeType::Bun => write!(f, "bun"),
+            RuntimeType::Node => write!(f, "node"),
         }
     }
 }
@@ -143,14 +173,7 @@ impl FromStr for RuntimeType {
     type Err = RuntimeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use super::constants::commands;
-
-        match s.to_lowercase().as_str() {
-            "uv" | commands::UVX => Ok(RuntimeType::Uv),
-            "bun" | "bunjs" | commands::BUNX => Ok(RuntimeType::Bun),
-            "node" | "nodejs" | "npm" | commands::NPX => Ok(RuntimeType::Bun),
-            _ => Err(RuntimeError::UnsupportedRuntimeType(s.to_string())),
-        }
+        Self::from_command(s).ok_or_else(|| RuntimeError::UnsupportedRuntimeType(s.to_string()))
     }
 }
 
@@ -244,5 +267,31 @@ mod tests {
 
         assert_eq!(app_deserialized, app);
         assert_eq!(ext_deserialized, ext);
+    }
+
+    #[test]
+    fn test_runtime_type_from_command_aliases() {
+        assert_eq!(RuntimeType::from_command("uv"), Some(RuntimeType::Uv));
+        assert_eq!(RuntimeType::from_command("uvx"), Some(RuntimeType::Uv));
+        assert_eq!(RuntimeType::from_command("bun"), Some(RuntimeType::Bun));
+        assert_eq!(RuntimeType::from_command("bunx"), Some(RuntimeType::Bun));
+        assert_eq!(RuntimeType::from_command("node"), Some(RuntimeType::Node));
+        assert_eq!(RuntimeType::from_command("nodejs"), Some(RuntimeType::Node));
+        assert_eq!(RuntimeType::from_command("npm"), Some(RuntimeType::Node));
+        assert_eq!(RuntimeType::from_command("npx"), Some(RuntimeType::Node));
+        assert_eq!(RuntimeType::from_command("python"), None);
+    }
+
+    #[test]
+    fn test_runtime_type_defaults_and_executable_names() {
+        assert_eq!(RuntimeType::Node.default_version(), "lts");
+        assert_eq!(
+            RuntimeType::Node.executable_name(),
+            format!("node{}", RuntimeType::executable_extension())
+        );
+        let expected_npm = if cfg!(windows) { "npm.cmd" } else { "npm" };
+        let expected_npx = if cfg!(windows) { "npx.cmd" } else { "npx" };
+        assert_eq!(RuntimeType::Node.executable_name_for_command("npm"), expected_npm);
+        assert_eq!(RuntimeType::Node.executable_name_for_command("npx"), expected_npx);
     }
 }

--- a/backend/src/config/runtime.rs
+++ b/backend/src/config/runtime.rs
@@ -36,53 +36,50 @@ pub async fn prepare_command_env_with_db(
         command.as_std().get_program().to_string_lossy()
     );
 
-    // 1. Determine runtime type (npx is handled by command transformation, not here)
-    let runtime_type = match command_str {
-        commands::UVX => Some(RuntimeType::Uv),
-        commands::BUNX => Some(RuntimeType::Bun),
-        _ => None,
-    };
+    // 1. Determine runtime type from the command alias.
+    let runtime_type = RuntimeType::from_command(command_str);
 
     // 2. Use RuntimeManager to find runtime paths
-    let Some(rt_type) = runtime_type else {
+    if let Some(rt_type) = runtime_type {
+        let manager = RuntimeManager::new();
+
+        if let Some(runtime_path) = manager.get_command_path(command_str) {
+            tracing::debug!(
+                "Using MCPMate managed runtime for '{}': {}",
+                command_str,
+                runtime_path.display()
+            );
+
+            // Use shared environment management system
+            let runtime_type_str = rt_type.as_str();
+
+            prepare_command_environment(command, runtime_type_str, &runtime_path).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to prepare {} runtime environment for '{}': {}",
+                    runtime_type_str,
+                    command_str,
+                    e
+                )
+            })?;
+
+            tracing::debug!(
+                "Successfully prepared {} environment using simplified system",
+                runtime_type_str
+            );
+        } else {
+            tracing::debug!(
+                "No MCPMate-managed runtime found for {}, preparing basic environment",
+                command_str
+            );
+            prepare_basic_command_env(command, command_str)?;
+        }
+    } else {
         tracing::debug!(
             "No runtime type mapping for {}, preparing basic environment",
             command_str
         );
-        return prepare_basic_command_env(command, command_str);
-    };
-
-    let manager = RuntimeManager::new();
-    let Some(runtime_path) = manager.get_executable_path(rt_type) else {
-        tracing::debug!(
-            "No MCPMate-managed runtime found for {}, preparing basic environment",
-            command_str
-        );
-        return prepare_basic_command_env(command, command_str);
-    };
-
-    tracing::debug!(
-        "Using MCPMate managed runtime for '{}': {}",
-        command_str,
-        runtime_path.display()
-    );
-
-    // Use shared environment management system
-    let runtime_type_str = rt_type.as_str();
-
-    prepare_command_environment(command, runtime_type_str, &runtime_path).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to prepare {} runtime environment for '{}': {}",
-            runtime_type_str,
-            command_str,
-            e
-        )
-    })?;
-
-    tracing::debug!(
-        "Successfully prepared {} environment using simplified system",
-        runtime_type_str
-    );
+        prepare_basic_command_env(command, command_str)?;
+    }
 
     Ok(())
 }
@@ -96,19 +93,25 @@ fn prepare_basic_command_env(
 
     let paths = global_paths();
 
-    // Set basic cache directories based on command type (npx handled by transformation)
+    // Set basic cache directories based on command type.
     match command_str {
-        commands::UVX => {
+        commands::UV | commands::UVX => {
             let cache_dir = paths.runtime_cache_dir("uv");
             std::fs::create_dir_all(&cache_dir)?;
             command.env("UV_CACHE_DIR", cache_dir.to_string_lossy().as_ref());
             tracing::debug!("Set UV_CACHE_DIR to: {}", cache_dir.display());
         }
-        commands::BUNX => {
+        commands::BUN | commands::BUNX => {
             let cache_dir = paths.runtime_cache_dir("bun");
             std::fs::create_dir_all(&cache_dir)?;
             command.env("BUN_INSTALL_CACHE_DIR", cache_dir.to_string_lossy().as_ref());
             tracing::debug!("Set BUN_INSTALL_CACHE_DIR to: {}", cache_dir.display());
+        }
+        commands::NODE | commands::NPM | commands::NPX => {
+            let cache_dir = paths.runtime_cache_dir("node");
+            std::fs::create_dir_all(&cache_dir)?;
+            command.env("NPM_CONFIG_CACHE", cache_dir.to_string_lossy().as_ref());
+            tracing::debug!("Set NPM_CONFIG_CACHE to: {}", cache_dir.display());
         }
         _ => {
             tracing::debug!("No specific environment setup for command: {}", command_str);

--- a/backend/src/core/foundation/utils.rs
+++ b/backend/src/core/foundation/utils.rs
@@ -13,20 +13,20 @@ use crate::common::constants::commands;
 /// determine appropriate connection timeout based on command type
 pub fn get_connection_timeout(command: &str) -> Duration {
     match command {
-        commands::DOCKER => Duration::from_secs(120), // Docker operations can take longer
-        commands::NPX => Duration::from_secs(60),     // npm operations can take time (handled by transformation)
-        commands::UVX | commands::BUNX => Duration::from_secs(30), // Runtime commands may need more time
-        _ => Duration::from_secs(10),                 // Regular commands
+        commands::DOCKER => Duration::from_secs(120),
+        commands::NODE | commands::NPM | commands::NPX => Duration::from_secs(60),
+        commands::UV | commands::UVX | commands::BUN | commands::BUNX => Duration::from_secs(30),
+        _ => Duration::from_secs(10),
     }
 }
 
 /// determine appropriate tools listing timeout based on command type
 pub fn get_tools_timeout(command: &str) -> Duration {
     match command {
-        commands::DOCKER => Duration::from_secs(60), // Docker operations can take longer
-        commands::NPX => Duration::from_secs(60),    // npm timeout (handled by transformation)
-        commands::UVX | commands::BUNX => Duration::from_secs(20), // Runtime commands may need more time
-        _ => Duration::from_secs(10),                // Regular commands
+        commands::DOCKER => Duration::from_secs(60),
+        commands::NODE | commands::NPM | commands::NPX => Duration::from_secs(60),
+        commands::UV | commands::UVX | commands::BUN | commands::BUNX => Duration::from_secs(20),
+        _ => Duration::from_secs(10),
     }
 }
 
@@ -175,17 +175,23 @@ pub fn prepare_command(
     cmd
 }
 
-/// check if a command needs runtime setup (python, etc.)
-/// Note: npx is handled by command transformation to bunx
+/// Check if a command needs MCPMate runtime environment setup.
 pub fn needs_runtime_setup(command: &str) -> bool {
-    matches!(command, commands::UVX | commands::BUNX | commands::DOCKER)
+    matches!(
+        command,
+        commands::UV
+            | commands::UVX
+            | commands::BUN
+            | commands::BUNX
+            | commands::NODE
+            | commands::NPM
+            | commands::NPX
+            | commands::DOCKER
+    )
 }
 
-/// Transform npx commands to bunx for better performance and compatibility
+/// Preserve the user-provided command alias for runtime resolution.
 pub fn transform_command(command: &str) -> String {
-    if command.eq_ignore_ascii_case("npx") {
-        tracing::debug!("Respecting user-provided 'npx' command without bunx rewrite");
-    }
     command.to_string()
 }
 

--- a/backend/src/runtime/downloader.rs
+++ b/backend/src/runtime/downloader.rs
@@ -5,12 +5,39 @@
 
 use anyhow::{Context, Result};
 use reqwest::Client;
+use serde::Deserialize;
 use std::path::PathBuf;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 use crate::common::RuntimeType;
 use crate::common::env::{Architecture, OperatingSystem, detect_environment};
+
+const NODE_DIST_INDEX_URL: &str = "https://nodejs.org/dist/index.json";
+
+#[derive(Debug, Clone)]
+struct ResolvedRuntimeDownload {
+    file_name: String,
+    resolved_version: String,
+    url: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct NodeDistIndexEntry {
+    files: Vec<String>,
+    lts: serde_json::Value,
+    version: String,
+}
+
+impl NodeDistIndexEntry {
+    fn is_lts(&self) -> bool {
+        !matches!(self.lts, serde_json::Value::Bool(false))
+    }
+
+    fn parsed_version(&self) -> Option<semver::Version> {
+        semver::Version::parse(self.version.trim_start_matches('v')).ok()
+    }
+}
 
 /// Simple runtime downloader
 pub struct RuntimeDownloader {
@@ -27,22 +54,25 @@ impl RuntimeDownloader {
     pub async fn download_runtime(
         &self,
         runtime_type: RuntimeType,
+        version: Option<&str>,
         target_dir: &PathBuf,
     ) -> Result<PathBuf> {
-        // Ensure target directory exists
         tokio::fs::create_dir_all(target_dir)
             .await
             .context("Failed to create target directory")?;
 
-        // Get download URL
-        let download_url = self.get_download_url(runtime_type)?;
+        let resolved = self.resolve_download(runtime_type, version).await?;
 
-        tracing::info!("Downloading {} from {}", runtime_type.as_str(), download_url);
+        tracing::info!(
+            "Downloading {} {} from {}",
+            runtime_type.as_str(),
+            resolved.resolved_version,
+            resolved.url
+        );
 
-        // Download the file
         let response = self
             .client
-            .get(&download_url)
+            .get(&resolved.url)
             .send()
             .await
             .context("Failed to start download")?;
@@ -51,11 +81,7 @@ impl RuntimeDownloader {
             return Err(anyhow::anyhow!("Download failed with status: {}", response.status()));
         }
 
-        // Determine file name and path
-        let file_name = self.get_file_name(runtime_type)?;
-        let file_path = target_dir.join(&file_name);
-
-        // Write file
+        let file_path = target_dir.join(&resolved.file_name);
         let mut file = File::create(&file_path)
             .await
             .context("Failed to create download file")?;
@@ -66,28 +92,33 @@ impl RuntimeDownloader {
             .await
             .context("Failed to write download file")?;
 
-        tracing::info!("Downloaded {} to {}", runtime_type.as_str(), file_path.display());
+        tracing::info!(
+            "Downloaded {} {} to {}",
+            runtime_type.as_str(),
+            resolved.resolved_version,
+            file_path.display()
+        );
         Ok(file_path)
     }
 
-    /// Get download URL for a runtime
-    fn get_download_url(
+    async fn resolve_download(
         &self,
         runtime_type: RuntimeType,
-    ) -> Result<String> {
+        version: Option<&str>,
+    ) -> Result<ResolvedRuntimeDownload> {
         let env = detect_environment()?;
 
         match runtime_type {
-            RuntimeType::Bun => self.get_bun_download_url(&env),
-            RuntimeType::Uv => self.get_uv_download_url(&env),
+            RuntimeType::Bun => self.resolve_bun_download(&env),
+            RuntimeType::Uv => self.resolve_uv_download(&env),
+            RuntimeType::Node => self.resolve_node_download(&env, version).await,
         }
     }
 
-    /// Get Bun download URL
-    fn get_bun_download_url(
+    fn resolve_bun_download(
         &self,
         env: &crate::common::env::Environment,
-    ) -> Result<String> {
+    ) -> Result<ResolvedRuntimeDownload> {
         let platform = match env.os {
             OperatingSystem::MacOS => "darwin",
             OperatingSystem::Linux => "linux",
@@ -99,19 +130,18 @@ impl RuntimeDownloader {
             Architecture::Aarch64 => "aarch64",
         };
 
-        Ok(format!(
-            "https://github.com/oven-sh/bun/releases/latest/download/bun-{}-{}.zip",
-            platform, arch
-        ))
+        let file_name = format!("bun-{}-{}.zip", platform, arch);
+        Ok(ResolvedRuntimeDownload {
+            url: format!("https://github.com/oven-sh/bun/releases/latest/download/{file_name}"),
+            file_name,
+            resolved_version: RuntimeType::Bun.default_version().to_string(),
+        })
     }
 
-    /// Get UV download URL
-    ///
-    /// UV publishes `.zip` for Windows and `.tar.gz` for macOS/Linux.
-    fn get_uv_download_url(
+    fn resolve_uv_download(
         &self,
         env: &crate::common::env::Environment,
-    ) -> Result<String> {
+    ) -> Result<ResolvedRuntimeDownload> {
         let platform = match env.os {
             OperatingSystem::MacOS => "apple-darwin",
             OperatingSystem::Linux => "unknown-linux-gnu",
@@ -128,48 +158,161 @@ impl RuntimeDownloader {
             _ => "tar.gz",
         };
 
-        Ok(format!(
-            "https://github.com/astral-sh/uv/releases/latest/download/uv-{}-{}.{}",
-            arch, platform, ext
+        let file_name = format!("uv-{}-{}.{}", arch, platform, ext);
+        Ok(ResolvedRuntimeDownload {
+            url: format!("https://github.com/astral-sh/uv/releases/latest/download/{file_name}"),
+            file_name,
+            resolved_version: RuntimeType::Uv.default_version().to_string(),
+        })
+    }
+
+    async fn resolve_node_download(
+        &self,
+        env: &crate::common::env::Environment,
+        version: Option<&str>,
+    ) -> Result<ResolvedRuntimeDownload> {
+        let requested = version
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(RuntimeType::Node.default_version());
+
+        let index = self.fetch_node_dist_index().await?;
+        let entry = self.resolve_node_index_entry(&index, requested)?;
+        let version_tag = entry.version.clone();
+        let archive_platform = Self::node_archive_platform(env);
+        let index_platform = Self::node_index_platform(env);
+        let arch = env.arch.node_arch();
+        let ext = match env.os {
+            OperatingSystem::Windows => "zip",
+            _ => "tar.gz",
+        };
+        let file_name = format!("node-{}-{}-{}.{}", version_tag, archive_platform, arch, ext);
+        let file_key = match env.os {
+            OperatingSystem::Windows => format!("{}-{}-zip", index_platform, arch),
+            OperatingSystem::MacOS => format!("{}-{}-tar", index_platform, arch),
+            OperatingSystem::Linux => format!("{}-{}", index_platform, arch),
+        };
+
+        if !entry.files.iter().any(|value| value == &file_key) {
+            return Err(anyhow::anyhow!(
+                "Node.js {} does not publish {} for this platform",
+                version_tag,
+                file_key
+            ));
+        }
+
+        Ok(ResolvedRuntimeDownload {
+            url: format!("https://nodejs.org/dist/{version_tag}/{file_name}"),
+            file_name,
+            resolved_version: version_tag,
+        })
+    }
+
+    async fn fetch_node_dist_index(&self) -> Result<Vec<NodeDistIndexEntry>> {
+        let response = self
+            .client
+            .get(NODE_DIST_INDEX_URL)
+            .send()
+            .await
+            .context("Failed to fetch Node.js dist index")?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Node.js dist index request failed with status: {}",
+                response.status()
+            ));
+        }
+
+        response
+            .json::<Vec<NodeDistIndexEntry>>()
+            .await
+            .context("Failed to decode Node.js dist index")
+    }
+
+    fn resolve_node_index_entry<'a>(
+        &self,
+        index: &'a [NodeDistIndexEntry],
+        requested: &str,
+    ) -> Result<&'a NodeDistIndexEntry> {
+        let normalized = requested.trim().trim_start_matches('v').to_ascii_lowercase();
+
+        if normalized == "latest" {
+            return index
+                .first()
+                .ok_or_else(|| anyhow::anyhow!("Node.js dist index is empty"));
+        }
+
+        if normalized == "lts" {
+            return index
+                .iter()
+                .find(|entry| entry.is_lts())
+                .ok_or_else(|| anyhow::anyhow!("No active LTS release found in Node.js dist index"));
+        }
+
+        let requested_parts = normalized.split('.').collect::<Vec<_>>();
+
+        if requested_parts.len() == 1 && requested_parts[0].chars().all(|ch| ch.is_ascii_digit()) {
+            let requested_major = requested_parts[0]
+                .parse::<u64>()
+                .context("Invalid Node.js major version")?;
+
+            return index
+                .iter()
+                .find(|entry| {
+                    entry
+                        .parsed_version()
+                        .is_some_and(|version| version.major == requested_major)
+                })
+                .ok_or_else(|| anyhow::anyhow!("Node.js major version {} not found", requested_major));
+        }
+
+        if let Ok(requested_version) = semver::Version::parse(&normalized) {
+            return index
+                .iter()
+                .find(|entry| entry.parsed_version().as_ref() == Some(&requested_version))
+                .ok_or_else(|| anyhow::anyhow!("Node.js version v{} not found", requested_version));
+        }
+
+        if requested_parts.len() >= 2
+            && requested_parts
+                .iter()
+                .all(|part| part.chars().all(|ch| ch.is_ascii_digit()))
+        {
+            return index
+                .iter()
+                .find(|entry| {
+                    let Some(version) = entry.parsed_version() else {
+                        return false;
+                    };
+
+                    version.major.to_string() == requested_parts[0]
+                        && version.minor.to_string() == requested_parts[1]
+                        && requested_parts
+                            .get(2)
+                            .is_none_or(|patch| version.patch.to_string() == *patch)
+                })
+                .ok_or_else(|| anyhow::anyhow!("Node.js version prefix {} not found", requested));
+        }
+
+        Err(anyhow::anyhow!(
+            "Unsupported Node.js version spec '{}'. Use lts, latest, a major version, or a full semver.",
+            requested
         ))
     }
 
-    /// Get file name for downloaded runtime
-    fn get_file_name(
-        &self,
-        runtime_type: RuntimeType,
-    ) -> Result<String> {
-        let env = detect_environment()?;
+    fn node_archive_platform(env: &crate::common::env::Environment) -> &'static str {
+        match env.os {
+            OperatingSystem::MacOS => "darwin",
+            OperatingSystem::Linux => "linux",
+            OperatingSystem::Windows => "win",
+        }
+    }
 
-        match runtime_type {
-            RuntimeType::Bun => {
-                let platform = match env.os {
-                    OperatingSystem::MacOS => "darwin",
-                    OperatingSystem::Linux => "linux",
-                    OperatingSystem::Windows => "windows",
-                };
-                let arch = match env.arch {
-                    Architecture::X86_64 => "x64",
-                    Architecture::Aarch64 => "aarch64",
-                };
-                Ok(format!("bun-{}-{}.zip", platform, arch))
-            }
-            RuntimeType::Uv => {
-                let platform = match env.os {
-                    OperatingSystem::MacOS => "apple-darwin",
-                    OperatingSystem::Linux => "unknown-linux-gnu",
-                    OperatingSystem::Windows => "pc-windows-msvc",
-                };
-                let arch = match env.arch {
-                    Architecture::X86_64 => "x86_64",
-                    Architecture::Aarch64 => "aarch64",
-                };
-                let ext = match env.os {
-                    OperatingSystem::Windows => "zip",
-                    _ => "tar.gz",
-                };
-                Ok(format!("uv-{}-{}.{}", arch, platform, ext))
-            }
+    fn node_index_platform(env: &crate::common::env::Environment) -> &'static str {
+        match env.os {
+            OperatingSystem::MacOS => "osx",
+            OperatingSystem::Linux => "linux",
+            OperatingSystem::Windows => "win",
         }
     }
 }
@@ -177,5 +320,95 @@ impl RuntimeDownloader {
 impl Default for RuntimeDownloader {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::env::{Architecture, Environment, OperatingSystem};
+    use serde_json::json;
+
+    fn entry(
+        version: &str,
+        lts: serde_json::Value,
+    ) -> NodeDistIndexEntry {
+        NodeDistIndexEntry {
+            version: version.to_string(),
+            lts,
+            files: vec![
+                "linux-x64".to_string(),
+                "linux-arm64".to_string(),
+                "osx-arm64-tar".to_string(),
+                "osx-x64-tar".to_string(),
+                "win-x64-zip".to_string(),
+            ],
+        }
+    }
+
+    #[test]
+    fn resolves_node_lts_and_latest() {
+        let downloader = RuntimeDownloader::new();
+        let index = vec![
+            entry("v25.1.0", json!(false)),
+            entry("v24.15.0", json!("Krypton")),
+            entry("v22.20.0", json!("Jod")),
+        ];
+
+        assert_eq!(
+            downloader.resolve_node_index_entry(&index, "latest").unwrap().version,
+            "v25.1.0"
+        );
+        assert_eq!(
+            downloader.resolve_node_index_entry(&index, "lts").unwrap().version,
+            "v24.15.0"
+        );
+    }
+
+    #[test]
+    fn resolves_node_major_and_exact_versions() {
+        let downloader = RuntimeDownloader::new();
+        let index = vec![
+            entry("v25.1.0", json!(false)),
+            entry("v24.15.0", json!("Krypton")),
+            entry("v24.14.3", json!("Krypton")),
+        ];
+
+        assert_eq!(
+            downloader.resolve_node_index_entry(&index, "24").unwrap().version,
+            "v24.15.0"
+        );
+        assert_eq!(
+            downloader.resolve_node_index_entry(&index, "24.14").unwrap().version,
+            "v24.14.3"
+        );
+        assert_eq!(
+            downloader.resolve_node_index_entry(&index, "v24.15.0").unwrap().version,
+            "v24.15.0"
+        );
+    }
+
+    #[test]
+    fn node_platform_uses_official_dist_labels() {
+        let mac = Environment {
+            os: OperatingSystem::MacOS,
+            arch: Architecture::Aarch64,
+        };
+        let linux = Environment {
+            os: OperatingSystem::Linux,
+            arch: Architecture::X86_64,
+        };
+        let windows = Environment {
+            os: OperatingSystem::Windows,
+            arch: Architecture::X86_64,
+        };
+
+        assert_eq!(RuntimeDownloader::node_archive_platform(&mac), "darwin");
+        assert_eq!(RuntimeDownloader::node_index_platform(&mac), "osx");
+        assert_eq!(RuntimeDownloader::node_archive_platform(&linux), "linux");
+        assert_eq!(RuntimeDownloader::node_index_platform(&linux), "linux");
+        assert_eq!(RuntimeDownloader::node_archive_platform(&windows), "win");
+        assert_eq!(RuntimeDownloader::node_index_platform(&windows), "win");
+        assert_eq!(mac.arch.node_arch(), "arm64");
     }
 }

--- a/backend/src/runtime/downloader.rs
+++ b/backend/src/runtime/downloader.rs
@@ -274,6 +274,7 @@ impl RuntimeDownloader {
         }
 
         if requested_parts.len() >= 2
+            && requested_parts.len() <= 3
             && requested_parts
                 .iter()
                 .all(|part| part.chars().all(|ch| ch.is_ascii_digit()))
@@ -385,6 +386,25 @@ mod tests {
         assert_eq!(
             downloader.resolve_node_index_entry(&index, "v24.15.0").unwrap().version,
             "v24.15.0"
+        );
+    }
+
+    #[test]
+    fn rejects_node_versions_with_too_many_segments() {
+        let downloader = RuntimeDownloader::new();
+        let index = vec![
+            entry("v25.1.0", json!(false)),
+            entry("v24.15.0", json!("Krypton")),
+            entry("v24.14.3", json!("Krypton")),
+        ];
+
+        let error = downloader
+            .resolve_node_index_entry(&index, "24.15.0.1")
+            .expect_err("invalid 4-segment version should be rejected");
+
+        assert!(
+            error.to_string().contains("Unsupported Node.js version spec"),
+            "unexpected error: {error:#}"
         );
     }
 

--- a/backend/src/runtime/installer.rs
+++ b/backend/src/runtime/installer.rs
@@ -145,49 +145,52 @@ impl RuntimeInstaller {
         archive_file: &Path,
         target_dir: &Path,
     ) -> Result<PathBuf> {
-        // Use a staging directory so we never destroy a working installation
-        // mid-flight. If extraction or setup fails, the existing target_dir
-        // remains intact.
         let staging_dir = Self::prepare_staging_dir(target_dir, "staging").await?;
-
-        let is_zip = archive_file
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"));
-
-        if is_zip {
-            self.extract_zip(archive_file, &staging_dir).await?;
-        } else {
-            self.extract_tar_gz_skipping_links(archive_file, &staging_dir).await?;
-        }
-
-        let install_root = self.find_node_install_root(&staging_dir)?;
         let final_staging = Self::staging_name(target_dir, "final");
 
-        // Clean any leftover final dir, then rename install_root -> final_staging
-        Self::clean_dir(&final_staging).await?;
-        tokio::fs::rename(&install_root, &final_staging).await?;
+        let result = async {
+            let is_zip = archive_file
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"));
 
-        #[cfg(unix)]
-        self.create_node_unix_shims(&final_staging).await?;
+            if is_zip {
+                self.extract_zip(archive_file, &staging_dir).await?;
+            } else {
+                self.extract_tar_gz_skipping_links(archive_file, &staging_dir).await?;
+            }
 
-        let target_path = final_staging.join(RuntimeType::Node.executable_name());
-        if !target_path.exists() {
-            return Err(anyhow::anyhow!(
-                "Installed Node.js executable not found at {}",
-                target_path.display()
-            ));
+            let install_root = self.find_node_install_root(&staging_dir)?;
+
+            Self::clean_dir(&final_staging).await?;
+            tokio::fs::rename(&install_root, &final_staging).await?;
+
+            #[cfg(unix)]
+            self.create_node_unix_shims(&final_staging).await?;
+
+            let target_path = final_staging.join(RuntimeType::Node.executable_name());
+            if !target_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Installed Node.js executable not found at {}",
+                    target_path.display()
+                ));
+            }
+
+            Self::set_executable_permissions(&target_path).await?;
+            Self::clean_dir(&staging_dir).await?;
+            Self::commit_staging(&final_staging, target_dir).await?;
+
+            Ok(target_dir.join(RuntimeType::Node.executable_name()))
         }
+        .await;
 
-        Self::set_executable_permissions(&target_path).await?;
-
-        // Clean up first-stage staging
-        let _ = Self::clean_dir(&staging_dir).await;
-
-        // Atomic swap
-        Self::commit_staging(&final_staging, target_dir).await?;
-
-        let final_path = target_dir.join(RuntimeType::Node.executable_name());
-        Ok(final_path)
+        match result {
+            Ok(final_path) => Ok(final_path),
+            Err(error) => {
+                let _ = Self::clean_dir(&staging_dir).await;
+                let _ = Self::clean_dir(&final_staging).await;
+                Err(error)
+            }
+        }
     }
 
     /// Install UV runtime
@@ -861,6 +864,77 @@ mod tests {
             assert!(target_dir.join("npm.cmd").exists(), "npm.cmd should exist");
             assert!(target_dir.join("npx.cmd").exists(), "npx.cmd should exist");
         }
+    }
+
+    #[tokio::test]
+    async fn install_node_keeps_existing_runtime_when_archive_is_invalid() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let installer = RuntimeInstaller::new();
+        let target_dir = temp_dir.path().join("node-runtime");
+        fs::create_dir_all(&target_dir).expect("create existing runtime dir");
+
+        #[cfg(unix)]
+        let existing_binary = target_dir.join("node");
+        #[cfg(windows)]
+        let existing_binary = target_dir.join("node.exe");
+
+        fs::write(&existing_binary, b"old-node").expect("seed existing runtime");
+
+        #[cfg(unix)]
+        let archive_path = {
+            let archive_path = temp_dir.path().join("broken-node.tar.gz");
+            let file = StdFile::create(&archive_path).expect("create tar.gz");
+            let encoder = GzEncoder::new(file, Compression::default());
+            let mut builder = Builder::new(encoder);
+
+            let mut readme_header = tar::Header::new_gnu();
+            readme_header
+                .set_path("node-v24.15.0-darwin-arm64/README.md")
+                .expect("set readme path");
+            readme_header.set_size(6);
+            readme_header.set_cksum();
+            builder
+                .append(&readme_header, &b"broken"[..])
+                .expect("append readme");
+
+            let encoder = builder.into_inner().expect("finish tar");
+            encoder.finish().expect("finish gzip");
+            archive_path
+        };
+
+        #[cfg(windows)]
+        let archive_path = {
+            let archive_path = temp_dir.path().join("broken-node.zip");
+            let file = StdFile::create(&archive_path).expect("create zip");
+            let mut zip = zip::ZipWriter::new(file);
+
+            zip.start_file(
+                "node-v24.15.0-win-x64/README.md",
+                SimpleFileOptions::default(),
+            )
+            .expect("start readme");
+            zip.write_all(b"broken").expect("write readme");
+
+            zip.finish().expect("finish zip");
+            archive_path
+        };
+
+        let error = installer
+            .install_node(&archive_path, &target_dir)
+            .await
+            .expect_err("invalid archive should fail");
+
+        assert!(
+            error.to_string().contains("install root not found"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(
+            fs::read(&existing_binary).expect("read existing runtime"),
+            b"old-node"
+        );
+        assert!(!RuntimeInstaller::staging_name(&target_dir, "staging").exists());
+        assert!(!RuntimeInstaller::staging_name(&target_dir, "final").exists());
+        assert!(!RuntimeInstaller::staging_name(&target_dir, "old").exists());
     }
 
     #[test]

--- a/backend/src/runtime/installer.rs
+++ b/backend/src/runtime/installer.rs
@@ -97,21 +97,21 @@ impl RuntimeInstaller {
         zip_file: &Path,
         target_dir: &Path,
     ) -> Result<PathBuf> {
-        tokio::fs::create_dir_all(target_dir).await?;
+        let staging_dir = Self::prepare_staging_dir(target_dir, "staging").await?;
 
         let extract_dir = Self::unique_temp_dir("mcpmate-bun-extract");
         self.prepare_extract_dir(&extract_dir).await?;
         self.extract_zip(zip_file, &extract_dir).await?;
 
         let bun_exe = self.find_bun_executable(&extract_dir)?;
-        let target_path = target_dir.join(if cfg!(windows) { "bun.exe" } else { "bun" });
+        let target_path = staging_dir.join(if cfg!(windows) { "bun.exe" } else { "bun" });
         tokio::fs::copy(&bun_exe, &target_path)
             .await
             .context("Failed to copy bun executable")?;
 
         Self::set_executable_permissions(&target_path).await?;
 
-        let bunx_path = target_dir.join(if cfg!(windows) { "bunx.exe" } else { "bunx" });
+        let bunx_path = staging_dir.join(if cfg!(windows) { "bunx.exe" } else { "bunx" });
         #[cfg(unix)]
         {
             if bunx_path.exists() {
@@ -134,7 +134,10 @@ impl RuntimeInstaller {
             tracing::warn!("Failed to clean up extract directory: {}", error);
         }
 
-        Ok(target_path)
+        Self::commit_staging(&staging_dir, target_dir).await?;
+
+        let final_path = target_dir.join(if cfg!(windows) { "bun.exe" } else { "bun" });
+        Ok(final_path)
     }
 
     async fn install_node(
@@ -142,27 +145,32 @@ impl RuntimeInstaller {
         archive_file: &Path,
         target_dir: &Path,
     ) -> Result<PathBuf> {
-        let extract_dir = Self::unique_temp_dir("mcpmate-node-extract");
-        self.prepare_extract_dir(&extract_dir).await?;
-        self.prepare_extract_dir(target_dir).await?;
+        // Use a staging directory so we never destroy a working installation
+        // mid-flight. If extraction or setup fails, the existing target_dir
+        // remains intact.
+        let staging_dir = Self::prepare_staging_dir(target_dir, "staging").await?;
 
         let is_zip = archive_file
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"));
 
         if is_zip {
-            self.extract_zip(archive_file, &extract_dir).await?;
+            self.extract_zip(archive_file, &staging_dir).await?;
         } else {
-            self.extract_tar_gz_skipping_links(archive_file, &extract_dir).await?;
+            self.extract_tar_gz_skipping_links(archive_file, &staging_dir).await?;
         }
 
-        let install_root = self.find_node_install_root(&extract_dir)?;
-        self.copy_directory_contents(&install_root, target_dir).await?;
+        let install_root = self.find_node_install_root(&staging_dir)?;
+        let final_staging = Self::staging_name(target_dir, "final");
+
+        // Clean any leftover final dir, then rename install_root -> final_staging
+        Self::clean_dir(&final_staging).await?;
+        tokio::fs::rename(&install_root, &final_staging).await?;
 
         #[cfg(unix)]
-        self.create_node_unix_shims(target_dir).await?;
+        self.create_node_unix_shims(&final_staging).await?;
 
-        let target_path = target_dir.join(RuntimeType::Node.executable_name());
+        let target_path = final_staging.join(RuntimeType::Node.executable_name());
         if !target_path.exists() {
             return Err(anyhow::anyhow!(
                 "Installed Node.js executable not found at {}",
@@ -172,11 +180,14 @@ impl RuntimeInstaller {
 
         Self::set_executable_permissions(&target_path).await?;
 
-        if let Err(error) = tokio::fs::remove_dir_all(&extract_dir).await {
-            tracing::warn!("Failed to clean up extract directory: {}", error);
-        }
+        // Clean up first-stage staging
+        let _ = Self::clean_dir(&staging_dir).await;
 
-        Ok(target_path)
+        // Atomic swap
+        Self::commit_staging(&final_staging, target_dir).await?;
+
+        let final_path = target_dir.join(RuntimeType::Node.executable_name());
+        Ok(final_path)
     }
 
     /// Install UV runtime
@@ -187,7 +198,7 @@ impl RuntimeInstaller {
         archive_file: &Path,
         target_dir: &Path,
     ) -> Result<PathBuf> {
-        tokio::fs::create_dir_all(target_dir).await?;
+        let staging_dir = Self::prepare_staging_dir(target_dir, "staging").await?;
 
         let extract_dir = Self::unique_temp_dir("mcpmate-uv-extract");
         self.prepare_extract_dir(&extract_dir).await?;
@@ -203,7 +214,7 @@ impl RuntimeInstaller {
         }
 
         let uv_exe = self.find_uv_executable(&extract_dir)?;
-        let target_path = target_dir.join(if cfg!(windows) { "uv.exe" } else { "uv" });
+        let target_path = staging_dir.join(if cfg!(windows) { "uv.exe" } else { "uv" });
         tokio::fs::copy(&uv_exe, &target_path)
             .await
             .context("Failed to copy uv executable")?;
@@ -211,7 +222,7 @@ impl RuntimeInstaller {
         Self::set_executable_permissions(&target_path).await?;
 
         let uvx_exe = self.find_uvx_executable(&extract_dir)?;
-        let uvx_path = target_dir.join(if cfg!(windows) { "uvx.exe" } else { "uvx" });
+        let uvx_path = staging_dir.join(if cfg!(windows) { "uvx.exe" } else { "uvx" });
 
         tokio::fs::copy(&uvx_exe, &uvx_path)
             .await
@@ -223,7 +234,10 @@ impl RuntimeInstaller {
             tracing::warn!("Failed to clean up extract directory: {}", error);
         }
 
-        Ok(target_path)
+        Self::commit_staging(&staging_dir, target_dir).await?;
+
+        let final_path = target_dir.join(if cfg!(windows) { "uv.exe" } else { "uv" });
+        Ok(final_path)
     }
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
@@ -265,6 +279,57 @@ impl RuntimeInstaller {
         tokio::fs::create_dir_all(target_dir)
             .await
             .context("Failed to create extract directory")?;
+        Ok(())
+    }
+
+    /// Remove a directory tree, ignoring "not found" errors.
+    async fn clean_dir(path: &Path) -> Result<()> {
+        if let Err(error) = tokio::fs::remove_dir_all(path).await {
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(error).context("Failed to clean directory");
+            }
+        }
+        Ok(())
+    }
+
+    /// Generate a sibling directory name for staging or backup.
+    fn staging_name(target_dir: &Path, suffix: &str) -> PathBuf {
+        target_dir
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(format!(
+                "{}.{}",
+                target_dir
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy(),
+                suffix
+            ))
+    }
+
+    /// Create a clean sibling staging directory for installation work.
+    async fn prepare_staging_dir(target_dir: &Path, suffix: &str) -> Result<PathBuf> {
+        let staging_dir = Self::staging_name(target_dir, suffix);
+        Self::clean_dir(&staging_dir).await?;
+        tokio::fs::create_dir_all(&staging_dir).await?;
+        Ok(staging_dir)
+    }
+
+    /// Atomically swap a fully-prepared staging directory into place.
+    ///
+    /// 1. Rename existing `target_dir` to `{target}.old`
+    /// 2. Rename `staging_dir` to `target_dir` (atomic on same filesystem)
+    /// 3. Clean up old backup
+    async fn commit_staging(staging_dir: &Path, target_dir: &Path) -> Result<()> {
+        let backup_dir = Self::staging_name(target_dir, "old");
+        Self::clean_dir(&backup_dir).await?;
+
+        if target_dir.exists() {
+            tokio::fs::rename(target_dir, &backup_dir).await?;
+        }
+        tokio::fs::rename(staging_dir, target_dir).await?;
+
+        let _ = Self::clean_dir(&backup_dir).await;
         Ok(())
     }
 
@@ -406,75 +471,6 @@ impl RuntimeInstaller {
         Ok(())
     }
 
-    async fn copy_directory_contents(
-        &self,
-        source_dir: &Path,
-        target_dir: &Path,
-    ) -> Result<()> {
-        let source_dir = source_dir.to_path_buf();
-        let target_dir = target_dir.to_path_buf();
-
-        task::spawn_blocking(move || -> Result<()> {
-            std::fs::create_dir_all(&target_dir)
-                .with_context(|| format!("Failed to create target dir: {}", target_dir.display()))?;
-
-            for entry in WalkDir::new(&source_dir) {
-                let entry = entry.context("Failed to walk source directory")?;
-                let path = entry.path();
-                let relative_path = path
-                    .strip_prefix(&source_dir)
-                    .with_context(|| format!("Failed to relativize path: {}", path.display()))?;
-
-                if relative_path.as_os_str().is_empty() {
-                    continue;
-                }
-
-                let destination = target_dir.join(relative_path);
-                let file_type = entry.file_type();
-
-                if file_type.is_dir() {
-                    std::fs::create_dir_all(&destination).with_context(|| {
-                        format!("Failed to create destination directory: {}", destination.display())
-                    })?;
-                    continue;
-                }
-
-                if !file_type.is_file() {
-                    continue;
-                }
-
-                if let Some(parent) = destination.parent() {
-                    std::fs::create_dir_all(parent)
-                        .with_context(|| format!("Failed to create destination parent: {}", parent.display()))?;
-                }
-
-                std::fs::copy(path, &destination).with_context(|| {
-                    format!(
-                        "Failed to copy runtime file from {} to {}",
-                        path.display(),
-                        destination.display()
-                    )
-                })?;
-
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let mode = std::fs::metadata(path)
-                        .with_context(|| format!("Failed to read metadata for {}", path.display()))?
-                        .permissions()
-                        .mode();
-                    std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(mode))
-                        .with_context(|| format!("Failed to set permissions on {}", destination.display()))?;
-                }
-            }
-
-            Ok(())
-        })
-        .await
-        .context("Failed to join runtime copy task")??;
-
-        Ok(())
-    }
 
     fn find_node_install_root(
         &self,
@@ -627,8 +623,8 @@ exec "$DIR/node" "$DIR/lib/node_modules/npm/bin/npx-cli.js" "$@"
 
         Err(anyhow::anyhow!("UVX executable not found in extracted files"))
     }
-}
 
+}
 impl Default for RuntimeInstaller {
     fn default() -> Self {
         Self::new()

--- a/backend/src/runtime/installer.rs
+++ b/backend/src/runtime/installer.rs
@@ -9,8 +9,9 @@ use nanoid::nanoid;
 use std::fs::File as StdFile;
 use std::io;
 use std::path::{Component, Path, PathBuf};
-use tar::Archive;
+use tar::{Archive, EntryType};
 use tokio::task;
+use walkdir::WalkDir;
 use zip::ZipArchive;
 
 use super::downloader::RuntimeDownloader;
@@ -36,34 +37,34 @@ impl RuntimeInstaller {
     pub async fn install_runtime(
         &self,
         runtime_type: RuntimeType,
+        version: Option<&str>,
     ) -> Result<PathBuf> {
-        tracing::info!("Installing runtime: {}", runtime_type.as_str());
+        tracing::info!(
+            "Installing runtime: {}{}",
+            runtime_type.as_str(),
+            version.map(|value| format!(" ({})", value.trim())).unwrap_or_default()
+        );
 
-        // Ensure runtimes directory exists
         self.manager.ensure_runtimes_dir()?;
 
-        // Create temporary download directory
         let temp_dir = Self::unique_temp_dir("mcpmate-runtime-install");
         tokio::fs::create_dir_all(&temp_dir)
             .await
             .context("Failed to create temp directory")?;
 
-        // Download the runtime
         let downloaded_file = self
             .downloader
-            .download_runtime(runtime_type, &temp_dir)
+            .download_runtime(runtime_type, version, &temp_dir)
             .await
             .context("Failed to download runtime")?;
 
-        // Extract and install
         let installed_path = self
             .extract_and_install(runtime_type, &downloaded_file)
             .await
             .context("Failed to extract and install runtime")?;
 
-        // Clean up temp directory
-        if let Err(e) = tokio::fs::remove_dir_all(&temp_dir).await {
-            tracing::warn!("Failed to clean up temp directory: {}", e);
+        if let Err(error) = tokio::fs::remove_dir_all(&temp_dir).await {
+            tracing::warn!("Failed to clean up temp directory: {}", error);
         }
 
         tracing::info!(
@@ -81,16 +82,12 @@ impl RuntimeInstaller {
         downloaded_file: &Path,
     ) -> Result<PathBuf> {
         let runtimes_dir = self.manager.runtimes_dir();
-
-        // Create runtime-specific subdirectory
-        let target_dir = match runtime_type {
-            RuntimeType::Bun => runtimes_dir.join("bun"),
-            RuntimeType::Uv => runtimes_dir.join("uv"),
-        };
+        let target_dir = runtimes_dir.join(runtime_type.as_str());
 
         match runtime_type {
             RuntimeType::Bun => self.install_bun(downloaded_file, &target_dir).await,
             RuntimeType::Uv => self.install_uv(downloaded_file, &target_dir).await,
+            RuntimeType::Node => self.install_node(downloaded_file, &target_dir).await,
         }
     }
 
@@ -100,33 +97,20 @@ impl RuntimeInstaller {
         zip_file: &Path,
         target_dir: &Path,
     ) -> Result<PathBuf> {
-        // Ensure target directory exists
         tokio::fs::create_dir_all(target_dir).await?;
 
-        // Extract zip file
         let extract_dir = Self::unique_temp_dir("mcpmate-bun-extract");
         self.prepare_extract_dir(&extract_dir).await?;
         self.extract_zip(zip_file, &extract_dir).await?;
 
-        // Find bun executable in extracted directory
         let bun_exe = self.find_bun_executable(&extract_dir)?;
-
-        // Copy to target directory
         let target_path = target_dir.join(if cfg!(windows) { "bun.exe" } else { "bun" });
         tokio::fs::copy(&bun_exe, &target_path)
             .await
             .context("Failed to copy bun executable")?;
 
-        // Make executable on Unix systems
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = tokio::fs::metadata(&target_path).await?.permissions();
-            perms.set_mode(0o755);
-            tokio::fs::set_permissions(&target_path, perms).await?;
-        }
+        Self::set_executable_permissions(&target_path).await?;
 
-        // Create bunx symlink/copy
         let bunx_path = target_dir.join(if cfg!(windows) { "bunx.exe" } else { "bunx" });
         #[cfg(unix)]
         {
@@ -144,9 +128,52 @@ impl RuntimeInstaller {
                 .context("Failed to copy bunx executable")?;
         }
 
-        // Clean up extract directory
-        if let Err(e) = tokio::fs::remove_dir_all(&extract_dir).await {
-            tracing::warn!("Failed to clean up extract directory: {}", e);
+        Self::set_executable_permissions(&bunx_path).await?;
+
+        if let Err(error) = tokio::fs::remove_dir_all(&extract_dir).await {
+            tracing::warn!("Failed to clean up extract directory: {}", error);
+        }
+
+        Ok(target_path)
+    }
+
+    async fn install_node(
+        &self,
+        archive_file: &Path,
+        target_dir: &Path,
+    ) -> Result<PathBuf> {
+        let extract_dir = Self::unique_temp_dir("mcpmate-node-extract");
+        self.prepare_extract_dir(&extract_dir).await?;
+        self.prepare_extract_dir(target_dir).await?;
+
+        let is_zip = archive_file
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"));
+
+        if is_zip {
+            self.extract_zip(archive_file, &extract_dir).await?;
+        } else {
+            self.extract_tar_gz_skipping_links(archive_file, &extract_dir).await?;
+        }
+
+        let install_root = self.find_node_install_root(&extract_dir)?;
+        self.copy_directory_contents(&install_root, target_dir).await?;
+
+        #[cfg(unix)]
+        self.create_node_unix_shims(target_dir).await?;
+
+        let target_path = target_dir.join(RuntimeType::Node.executable_name());
+        if !target_path.exists() {
+            return Err(anyhow::anyhow!(
+                "Installed Node.js executable not found at {}",
+                target_path.display()
+            ));
+        }
+
+        Self::set_executable_permissions(&target_path).await?;
+
+        if let Err(error) = tokio::fs::remove_dir_all(&extract_dir).await {
+            tracing::warn!("Failed to clean up extract directory: {}", error);
         }
 
         Ok(target_path)
@@ -160,10 +187,8 @@ impl RuntimeInstaller {
         archive_file: &Path,
         target_dir: &Path,
     ) -> Result<PathBuf> {
-        // Ensure target directory exists
         tokio::fs::create_dir_all(target_dir).await?;
 
-        // Extract archive (zip on Windows, tar.gz on macOS/Linux)
         let extract_dir = Self::unique_temp_dir("mcpmate-uv-extract");
         self.prepare_extract_dir(&extract_dir).await?;
 
@@ -177,25 +202,14 @@ impl RuntimeInstaller {
             self.extract_tar_gz(archive_file, &extract_dir).await?;
         }
 
-        // Find uv executable in extracted directory
         let uv_exe = self.find_uv_executable(&extract_dir)?;
-
-        // Copy uv to target directory
         let target_path = target_dir.join(if cfg!(windows) { "uv.exe" } else { "uv" });
         tokio::fs::copy(&uv_exe, &target_path)
             .await
             .context("Failed to copy uv executable")?;
 
-        // Make executable on Unix systems
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = tokio::fs::metadata(&target_path).await?.permissions();
-            perms.set_mode(0o755);
-            tokio::fs::set_permissions(&target_path, perms).await?;
-        }
+        Self::set_executable_permissions(&target_path).await?;
 
-        // Find and copy uvx executable (official uvx binary from the package)
         let uvx_exe = self.find_uvx_executable(&extract_dir)?;
         let uvx_path = target_dir.join(if cfg!(windows) { "uvx.exe" } else { "uvx" });
 
@@ -203,18 +217,10 @@ impl RuntimeInstaller {
             .await
             .context("Failed to copy uvx executable")?;
 
-        // Make uvx executable on Unix systems
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = tokio::fs::metadata(&uvx_path).await?.permissions();
-            perms.set_mode(0o755);
-            tokio::fs::set_permissions(&uvx_path, perms).await?;
-        }
+        Self::set_executable_permissions(&uvx_path).await?;
 
-        // Clean up extract directory
-        if let Err(e) = tokio::fs::remove_dir_all(&extract_dir).await {
-            tracing::warn!("Failed to clean up extract directory: {}", e);
+        if let Err(error) = tokio::fs::remove_dir_all(&extract_dir).await {
+            tracing::warn!("Failed to clean up extract directory: {}", error);
         }
 
         Ok(target_path)
@@ -250,15 +256,27 @@ impl RuntimeInstaller {
         &self,
         target_dir: &Path,
     ) -> Result<()> {
-        if let Err(e) = tokio::fs::remove_dir_all(target_dir).await {
-            if e.kind() != io::ErrorKind::NotFound {
-                return Err(e).context("Failed to clean extract directory");
+        if let Err(error) = tokio::fs::remove_dir_all(target_dir).await {
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(error).context("Failed to clean extract directory");
             }
         }
 
         tokio::fs::create_dir_all(target_dir)
             .await
             .context("Failed to create extract directory")?;
+        Ok(())
+    }
+
+    async fn set_executable_permissions(path: &Path) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = tokio::fs::metadata(path).await?.permissions();
+            perms.set_mode(0o755);
+            tokio::fs::set_permissions(path, perms).await?;
+        }
+
         Ok(())
     }
 
@@ -308,6 +326,22 @@ impl RuntimeInstaller {
         tar_file: &Path,
         target_dir: &Path,
     ) -> Result<()> {
+        Self::extract_tar_gz_internal(tar_file, target_dir, false).await
+    }
+
+    async fn extract_tar_gz_skipping_links(
+        &self,
+        tar_file: &Path,
+        target_dir: &Path,
+    ) -> Result<()> {
+        Self::extract_tar_gz_internal(tar_file, target_dir, true).await
+    }
+
+    async fn extract_tar_gz_internal(
+        tar_file: &Path,
+        target_dir: &Path,
+        skip_links: bool,
+    ) -> Result<()> {
         let tar_file = tar_file.to_path_buf();
         let target_dir = target_dir.to_path_buf();
 
@@ -327,6 +361,14 @@ impl RuntimeInstaller {
                 if file_type.is_dir() {
                     std::fs::create_dir_all(&safe_path)
                         .with_context(|| format!("Failed to create tar directory: {}", safe_path.display()))?;
+                    continue;
+                }
+
+                if skip_links && (file_type == EntryType::Symlink || file_type == EntryType::Link) {
+                    tracing::debug!(
+                        "Skipping tar link entry during runtime install: {}",
+                        entry_path.display()
+                    );
                     continue;
                 }
 
@@ -364,6 +406,177 @@ impl RuntimeInstaller {
         Ok(())
     }
 
+    async fn copy_directory_contents(
+        &self,
+        source_dir: &Path,
+        target_dir: &Path,
+    ) -> Result<()> {
+        let source_dir = source_dir.to_path_buf();
+        let target_dir = target_dir.to_path_buf();
+
+        task::spawn_blocking(move || -> Result<()> {
+            std::fs::create_dir_all(&target_dir)
+                .with_context(|| format!("Failed to create target dir: {}", target_dir.display()))?;
+
+            for entry in WalkDir::new(&source_dir) {
+                let entry = entry.context("Failed to walk source directory")?;
+                let path = entry.path();
+                let relative_path = path
+                    .strip_prefix(&source_dir)
+                    .with_context(|| format!("Failed to relativize path: {}", path.display()))?;
+
+                if relative_path.as_os_str().is_empty() {
+                    continue;
+                }
+
+                let destination = target_dir.join(relative_path);
+                let file_type = entry.file_type();
+
+                if file_type.is_dir() {
+                    std::fs::create_dir_all(&destination).with_context(|| {
+                        format!("Failed to create destination directory: {}", destination.display())
+                    })?;
+                    continue;
+                }
+
+                if !file_type.is_file() {
+                    continue;
+                }
+
+                if let Some(parent) = destination.parent() {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("Failed to create destination parent: {}", parent.display()))?;
+                }
+
+                std::fs::copy(path, &destination).with_context(|| {
+                    format!(
+                        "Failed to copy runtime file from {} to {}",
+                        path.display(),
+                        destination.display()
+                    )
+                })?;
+
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let mode = std::fs::metadata(path)
+                        .with_context(|| format!("Failed to read metadata for {}", path.display()))?
+                        .permissions()
+                        .mode();
+                    std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(mode))
+                        .with_context(|| format!("Failed to set permissions on {}", destination.display()))?;
+                }
+            }
+
+            Ok(())
+        })
+        .await
+        .context("Failed to join runtime copy task")??;
+
+        Ok(())
+    }
+
+    fn find_node_install_root(
+        &self,
+        extract_dir: &Path,
+    ) -> Result<PathBuf> {
+        if cfg!(windows) {
+            for entry in WalkDir::new(extract_dir) {
+                let entry = entry?;
+                if entry.file_name() == "node.exe" {
+                    let parent = entry.path().parent().ok_or_else(|| {
+                        anyhow::anyhow!("Node.js install root missing for {}", entry.path().display())
+                    })?;
+                    return Ok(parent.to_path_buf());
+                }
+            }
+        } else {
+            for entry in WalkDir::new(extract_dir) {
+                let entry = entry?;
+                if entry.file_name() == "node"
+                    && entry
+                        .path()
+                        .parent()
+                        .and_then(Path::file_name)
+                        .is_some_and(|part| part == "bin")
+                {
+                    let root = entry
+                        .path()
+                        .parent()
+                        .and_then(Path::parent)
+                        .ok_or_else(|| anyhow::anyhow!("Node.js install root missing"))?;
+                    return Ok(root.to_path_buf());
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("Node.js install root not found in extracted files"))
+    }
+
+    #[cfg(unix)]
+    async fn create_node_unix_shims(
+        &self,
+        target_dir: &Path,
+    ) -> Result<()> {
+        let bin_node = target_dir.join("bin").join("node");
+        let root_node = target_dir.join("node");
+        let npm_path = target_dir.join("npm");
+        let npx_path = target_dir.join("npx");
+
+        if !bin_node.exists() {
+            return Err(anyhow::anyhow!("Extracted Node.js archive does not contain bin/node"));
+        }
+
+        Self::recreate_hard_link_or_copy(&bin_node, &root_node).await?;
+        Self::set_executable_permissions(&root_node).await?;
+
+        let npm_script = r#"#!/bin/sh
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$DIR/node" "$DIR/lib/node_modules/npm/bin/npm-cli.js" "$@"
+"#;
+        tokio::fs::write(&npm_path, npm_script)
+            .await
+            .context("Failed to write npm launcher")?;
+        Self::set_executable_permissions(&npm_path).await?;
+
+        let npx_script = r#"#!/bin/sh
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$DIR/node" "$DIR/lib/node_modules/npm/bin/npx-cli.js" "$@"
+"#;
+        tokio::fs::write(&npx_path, npx_script)
+            .await
+            .context("Failed to write npx launcher")?;
+        Self::set_executable_permissions(&npx_path).await?;
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    async fn recreate_hard_link_or_copy(
+        source: &Path,
+        destination: &Path,
+    ) -> Result<()> {
+        if destination.exists() {
+            tokio::fs::remove_file(destination)
+                .await
+                .with_context(|| format!("Failed to remove existing file: {}", destination.display()))?;
+        }
+
+        match tokio::fs::hard_link(source, destination).await {
+            Ok(()) => Ok(()),
+            Err(_) => {
+                tokio::fs::copy(source, destination).await.with_context(|| {
+                    format!(
+                        "Failed to copy runtime binary from {} to {}",
+                        source.display(),
+                        destination.display()
+                    )
+                })?;
+                Ok(())
+            }
+        }
+    }
+
     /// Find bun executable in extracted directory
     fn find_bun_executable(
         &self,
@@ -371,8 +584,7 @@ impl RuntimeInstaller {
     ) -> Result<PathBuf> {
         let exe_name = if cfg!(windows) { "bun.exe" } else { "bun" };
 
-        // Look for bun executable recursively
-        for entry in walkdir::WalkDir::new(extract_dir) {
+        for entry in WalkDir::new(extract_dir) {
             let entry = entry?;
             if entry.file_name() == exe_name {
                 return Ok(entry.path().to_path_buf());
@@ -389,8 +601,7 @@ impl RuntimeInstaller {
     ) -> Result<PathBuf> {
         let exe_name = if cfg!(windows) { "uv.exe" } else { "uv" };
 
-        // Look for uv executable recursively
-        for entry in walkdir::WalkDir::new(extract_dir) {
+        for entry in WalkDir::new(extract_dir) {
             let entry = entry?;
             if entry.file_name() == exe_name {
                 return Ok(entry.path().to_path_buf());
@@ -407,8 +618,7 @@ impl RuntimeInstaller {
     ) -> Result<PathBuf> {
         let exe_name = if cfg!(windows) { "uvx.exe" } else { "uvx" };
 
-        // Look for uvx executable recursively
-        for entry in walkdir::WalkDir::new(extract_dir) {
+        for entry in WalkDir::new(extract_dir) {
             let entry = entry?;
             if entry.file_name() == exe_name {
                 return Ok(entry.path().to_path_buf());
@@ -526,6 +736,53 @@ mod tests {
             .expect_err("reject symlink");
 
         assert!(err.to_string().contains("Unsupported tar entry type"));
+    }
+
+    #[tokio::test]
+    async fn extract_tar_gz_skips_symlink_entries_for_node_archives() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let tar_path = temp_dir.path().join("node.tar.gz");
+        let file = StdFile::create(&tar_path).expect("create tar.gz");
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut builder = Builder::new(encoder);
+
+        let mut file_header = tar::Header::new_gnu();
+        file_header
+            .set_path("node-v24.15.0-darwin-arm64/bin/node")
+            .expect("set file path");
+        file_header.set_mode(0o755);
+        file_header.set_size(4);
+        file_header.set_cksum();
+        builder.append(&file_header, &b"node"[..]).expect("append node");
+
+        let mut link_header = tar::Header::new_gnu();
+        link_header.set_entry_type(EntryType::Symlink);
+        link_header
+            .set_path("node-v24.15.0-darwin-arm64/bin/npm")
+            .expect("set link path");
+        link_header
+            .set_link_name("../lib/node_modules/npm/bin/npm-cli.js")
+            .expect("set link name");
+        link_header.set_size(0);
+        link_header.set_cksum();
+        builder.append(&link_header, std::io::empty()).expect("append symlink");
+
+        let encoder = builder.into_inner().expect("finish tar");
+        encoder.finish().expect("finish gzip");
+
+        let target_dir = temp_dir.path().join("extract");
+        let installer = RuntimeInstaller::new();
+        installer
+            .prepare_extract_dir(&target_dir)
+            .await
+            .expect("prepare extract dir");
+        installer
+            .extract_tar_gz_skipping_links(&tar_path, &target_dir)
+            .await
+            .expect("extract tar.gz while skipping links");
+
+        assert!(target_dir.join("node-v24.15.0-darwin-arm64/bin/node").exists());
+        assert!(!target_dir.join("node-v24.15.0-darwin-arm64/bin/npm").exists());
     }
 
     #[test]

--- a/backend/src/runtime/installer.rs
+++ b/backend/src/runtime/installer.rs
@@ -781,6 +781,88 @@ mod tests {
         assert!(!target_dir.join("node-v24.15.0-darwin-arm64/bin/npm").exists());
     }
 
+    #[tokio::test]
+    async fn install_node_creates_expected_runtime_layout() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let installer = RuntimeInstaller::new();
+        let target_dir = temp_dir.path().join("node-runtime");
+
+        #[cfg(unix)]
+        let archive_path = {
+            let archive_path = temp_dir.path().join("node.tar.gz");
+            let file = StdFile::create(&archive_path).expect("create tar.gz");
+            let encoder = GzEncoder::new(file, Compression::default());
+            let mut builder = Builder::new(encoder);
+
+            let mut node_header = tar::Header::new_gnu();
+            node_header
+                .set_path("node-v24.15.0-darwin-arm64/bin/node")
+                .expect("set node path");
+            node_header.set_mode(0o755);
+            node_header.set_size(4);
+            node_header.set_cksum();
+            builder
+                .append(&node_header, &b"node"[..])
+                .expect("append node binary");
+
+            let encoder = builder.into_inner().expect("finish tar");
+            encoder.finish().expect("finish gzip");
+            archive_path
+        };
+
+        #[cfg(windows)]
+        let archive_path = {
+            let archive_path = temp_dir.path().join("node.zip");
+            let file = StdFile::create(&archive_path).expect("create zip");
+            let mut zip = zip::ZipWriter::new(file);
+
+            zip.start_file(
+                "node-v24.15.0-win-x64/node.exe",
+                SimpleFileOptions::default(),
+            )
+            .expect("start node.exe");
+            zip.write_all(b"node").expect("write node.exe");
+
+            zip.start_file(
+                "node-v24.15.0-win-x64/npm.cmd",
+                SimpleFileOptions::default(),
+            )
+            .expect("start npm.cmd");
+            zip.write_all(b"npm").expect("write npm.cmd");
+
+            zip.start_file(
+                "node-v24.15.0-win-x64/npx.cmd",
+                SimpleFileOptions::default(),
+            )
+            .expect("start npx.cmd");
+            zip.write_all(b"npx").expect("write npx.cmd");
+
+            zip.finish().expect("finish zip");
+            archive_path
+        };
+
+        let installed_path = installer
+            .install_node(&archive_path, &target_dir)
+            .await
+            .expect("install node runtime");
+
+        assert!(installed_path.exists(), "installed node path should exist");
+
+        #[cfg(unix)]
+        {
+            assert!(target_dir.join("node").exists(), "node shim should exist");
+            assert!(target_dir.join("npm").exists(), "npm shim should exist");
+            assert!(target_dir.join("npx").exists(), "npx shim should exist");
+        }
+
+        #[cfg(windows)]
+        {
+            assert!(target_dir.join("node.exe").exists(), "node.exe should exist");
+            assert!(target_dir.join("npm.cmd").exists(), "npm.cmd should exist");
+            assert!(target_dir.join("npx.cmd").exists(), "npx.cmd should exist");
+        }
+    }
+
     #[test]
     fn unique_temp_dir_creates_distinct_paths() {
         assert_ne!(

--- a/backend/src/runtime/manager.rs
+++ b/backend/src/runtime/manager.rs
@@ -33,74 +33,60 @@ impl RuntimeManager {
         self.get_executable_path(runtime_type).is_some()
     }
 
-    /// Get the executable path for a runtime
+    /// Get the executable path for a runtime.
     pub fn get_executable_path(
         &self,
         runtime_type: RuntimeType,
     ) -> Option<PathBuf> {
-        // Check for MCPMate managed executables (preferred for version consistency and security)
-        match runtime_type {
-            RuntimeType::Uv => {
-                let runtime_dir = self.runtimes_dir.join(runtime_type.as_str());
+        let candidates: &[&str] = match runtime_type {
+            RuntimeType::Uv => &[commands::UV, commands::UVX],
+            RuntimeType::Bun => &[commands::BUN, commands::BUNX],
+            RuntimeType::Node => &[commands::NODE, commands::NPM, commands::NPX],
+        };
 
-                // Check for uvx first (preferred for MCP servers)
-                let uvx_name = runtime_type.executable_name_for_command(commands::UVX);
-                let uvx_path = runtime_dir.join(uvx_name);
-                if uvx_path.exists() {
-                    return Some(uvx_path);
-                }
-
-                // Fall back to uv
-                let runtime_name = runtime_type.executable_name();
-                let runtime_path = runtime_dir.join(runtime_name);
-                if runtime_path.exists() {
-                    Some(runtime_path)
-                } else {
-                    None
-                }
-            }
-            RuntimeType::Bun => {
-                let runtime_dir = self.runtimes_dir.join(runtime_type.as_str());
-
-                // Check for bunx first (preferred)
-                let bunx_name = runtime_type.executable_name_for_command(commands::BUNX);
-                let bunx_path = runtime_dir.join(bunx_name);
-                if bunx_path.exists() {
-                    return Some(bunx_path);
-                }
-
-                // Fall back to bun
-                let runtime_name = runtime_type.executable_name();
-                let runtime_path = runtime_dir.join(runtime_name);
-                if runtime_path.exists() {
-                    Some(runtime_path)
-                } else {
-                    None
-                }
-            }
-        }
+        candidates
+            .iter()
+            .find_map(|command| self.resolve_command_path(runtime_type, command))
     }
 
-    /// Get runtime path for a command (uvx -> Uv, bunx -> Bun)
-    /// Note: npx is handled by command transformation to bunx
+    /// Get the executable path for an exact command alias.
+    pub fn get_command_path(
+        &self,
+        command: &str,
+    ) -> Option<PathBuf> {
+        let runtime_type = RuntimeType::from_command(command)?;
+        self.resolve_command_path(runtime_type, command)
+    }
+
+    /// Get runtime path for a command alias.
     pub fn get_runtime_for_command(
         &self,
         command: &str,
     ) -> Option<PathBuf> {
-        let runtime_type = match command {
-            commands::UVX => RuntimeType::Uv,
-            commands::BUNX => RuntimeType::Bun,
-            _ => return None,
-        };
+        self.get_command_path(command)
+    }
 
-        self.get_executable_path(runtime_type)
+    fn resolve_command_path(
+        &self,
+        runtime_type: RuntimeType,
+        command: &str,
+    ) -> Option<PathBuf> {
+        let runtime_dir = self.runtimes_dir.join(runtime_type.as_str());
+        let executable_name = runtime_type.executable_name_for_command(command);
+        let mut candidates = vec![runtime_dir.join(&executable_name)];
+
+        if matches!(runtime_type, RuntimeType::Node) {
+            candidates.push(runtime_dir.join("bin").join(&executable_name));
+        }
+
+        candidates.into_iter().find(|path| path.exists())
     }
 
     /// List all installed runtimes
     pub fn list_installed(&self) -> Vec<RuntimeInfo> {
         let mut runtimes = Vec::new();
 
-        for runtime_type in [RuntimeType::Uv, RuntimeType::Bun] {
+        for &runtime_type in RuntimeType::all() {
             let info = RuntimeInfo {
                 runtime_type,
                 available: self.is_installed(runtime_type),

--- a/board/src/lib/api.ts
+++ b/board/src/lib/api.ts
@@ -1710,17 +1710,37 @@ export const runtimeApi = {
 		return extractApiData(response);
 	},
 
-	resetCache: (cacheType?: "all" | "uv" | "bun") =>
-		fetchApi<ClearCacheResponse>("/api/runtime/cache/reset", {
-			method: "POST",
-			body: JSON.stringify({ cache_type: cacheType || "all" }),
-		}),
+	async resetCache(
+		cacheType?: "all" | "uv" | "bun" | "node",
+	): Promise<ClearCacheResponse> {
+		const response = await fetchApi<ApiWrapper<ClearCacheResponse>>(
+			"/api/runtime/cache/reset",
+			{
+				method: "POST",
+				body: JSON.stringify({ cache_type: cacheType || "all" }),
+			},
+		);
+		const data = extractApiData(response);
+		if (!data.success) {
+			throw new Error("Runtime cache reset failed");
+		}
+		return data;
+	},
 
-	install: (req: InstallRuntimeRequest) =>
-		fetchApi<InstallResponse>("/api/runtime/install", {
-			method: "POST",
-			body: JSON.stringify(req),
-		}),
+	async install(req: InstallRuntimeRequest): Promise<InstallResponse> {
+		const response = await fetchApi<ApiWrapper<InstallResponse>>(
+			"/api/runtime/install",
+			{
+				method: "POST",
+				body: JSON.stringify(req),
+			},
+		);
+		const data = extractApiData(response);
+		if (!data.success) {
+			throw new Error(data.message || "Runtime installation failed");
+		}
+		return data;
+	},
 };
 
 // Capabilities Cache API

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -767,6 +767,7 @@ export interface RuntimeStatusItem {
 export interface RuntimeStatusResponse {
   uv: RuntimeStatusItem;
   bun: RuntimeStatusItem;
+  node: RuntimeStatusItem;
 }
 
 export interface RuntimeCacheItem {
@@ -785,10 +786,11 @@ export interface RuntimeCacheResponse {
   summary: RuntimeCacheSummaryInfo;
   uv: RuntimeCacheItem;
   bun: RuntimeCacheItem;
+  node: RuntimeCacheItem;
 }
 
 export interface InstallRuntimeRequest {
-  runtime_type: string; // "uv" | "bun"
+  runtime_type: string; // "uv" | "bun" | "node"
   version?: string;
   timeout?: number;
   max_retries?: number;

--- a/board/src/pages/runtime/i18n/index.ts
+++ b/board/src/pages/runtime/i18n/index.ts
@@ -3,7 +3,8 @@ export const runtimeTranslations = {
         title: "Observe runtime status, queues, and cache",
 		types: {
 			uv: "UV",
-			bun: "BUN",
+			bun: "Bun",
+			node: "Node.js",
 		},
 		status: {
 			running: "running",
@@ -22,6 +23,25 @@ export const runtimeTranslations = {
 			size: "Size",
 			packages: "Packages",
 			lastModified: "Last Modified",
+		},
+		fallbacks: {
+			notAvailable: "N/A",
+			empty: "—",
+		},
+		toasts: {
+			resetAllTitle: "Caches reset",
+			resetAllDescription: "All runtime caches cleared.",
+			resetOneTitle: "Cache reset",
+			resetOneDescription: "{{runtime}} cache cleared.",
+			installTitle: "Install complete",
+			installDescription: "{{runtime}}: {{message}}",
+			installTargetMismatch:
+				"Requested {{requested}}, but the server reported {{actual}}.",
+			capabilitiesResetTitle: "Capabilities cache cleared",
+			capabilitiesResetDescription:
+				"Capability data will be rehydrated on next access.",
+			errorResetTitle: "Reset failed",
+			errorInstallTitle: "Install failed",
 		},
 		capabilities: {
 			title: "Capabilities Cache",
@@ -66,7 +86,8 @@ export const runtimeTranslations = {
         title: "维护内建运行时与缓存",
 		types: {
 			uv: "UV",
-			bun: "BUN",
+			bun: "Bun",
+			node: "Node.js",
 		},
 		status: {
 			running: "运行中",
@@ -85,6 +106,23 @@ export const runtimeTranslations = {
 			size: "大小",
 			packages: "包数量",
 			lastModified: "最后修改",
+		},
+		fallbacks: {
+			notAvailable: "N/A",
+			empty: "—",
+		},
+		toasts: {
+			resetAllTitle: "缓存已重置",
+			resetAllDescription: "所有运行时缓存已清除。",
+			resetOneTitle: "缓存已重置",
+			resetOneDescription: "{{runtime}} 缓存已清除。",
+			installTitle: "安装完成",
+			installDescription: "{{runtime}}：{{message}}",
+			installTargetMismatch: "请求的是 {{requested}}，但服务端返回的是 {{actual}}。",
+			capabilitiesResetTitle: "能力缓存已清除",
+			capabilitiesResetDescription: "能力数据会在下次访问时重新生成。",
+			errorResetTitle: "重置失败",
+			errorInstallTitle: "安装失败",
 		},
 		capabilities: {
 			title: "能力缓存",
@@ -128,7 +166,8 @@ export const runtimeTranslations = {
         title: "ランタイム状態・キュー・キャッシュの監視",
 		types: {
 			uv: "UV",
-			bun: "BUN",
+			bun: "Bun",
+			node: "Node.js",
 		},
 		status: {
 			running: "実行中",
@@ -147,6 +186,25 @@ export const runtimeTranslations = {
 			size: "サイズ",
 			packages: "パッケージ数",
 			lastModified: "最終更新",
+		},
+		fallbacks: {
+			notAvailable: "N/A",
+			empty: "—",
+		},
+		toasts: {
+			resetAllTitle: "キャッシュをリセットしました",
+			resetAllDescription: "すべてのランタイムキャッシュを削除しました。",
+			resetOneTitle: "キャッシュをリセットしました",
+			resetOneDescription: "{{runtime}} キャッシュを削除しました。",
+			installTitle: "インストール完了",
+			installDescription: "{{runtime}}: {{message}}",
+			installTargetMismatch:
+				"{{requested}} を要求しましたが、サーバーは {{actual}} を返しました。",
+			capabilitiesResetTitle: "機能キャッシュを削除しました",
+			capabilitiesResetDescription:
+				"機能データは次回アクセス時に再生成されます。",
+			errorResetTitle: "リセットに失敗しました",
+			errorInstallTitle: "インストールに失敗しました",
 		},
 		capabilities: {
 			title: "機能キャッシュ",

--- a/board/src/pages/runtime/runtime-page.tsx
+++ b/board/src/pages/runtime/runtime-page.tsx
@@ -105,13 +105,15 @@ export function RuntimePage() {
 			);
 			setConfirm(null);
 		},
-		onError: (e) =>
+		onError: (e) => {
+			qc.invalidateQueries({ queryKey: ["runtimeCache"] });
 			notifyError(
 				t("runtime:toasts.errorResetTitle", {
 					defaultValue: "Reset failed",
 				}),
 				e.message,
-			),
+			);
+		},
 	});
 
 	const resetOneM = useMutation<ClearCacheResponse, Error, RuntimeKind>({
@@ -129,13 +131,15 @@ export function RuntimePage() {
 			);
 			setConfirm(null);
 		},
-		onError: (e) =>
+		onError: (e) => {
+			qc.invalidateQueries({ queryKey: ["runtimeCache"] });
 			notifyError(
 				t("runtime:toasts.errorResetTitle", {
 					defaultValue: "Reset failed",
 				}),
 				e.message,
-			),
+			);
+		},
 	});
 
 	const installM = useMutation<InstallResponse, Error, RuntimeKind>({
@@ -174,13 +178,16 @@ export function RuntimePage() {
 			);
 			setConfirm(null);
 		},
-		onError: (e) =>
+		onError: (e) => {
+			qc.invalidateQueries({ queryKey: ["runtimeStatus"] });
+			qc.invalidateQueries({ queryKey: ["runtimeCache"] });
 			notifyError(
 				t("runtime:toasts.errorInstallTitle", {
 					defaultValue: "Install failed",
 				}),
 				e.message,
-			),
+			);
+		},
 	});
 
 	const capResetM = useMutation<ClearCacheResponse, Error, void>({

--- a/board/src/pages/runtime/runtime-page.tsx
+++ b/board/src/pages/runtime/runtime-page.tsx
@@ -15,27 +15,58 @@ import { capabilitiesApi, runtimeApi } from "../../lib/api";
 import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import { notifyError, notifySuccess } from "../../lib/notify";
 import type {
-	CapabilitiesStatsResponse,
 	ClearCacheResponse,
 	InstallResponse,
-	RuntimeCacheResponse,
-	RuntimeStatusResponse,
 } from "../../lib/types";
 import { formatBytes, formatLocalDateTime } from "../../lib/utils";
 
+type RuntimeKind = "uv" | "bun" | "node";
+
+const RUNTIME_KINDS: RuntimeKind[] = ["node", "bun", "uv"];
+
+type ConfirmState =
+	| { type: "resetAll" }
+	| { type: "resetOne"; key: RuntimeKind }
+	| { type: "install"; key: RuntimeKind }
+	| { type: "capabilitiesReset" }
+	| null;
+
+function normalizeRuntimeKind(
+	runtimeType: string | null | undefined,
+): RuntimeKind | null {
+	switch (runtimeType?.trim().toLowerCase()) {
+		case "node":
+			return "node";
+		case "bun":
+			return "bun";
+		case "uv":
+			return "uv";
+		default:
+			return null;
+	}
+}
+
+function getRuntimeFolder(path: string | null | undefined): string {
+	if (!path) {
+		return "";
+	}
+
+	const normalizedPath = path.replace(/\\/g, "/");
+	const lastSlashIndex = normalizedPath.lastIndexOf("/");
+
+	if (lastSlashIndex === -1) {
+		return "";
+	}
+
+	return normalizedPath.slice(0, lastSlashIndex);
+}
+
 export function RuntimePage() {
 	usePageTranslations("runtime");
-    const { t } = useTranslation();
+	const { t } = useTranslation();
 	const qc = useQueryClient();
-	const [confirm, setConfirm] = React.useState<
-		| { type: "resetAll" }
-		| { type: "resetOne"; key: "uv" | "bun" }
-		| { type: "install"; key: "uv" | "bun" }
-		| { type: "capabilitiesReset" }
-		| null
-	>(null);
+	const [confirm, setConfirm] = React.useState<ConfirmState>(null);
 
-	// Queries
 	const runtimeStatusQ = useQuery({
 		queryKey: ["runtimeStatus"],
 		queryFn: runtimeApi.getStatus,
@@ -60,65 +91,166 @@ export function RuntimePage() {
 		refetchOnWindowFocus: false,
 	});
 
-	// Mutations
 	const resetAllM = useMutation<{ success: boolean }, Error, void>({
 		mutationFn: async () => runtimeApi.resetCache("all"),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["runtimeCache"] });
-			notifySuccess("Caches reset", "All runtime caches cleared.");
+			notifySuccess(
+				t("runtime:toasts.resetAllTitle", {
+					defaultValue: "Caches reset",
+				}),
+				t("runtime:toasts.resetAllDescription", {
+					defaultValue: "All runtime caches cleared.",
+				}),
+			);
 			setConfirm(null);
 		},
-		onError: (e) => notifyError("Reset failed", e.message),
+		onError: (e) =>
+			notifyError(
+				t("runtime:toasts.errorResetTitle", {
+					defaultValue: "Reset failed",
+				}),
+				e.message,
+			),
 	});
 
-	const resetOneM = useMutation<ClearCacheResponse, Error, "uv" | "bun">({
+	const resetOneM = useMutation<ClearCacheResponse, Error, RuntimeKind>({
 		mutationFn: async (kind) => runtimeApi.resetCache(kind),
 		onSuccess: (_data, kind) => {
 			qc.invalidateQueries({ queryKey: ["runtimeCache"] });
-			notifySuccess("Cache reset", `${kind.toUpperCase()} cache cleared.`);
+			notifySuccess(
+				t("runtime:toasts.resetOneTitle", {
+					defaultValue: "Cache reset",
+				}),
+				t("runtime:toasts.resetOneDescription", {
+					defaultValue: "{{runtime}} cache cleared.",
+					runtime: getRuntimeLabel(kind),
+				}),
+			);
 			setConfirm(null);
 		},
-		onError: (e) => notifyError("Reset failed", e.message),
+		onError: (e) =>
+			notifyError(
+				t("runtime:toasts.errorResetTitle", {
+					defaultValue: "Reset failed",
+				}),
+				e.message,
+			),
 	});
 
-	const installM = useMutation<InstallResponse, Error, "uv" | "bun">({
+	const installM = useMutation<InstallResponse, Error, RuntimeKind>({
 		mutationFn: async (kind) =>
 			runtimeApi.install({ runtime_type: kind, verbose: true }),
 		onSuccess: (data, kind) => {
 			qc.invalidateQueries({ queryKey: ["runtimeStatus"] });
+			qc.invalidateQueries({ queryKey: ["runtimeCache"] });
+
+			const resolvedKind = normalizeRuntimeKind(data.runtime_type);
+			if (resolvedKind !== kind) {
+				notifyError(
+					t("runtime:toasts.errorInstallTitle", {
+						defaultValue: "Install failed",
+					}),
+					t("runtime:toasts.installTargetMismatch", {
+						defaultValue:
+							"Requested {{requested}}, but the server reported {{actual}}.",
+						requested: getRuntimeLabel(kind),
+						actual: resolvedKind ? getRuntimeLabel(resolvedKind) : data.runtime_type,
+					}),
+				);
+				setConfirm(null);
+				return;
+			}
+
 			notifySuccess(
-				"Install complete",
-				`${kind.toUpperCase()}: ${data.message}`,
+				t("runtime:toasts.installTitle", {
+					defaultValue: "Install complete",
+				}),
+				t("runtime:toasts.installDescription", {
+					defaultValue: "{{runtime}}: {{message}}",
+					runtime: getRuntimeLabel(kind),
+					message: data.message,
+				}),
 			);
 			setConfirm(null);
 		},
-		onError: (e) => notifyError("Install failed", e.message),
+		onError: (e) =>
+			notifyError(
+				t("runtime:toasts.errorInstallTitle", {
+					defaultValue: "Install failed",
+				}),
+				e.message,
+			),
 	});
 
-	// Capabilities cache reset
 	const capResetM = useMutation<ClearCacheResponse, Error, void>({
 		mutationFn: async () => capabilitiesApi.reset(),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["capabilities", "stats"] });
 			notifySuccess(
-				"Capabilities cache cleared",
-				"Capability data will be rehydrated on next access.",
+				t("runtime:toasts.capabilitiesResetTitle", {
+					defaultValue: "Capabilities cache cleared",
+				}),
+				t("runtime:toasts.capabilitiesResetDescription", {
+					defaultValue:
+						"Capability data will be rehydrated on next access.",
+				}),
 			);
 			setConfirm(null);
 		},
-		onError: (e) => notifyError("Reset failed", e.message),
+		onError: (e) =>
+			notifyError(
+				t("runtime:toasts.errorResetTitle", {
+					defaultValue: "Reset failed",
+				}),
+				e.message,
+			),
 	});
 
 	const isBusy =
 		resetAllM.isPending || resetOneM.isPending || installM.isPending;
+	const status = runtimeStatusQ.data;
+	const cache = runtimeCacheQ.data;
+	const capStats = capabilitiesStatsQ.data;
+	const getRuntimeLabel = (kind: RuntimeKind) =>
+		t(`runtime:types.${kind}`, { defaultValue: kind.toUpperCase() });
 
-	const status = runtimeStatusQ.data as RuntimeStatusResponse | undefined;
-	const cache = runtimeCacheQ.data as RuntimeCacheResponse | undefined;
-	const capStats = capabilitiesStatsQ.data as
-		| CapabilitiesStatsResponse
-		| undefined;
+	let confirmTitle = t("runtime:capabilities.resetConfirmTitle", {
+		defaultValue: "Reset capabilities cache?",
+	});
+	let confirmDescription = t("runtime:capabilities.resetConfirmDesc", {
+		defaultValue:
+			"This clears both memory and on-disk capability cache. It will be repopulated on next access.",
+	});
+	let confirmLabel = t("runtime:dialogs.confirm");
+	let confirmVariant: "default" | "destructive" = "destructive";
+	let confirmLoading = false;
 
-	const kinds: Array<"uv" | "bun"> = ["uv", "bun"];
+	if (confirm?.type === "resetAll") {
+		confirmTitle = t("runtime:dialogs.resetAllTitle");
+		confirmDescription = t("runtime:dialogs.resetAllDescription");
+		confirmLoading = resetAllM.isPending;
+	} else if (confirm?.type === "resetOne") {
+		confirmTitle = t("runtime:dialogs.resetOneTitle", {
+			key: getRuntimeLabel(confirm.key),
+		});
+		confirmDescription = t("runtime:dialogs.resetOneDescription", {
+			key: getRuntimeLabel(confirm.key),
+		});
+		confirmLoading = resetOneM.isPending;
+	} else if (confirm?.type === "install") {
+		confirmTitle = t("runtime:dialogs.installTitle", {
+			key: getRuntimeLabel(confirm.key),
+		});
+		confirmDescription = t("runtime:dialogs.installDescription", {
+			key: getRuntimeLabel(confirm.key),
+		});
+		confirmLabel = t("runtime:dialogs.installRepair");
+		confirmVariant = "default";
+		confirmLoading = installM.isPending;
+	} else if (confirm?.type === "capabilitiesReset") {
+		confirmLoading = capResetM.isPending;
+	}
 
 	return (
 		<div className="space-y-4">
@@ -142,8 +274,8 @@ export function RuntimePage() {
 			</div>
 
 			{runtimeStatusQ.isLoading || runtimeCacheQ.isLoading ? (
-				<div className="grid gap-4 md:grid-cols-2">
-					{[0, 1].map((i) => (
+				<div className="grid gap-4 md:grid-cols-3">
+					{[0, 1, 2].map((i) => (
 						<div
 							key={i}
 							className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
@@ -170,15 +302,12 @@ export function RuntimePage() {
 					))}
 				</div>
 			) : (
-				<div className="grid gap-4 md:grid-cols-2">
-					{kinds.map((key) => {
+				<div className="grid gap-4 md:grid-cols-3">
+					{RUNTIME_KINDS.map((key) => {
 						const st = status?.[key];
 						const c = cache?.[key];
 						const statusStr = st?.available ? "running" : "stopped";
-						const p = st?.path ? st.path.replace(/\\/g, "/") : "";
-						const folder = p.includes("/")
-							? p.slice(0, p.lastIndexOf("/"))
-							: "";
+						const folder = getRuntimeFolder(st?.path);
 
 						return (
 							<div
@@ -200,7 +329,12 @@ export function RuntimePage() {
 										<span className="text-slate-500">
 											{t("runtime:labels.version")}
 										</span>
-										<span>{st?.version || "N/A"}</span>
+										<span>
+										{st?.version ||
+											t("runtime:fallbacks.notAvailable", {
+												defaultValue: "N/A",
+											})}
+									</span>
 									</div>
 									{folder ? (
 										<div className="flex items-center justify-between">
@@ -220,7 +354,7 @@ export function RuntimePage() {
 											className="truncate max-w-[60%]"
 											title={st?.message || ""}
 										>
-											{st?.message || "—"}
+											{st?.message || t("runtime:fallbacks.empty", { defaultValue: "—" })}
 										</span>
 									</div>
 
@@ -246,7 +380,7 @@ export function RuntimePage() {
 										<span>
                                 {c?.last_modified
                                     ? formatLocalDateTime(c.last_modified)
-                                    : "—"}
+                                    : t("runtime:fallbacks.empty", { defaultValue: "—" })}
 										</span>
 									</div>
 								</div>
@@ -318,7 +452,7 @@ export function RuntimePage() {
 										className="truncate max-w-[60%]"
 										title={capStats?.storage?.db_path || ""}
 									>
-										{capStats?.storage?.db_path || "—"}
+										{capStats?.storage?.db_path || t("runtime:fallbacks.empty", { defaultValue: "—" })}
 									</span>
 								</div>
 								<div className="flex items-center justify-between">
@@ -334,7 +468,7 @@ export function RuntimePage() {
 									<span>
                                 {capStats.storage.last_cleanup
                                     ? formatLocalDateTime(capStats.storage.last_cleanup)
-                                    : "—"}
+                                    : t("runtime:fallbacks.empty", { defaultValue: "—" })}
 									</span>
 								</div>
 								<div className="flex items-center justify-between">
@@ -435,71 +569,28 @@ export function RuntimePage() {
 				</CardContent>
 			</Card>
 			{/* Global confirmation dialog */}
-			<ConfirmDialog
-				isOpen={confirm !== null}
-				onClose={() => setConfirm(null)}
-				onConfirm={async () => {
-					if (!confirm) return;
-					if (confirm.type === "resetAll") {
-						resetAllM.mutate();
-					} else if (confirm.type === "resetOne") {
-						resetOneM.mutate(confirm.key);
-					} else if (confirm.type === "install") {
-						installM.mutate(confirm.key);
-					} else if (confirm.type === "capabilitiesReset") {
-						capResetM.mutate();
-					}
-				}}
-				title={
-					confirm?.type === "resetAll"
-						? t("runtime:dialogs.resetAllTitle")
-						: confirm?.type === "resetOne"
-							? t("runtime:dialogs.resetOneTitle", {
-									key: confirm.key.toUpperCase(),
-								})
-							: confirm?.type === "install"
-								? t("runtime:dialogs.installTitle", {
-										key: confirm.key.toUpperCase(),
-									})
-								: t("runtime:capabilities.resetConfirmTitle", {
-										defaultValue: "Reset capabilities cache?",
-									})
-				}
-				description={
-					confirm?.type === "resetAll"
-						? t("runtime:dialogs.resetAllDescription")
-						: confirm?.type === "resetOne"
-							? t("runtime:dialogs.resetOneDescription", {
-									key: confirm.key.toUpperCase(),
-								})
-							: confirm?.type === "install"
-								? t("runtime:dialogs.installDescription", {
-										key: confirm.key.toUpperCase(),
-									})
-								: t("runtime:capabilities.resetConfirmDesc", {
-										defaultValue:
-											"This clears both memory and on-disk capability cache. It will be repopulated on next access.",
-									})
-				}
-				confirmLabel={
-					confirm?.type === "install"
-						? t("runtime:dialogs.installRepair")
-						: t("runtime:dialogs.confirm")
-				}
-				cancelLabel={t("runtime:dialogs.cancel")}
-				variant={confirm?.type === "install" ? "default" : "destructive"}
-				isLoading={
-					confirm?.type === "resetAll"
-						? resetAllM.isPending
-						: confirm?.type === "resetOne"
-							? resetOneM.isPending
-							: confirm?.type === "install"
-								? installM.isPending
-								: confirm?.type === "capabilitiesReset"
-									? capResetM.isPending
-									: false
-				}
-			/>
+				<ConfirmDialog
+					isOpen={confirm !== null}
+					onClose={() => setConfirm(null)}
+					onConfirm={async () => {
+						if (!confirm) return;
+						if (confirm.type === "resetAll") {
+							resetAllM.mutate();
+						} else if (confirm.type === "resetOne") {
+							resetOneM.mutate(confirm.key);
+						} else if (confirm.type === "install") {
+							installM.mutate(confirm.key);
+						} else if (confirm.type === "capabilitiesReset") {
+							capResetM.mutate();
+						}
+					}}
+					title={confirmTitle}
+					description={confirmDescription}
+					confirmLabel={confirmLabel}
+					cancelLabel={t("runtime:dialogs.cancel")}
+					variant={confirmVariant}
+					isLoading={confirmLoading}
+				/>
 		</div>
 	);
 }

--- a/scripts/dev-all
+++ b/scripts/dev-all
@@ -16,12 +16,47 @@ fi
 
 require_command cargo
 require_command bun
+require_command lsof
+
+report_port_conflict() {
+  local port="$1"
+  local name="$2"
+  local expected_dir="$3"
+  local pid cwd command scope
+
+  pid="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -n 1 || true)"
+  if [[ -z "$pid" ]]; then
+    return 0
+  fi
+
+  cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
+  command="$(ps -p "$pid" -o command= 2>/dev/null | sed -e 's/^[[:space:]]*//')"
+
+  if [[ -n "$cwd" && "$cwd" == "$expected_dir"* ]]; then
+    scope="this worktree"
+  else
+    scope="another worktree or project"
+  fi
+
+  printf 'Port %s for %s is already in use by PID %s (%s).\n' "$port" "$name" "$pid" "$scope" >&2
+  if [[ -n "$cwd" ]]; then
+    printf 'Working directory: %s\n' "$cwd" >&2
+  fi
+  if [[ -n "$command" ]]; then
+    printf 'Command: %s\n' "$command" >&2
+  fi
+  printf 'Stop the existing process before running ./scripts/dev-all in %s.\n' "$ROOT_DIR" >&2
+  exit 1
+}
 
 cleanup() {
   jobs -p | xargs -r kill >/dev/null 2>&1 || true
 }
 
 trap cleanup EXIT INT TERM
+
+report_port_conflict 8080 backend "$(project_dir backend)"
+report_port_conflict 5173 board "$(project_dir board)"
 
 print_section "backend"
 (cd "$(project_dir backend)" && cargo run --) &


### PR DESCRIPTION
## Summary

- Add Node.js as a first-class managed runtime alongside uv and Bun
- Introduce `RuntimeType::from_command()` for semantic command-to-runtime mapping (npx/npm → Node)
- Add `create_node_environment()` with `NPM_CONFIG_CACHE` path management
- Refactor runtime installer to support versioned Node downloads and repair/reinstall
- Replace manual `match` dispatch with `RuntimeType` enum iteration in status/cache listing
- Guard dev-all script with port conflict detection

## Changes

| Area | Changes |
|------|--------|
| Backend runtime | New `RuntimeType::Node` variant, installer versioning, semantic command matching via `from_command()` |
| Backend environment | `create_node_environment()`, `NPM_CONFIG_CACHE` const, Node-specific cache paths |
| Config | `prepare_command_env_with_db` uses `RuntimeType::from_command` + `get_command_path` for uniform handling of all runtimes |
| Board | Runtime page shows Node.js status, cache, install; `runtimeApi.install`/`resetCache` handle `"node"` cache type |
| Scripts | `dev-all` port conflict detection via `lsof` |

## Test plan

- [x] `cargo check --manifest-path backend/Cargo.toml`
- [x] `cargo test --manifest-path backend/Cargo.toml`
- [x] `bun run --cwd board build`
- [x] `./scripts/dev-all` — all 9 MCP servers prewarmed, no errors (6 servers use npx → Node.js path)
- [x] `./scripts/dev-desktop` — desktop integration passes
