### PR TITLE
fix(release): harden cross-platform desktop release flow

### DIFF
--- a/.github/actions/collect-updater/action.yml
+++ b/.github/actions/collect-updater/action.yml
@@ -40,67 +40,44 @@ runs:
         echo "Bundle dir: $BUNDLE_DIR"
         echo "Output dir: $OUTPUT_DIR"
 
+        collect_bundle_and_signature() {
+          local bundle="$1"
+          local base
+          base="$(basename "$bundle")"
+
+          cp "$bundle" "$OUTPUT_DIR/"
+          has_updater=true
+          echo "Collected: $base"
+
+          if [[ -f "${bundle}.sig" ]]; then
+            cp "${bundle}.sig" "$OUTPUT_DIR/"
+            echo "Collected: ${base}.sig"
+          fi
+        }
+
         case "$PLATFORM" in
           macos)
-            # Collect .app.tar.gz bundles
-            for bundle in "$BUNDLE_DIR/dmg"/*.app.tar.gz "$BUNDLE_DIR"/*.app.tar.gz; do
-              test -f "$bundle" || continue
-              cp "$bundle" "$OUTPUT_DIR/"
-              has_updater=true
-              echo "Collected: $(basename "$bundle")"
-              # Collect signature if exists
-              if [[ -f "${bundle}.sig" ]]; then
-                cp "${bundle}.sig" "$OUTPUT_DIR/"
-                echo "Collected: $(basename "$bundle").sig"
-              fi
-            done
+            while IFS= read -r -d '' bundle; do
+              collect_bundle_and_signature "$bundle"
+            done < <(find "$BUNDLE_DIR" -type f -name "*.app.tar.gz" -print0 2>/dev/null)
             ;;
 
           linux)
-            # Collect .AppImage bundles (updater format)
-            for bundle in "$BUNDLE_DIR/appimage"/*.AppImage "$BUNDLE_DIR"/*.AppImage; do
-              test -f "$bundle" || continue
-              cp "$bundle" "$OUTPUT_DIR/"
-              has_updater=true
-              echo "Collected: $(basename "$bundle")"
-              # Collect signature if exists
-              if [[ -f "${bundle}.sig" ]]; then
-                cp "${bundle}.sig" "$OUTPUT_DIR/"
-                echo "Collected: $(basename "$bundle").sig"
-              fi
-            done
+            while IFS= read -r -d '' bundle; do
+              collect_bundle_and_signature "$bundle"
+            done < <(find "$BUNDLE_DIR" -type f -name "*.AppImage" -print0 2>/dev/null)
             ;;
 
           windows)
-            # Collect .nsis.zip bundles + signatures
-            for bundle in "$BUNDLE_DIR/nsis"/*.nsis.zip "$BUNDLE_DIR"/*.nsis.zip; do
-              test -f "$bundle" || continue
-              cp "$bundle" "$OUTPUT_DIR/"
-              has_updater=true
-              echo "Collected: $(basename "$bundle")"
-              if [[ -f "${bundle}.sig" ]]; then
-                cp "${bundle}.sig" "$OUTPUT_DIR/"
-                echo "Collected: $(basename "$bundle").sig"
-              fi
-            done
-            # Collect .msi.zip bundles + signatures (MSI updater format)
-            for bundle in "$BUNDLE_DIR/msi"/*.msi.zip "$BUNDLE_DIR"/*.msi.zip; do
-              test -f "$bundle" || continue
-              cp "$bundle" "$OUTPUT_DIR/"
-              has_updater=true
-              echo "Collected: $(basename "$bundle")"
-              if [[ -f "${bundle}.sig" ]]; then
-                cp "${bundle}.sig" "$OUTPUT_DIR/"
-                echo "Collected: $(basename "$bundle").sig"
-              fi
-            done
-            # Collect standalone .msi.sig files (direct MSI signatures)
-            for sig in "$BUNDLE_DIR/msi"/*.msi.sig "$BUNDLE_DIR"/*.msi.sig; do
-              test -f "$sig" || continue
+            while IFS= read -r -d '' bundle; do
+              collect_bundle_and_signature "$bundle"
+            done < <(find "$BUNDLE_DIR" -type f \( -name "*.nsis.zip" -o -name "*.msi.zip" \) -print0 2>/dev/null)
+
+            while IFS= read -r -d '' sig; do
               cp "$sig" "$OUTPUT_DIR/"
               has_updater=true
               echo "Collected: $(basename "$sig")"
-            done
+            done < <(find "$BUNDLE_DIR" -type f -name "*.msi.sig" -print0 2>/dev/null)
             ;;
 
           *)

--- a/.github/actions/collect-updater/action.yml
+++ b/.github/actions/collect-updater/action.yml
@@ -63,9 +63,11 @@ runs:
             ;;
 
           linux)
-            while IFS= read -r -d '' bundle; do
-              collect_bundle_and_signature "$bundle"
-            done < <(find "$BUNDLE_DIR" -type f -name "*.AppImage" -print0 2>/dev/null)
+            while IFS= read -r -d '' sig; do
+              cp "$sig" "$OUTPUT_DIR/"
+              has_updater=true
+              echo "Collected: $(basename "$sig")"
+            done < <(find "$BUNDLE_DIR" -type f -name "*.AppImage.sig" -print0 2>/dev/null)
             ;;
 
           windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,15 @@ jobs:
             --skip-notarize \
             --output-dir "${GITHUB_WORKSPACE}/installers"
 
+      - name: List macOS bundles (debug)
+        run: |
+          find "desktop/src-tauri/target/${{ matrix.target }}/release/bundle" \
+            -type f \
+            \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.sig" \) \
+            | sort || true
+
       - name: Collect updater artifacts
+        id: collect-updater
         uses: ./.github/actions/collect-updater
         with:
           bundle-dir: "desktop/src-tauri/target/${{ matrix.target }}/release/bundle"
@@ -103,6 +111,8 @@ jobs:
           RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: |
+          shopt -s nullglob
+
           VERSION="${RELEASE_TAG#v}"
           VERSION="${VERSION%%-*}"
           case "$TARGET_ARCH" in
@@ -147,7 +157,7 @@ jobs:
           - arch: x64
             runner: windows-latest
             target: x86_64-pc-windows-msvc
-            experimental: true
+            experimental: false
           - arch: arm64
             runner: windows-11-arm
             target: aarch64-pc-windows-msvc
@@ -184,14 +194,71 @@ jobs:
             --with-updater \
             --output-dir "${GITHUB_WORKSPACE}/installers"
 
+      - name: List Windows bundles (debug)
+        shell: bash
+        run: |
+          find "desktop/src-tauri/target/${{ matrix.target }}/release/bundle" \
+            -type f \
+            \( -name "*.msi" -o -name "*.msi.zip" -o -name "*.nsis.zip" -o -name "*.sig" \) \
+            | sort || true
+
       - name: Collect updater artifacts
+        id: collect-updater
         uses: ./.github/actions/collect-updater
         with:
           bundle-dir: "desktop/src-tauri/target/${{ matrix.target }}/release/bundle"
           output-dir: "${{ github.workspace }}/updater"
           platform: windows
 
+      - name: Validate updater artifacts for stable target
+        shell: bash
+        env:
+          TARGET_ARCH: ${{ matrix.arch }}
+          EXPERIMENTAL_TARGET: ${{ matrix.experimental }}
+          HAS_UPDATER: ${{ steps.collect-updater.outputs.has-updater }}
+        run: |
+          if [[ "$HAS_UPDATER" == "true" ]]; then
+            exit 0
+          fi
+
+          if [[ "$EXPERIMENTAL_TARGET" == "true" ]]; then
+            echo "::warning::No updater artifacts found for experimental Windows ${TARGET_ARCH} target"
+            exit 0
+          fi
+
+          echo "::error::No updater artifacts found for stable Windows ${TARGET_ARCH} target" >&2
+          exit 1
+
+      - name: Collect installer artifacts
+        id: collect-installers
+        shell: bash
+        env:
+          TARGET_TRIPLE: ${{ matrix.target }}
+          TARGET_ARCH: ${{ matrix.arch }}
+          EXPERIMENTAL_TARGET: ${{ matrix.experimental }}
+        run: |
+          mkdir -p installers
+
+          found=false
+          while IFS= read -r -d '' installer; do
+            cp "$installer" installers/
+            found=true
+          done < <(find "desktop/src-tauri/target/${TARGET_TRIPLE}/release/bundle" -type f -name "*.msi" -print0 2>/dev/null)
+
+          echo "has-installers=$found" >> "$GITHUB_OUTPUT"
+
+          if [[ "$found" == "true" ]]; then
+            echo "Collected installer artifacts:"
+            ls -lh installers/
+          elif [[ "$EXPERIMENTAL_TARGET" == "true" ]]; then
+            echo "::warning::No installer artifacts found for experimental Windows ${TARGET_ARCH} target"
+          else
+            echo "::error::No installer artifacts found for Windows ${TARGET_ARCH} target" >&2
+            exit 1
+          fi
+
       - name: Upload installers
+        if: steps.collect-installers.outputs.has-installers == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: installers-windows-${{ matrix.arch }}
@@ -199,11 +266,12 @@ jobs:
           if-no-files-found: error
 
       - name: Upload updater artifacts
+        if: steps.collect-updater.outputs.has-updater == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: updater-windows-${{ matrix.arch }}
           path: updater/*
-          if-no-files-found: warn
+          if-no-files-found: error
 
   build-linux:
     needs: validate-tag
@@ -258,6 +326,13 @@ jobs:
             --with-updater \
             --output-dir "${GITHUB_WORKSPACE}/installers"
 
+      - name: List Linux bundles (debug)
+        run: |
+          find "desktop/src-tauri/target/${{ matrix.target }}/release/bundle" \
+            -type f \
+            \( -name "*.AppImage" -o -name "*.deb" -o -name "*.sig" \) \
+            | sort || true
+
       - name: Collect updater artifacts
         if: contains(matrix.bundles, 'appimage')
         uses: ./.github/actions/collect-updater
@@ -289,20 +364,13 @@ jobs:
     needs: [build-macos, build-windows, build-linux]
     runs-on: ubuntu-22.04
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
       RELEASE_REPO: ${{ github.repository }}
-      DISPATCH_TAG: ${{ github.event.inputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
-
-      - name: Resolve release tag
-        run: |
-          if [[ -n "$DISPATCH_TAG" ]]; then
-            echo "RELEASE_TAG=${DISPATCH_TAG}" >> "$GITHUB_ENV"
-          fi
 
       - name: Download all artifacts
         uses: actions/download-artifact@v6
@@ -341,6 +409,54 @@ jobs:
           rename_pair "MCPMate_${VERSION}_arm64.deb" "MCPMate_${VERSION}_linux_arm64.deb"
 
           find artifacts -type f | sort
+
+      - name: Assert required release assets
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          VERSION="${VERSION%%-*}"
+
+          required_assets=(
+            "MCPMate_${VERSION}_macos_aarch64.dmg"
+            "MCPMate_${VERSION}_macos_x86_64.dmg"
+            "MCPMate_${VERSION}_macos_aarch64.app.tar.gz"
+            "MCPMate_${VERSION}_macos_aarch64.app.tar.gz.sig"
+            "MCPMate_${VERSION}_macos_x86_64.app.tar.gz"
+            "MCPMate_${VERSION}_macos_x86_64.app.tar.gz.sig"
+            "MCPMate_${VERSION}_windows_x64.msi"
+            "MCPMate_${VERSION}_linux_x64.AppImage"
+            "MCPMate_${VERSION}_linux_x64.AppImage.sig"
+            "MCPMate_${VERSION}_linux_x64.deb"
+            "MCPMate_${VERSION}_linux_arm64.AppImage"
+            "MCPMate_${VERSION}_linux_arm64.AppImage.sig"
+            "MCPMate_${VERSION}_linux_arm64.deb"
+          )
+
+          missing=0
+          for asset in "${required_assets[@]}"; do
+            if [[ ! -f "artifacts/${asset}" ]]; then
+              echo "::error::Missing required release asset: ${asset}" >&2
+              missing=1
+            fi
+          done
+
+          if [[ ! -f "artifacts/MCPMate_${VERSION}_windows_x64.msi.sig" && ! -f "artifacts/MCPMate_${VERSION}_windows_x64.msi.zip.sig" ]]; then
+            echo "::error::Missing required release asset: MCPMate_${VERSION}_windows_x64.msi.sig or MCPMate_${VERSION}_windows_x64.msi.zip.sig" >&2
+            missing=1
+          fi
+
+          if [[ ! -f "artifacts/MCPMate_${VERSION}_windows_arm64.msi" ]]; then
+            echo "::warning::Experimental asset not found: MCPMate_${VERSION}_windows_arm64.msi"
+          fi
+
+          if [[ ! -f "artifacts/MCPMate_${VERSION}_windows_arm64.msi.sig" && ! -f "artifacts/MCPMate_${VERSION}_windows_arm64.msi.zip.sig" ]]; then
+            echo "::warning::Experimental asset not found: MCPMate_${VERSION}_windows_arm64.msi.sig or MCPMate_${VERSION}_windows_arm64.msi.zip.sig"
+          fi
+
+          if [[ "$missing" -ne 0 ]]; then
+            exit 1
+          fi
 
       - name: Generate update manifest
         run: |
@@ -453,5 +569,6 @@ jobs:
             artifacts/*.deb
             artifacts/*.app.tar.gz
             artifacts/*.nsis.zip
+            artifacts/*.msi.zip
             artifacts/signatures.zip
             artifacts/update.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,17 +441,35 @@ jobs:
             fi
           done
 
-          if [[ ! -f "artifacts/MCPMate_${VERSION}_windows_x64.msi.sig" && ! -f "artifacts/MCPMate_${VERSION}_windows_x64.msi.zip.sig" ]]; then
+          x64_msi_sig="artifacts/MCPMate_${VERSION}_windows_x64.msi.sig"
+          x64_msi_zip="artifacts/MCPMate_${VERSION}_windows_x64.msi.zip"
+          x64_msi_zip_sig="artifacts/MCPMate_${VERSION}_windows_x64.msi.zip.sig"
+
+          if [[ ! -f "$x64_msi_sig" && ! -f "$x64_msi_zip_sig" ]]; then
             echo "::error::Missing required release asset: MCPMate_${VERSION}_windows_x64.msi.sig or MCPMate_${VERSION}_windows_x64.msi.zip.sig" >&2
             missing=1
           fi
 
-          if [[ ! -f "artifacts/MCPMate_${VERSION}_windows_arm64.msi" ]]; then
+          if [[ -f "$x64_msi_zip_sig" && ! -f "$x64_msi_zip" ]]; then
+            echo "::error::Missing required release asset: MCPMate_${VERSION}_windows_x64.msi.zip" >&2
+            missing=1
+          fi
+
+          arm64_msi="artifacts/MCPMate_${VERSION}_windows_arm64.msi"
+          arm64_msi_zip="artifacts/MCPMate_${VERSION}_windows_arm64.msi.zip"
+          arm64_msi_sig="artifacts/MCPMate_${VERSION}_windows_arm64.msi.sig"
+          arm64_msi_zip_sig="artifacts/MCPMate_${VERSION}_windows_arm64.msi.zip.sig"
+
+          if [[ ! -f "$arm64_msi" ]]; then
             echo "::warning::Experimental asset not found: MCPMate_${VERSION}_windows_arm64.msi"
           fi
 
-          if [[ ! -f "artifacts/MCPMate_${VERSION}_windows_arm64.msi.sig" && ! -f "artifacts/MCPMate_${VERSION}_windows_arm64.msi.zip.sig" ]]; then
+          if [[ ! -f "$arm64_msi_sig" && ! -f "$arm64_msi_zip_sig" ]]; then
             echo "::warning::Experimental asset not found: MCPMate_${VERSION}_windows_arm64.msi.sig or MCPMate_${VERSION}_windows_arm64.msi.zip.sig"
+          fi
+
+          if [[ -f "$arm64_msi_zip_sig" && ! -f "$arm64_msi_zip" ]]; then
+            echo "::warning::Experimental asset not found: MCPMate_${VERSION}_windows_arm64.msi.zip"
           fi
 
           if [[ "$missing" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Switch updater artifact collection to recursive, platform-aware discovery in the shared `collect-updater` action.
- Add build-time artifact listing and stable-vs-experimental validation gates in the release workflow.
- Enforce required release assets before manifest generation and fix workflow-dispatch tag resolution.

## Changes
- Update `.github/actions/collect-updater/action.yml` to centralize bundle/signature collection and support nested bundle paths.
- Update `.github/workflows/release.yml` to:
  - list macOS/Windows/Linux bundle outputs for observability,
  - require updater/installer artifacts for stable Windows x64 while keeping Windows arm64 experimental,
  - assert required cross-platform release assets before publish,
  - use `${{ github.event.inputs.tag || github.ref_name }}` for `RELEASE_TAG` consistency.

## Test plan
- [x] Trigger `Desktop (macOS)` on `hotfix/release-workflow-cross-platform-artifacts`.
- [x] Trigger `Desktop (Windows)` on `hotfix/release-workflow-cross-platform-artifacts`.
- [x] Trigger `Desktop (Linux)` on `hotfix/release-workflow-cross-platform-artifacts`.
- [ ] Confirm all three workflows pass with expected artifacts.
- [ ] Confirm old-branch runs are canceled and no longer consuming runners.