### PR TITLE
ci(desktop): expose debug build profile controls

### DIFF
--- a/.github/actions/setup-desktop-build/action.yml
+++ b/.github/actions/setup-desktop-build/action.yml
@@ -17,9 +17,18 @@ runs:
       with:
         targets: ${{ inputs.rust-target }}
 
+    - name: Preflight Rust toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        which cargo
+        cargo -V
+        rustup show active-toolchain
+
     - name: Cache Rust build
       uses: Swatinem/rust-cache@v2
       with:
+        cache-bin: false
         workspaces: |
           backend -> target
           desktop/src-tauri -> target

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -16,6 +16,14 @@ on:
         description: "Tauri bundle types"
         required: false
         default: "appimage,deb"
+      profile:
+        description: "Cargo profile"
+        type: choice
+        required: false
+        default: "debug"
+        options:
+          - debug
+          - release
   push:
     branches:
       - main
@@ -84,19 +92,25 @@ jobs:
       - name: Build Linux desktop artifacts
         env:
           INPUT_BUNDLES: ${{ github.event.inputs.bundles }}
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
           TAURI_BUILD_EXTRA: "--features devtools"
         run: |
           chmod +x packaging/desktop/linux-build-tauri-release.sh
           BUNDLES="${INPUT_BUNDLES:-appimage,deb}"
+          PROFILE="${INPUT_PROFILE:-debug}"
           packaging/desktop/linux-build-tauri-release.sh \
+            --profile "$PROFILE" \
             --target "${{ matrix.arch == 'x64' && 'x86_64-unknown-linux-gnu' || 'aarch64-unknown-linux-gnu' }}" \
             --bundles "${BUNDLES}" \
             --output-dir "${GITHUB_WORKSPACE}/desktop-linux-artifacts/${{ matrix.arch }}"
 
       - name: Smoke test (sidecar arch + bundle format)
+        env:
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
         run: |
           set -euo pipefail
-          BUNDLE_DIR="desktop/src-tauri/target/${{ matrix.arch == 'x64' && 'x86_64-unknown-linux-gnu' || 'aarch64-unknown-linux-gnu' }}/release/bundle"
+          PROFILE="${INPUT_PROFILE:-debug}"
+          BUNDLE_DIR="desktop/src-tauri/target/${{ matrix.arch == 'x64' && 'x86_64-unknown-linux-gnu' || 'aarch64-unknown-linux-gnu' }}/${PROFILE}/bundle"
           echo "--- bundle layout ---"
           find "$BUNDLE_DIR" -type f | head -40 || true
           echo "--- sidecar architecture ---"

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -19,6 +19,14 @@ on:
         description: "Tauri bundle types (dmg only)"
         required: false
         default: "dmg"
+      profile:
+        description: "Cargo profile"
+        type: choice
+        required: false
+        default: "debug"
+        options:
+          - debug
+          - release
   push:
     branches:
       - main
@@ -71,20 +79,26 @@ jobs:
       - name: Build macOS DMG (no sign / no notarize)
         env:
           INPUT_BUNDLES: ${{ github.event.inputs.bundles }}
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
           TAURI_BUILD_EXTRA: "--features devtools"
         run: |
           BUNDLES="${INPUT_BUNDLES:-app,dmg}"
+          PROFILE="${INPUT_PROFILE:-debug}"
           chmod +x packaging/desktop/macos-build-tauri-release.sh
           packaging/desktop/macos-build-tauri-release.sh \
+            --profile "$PROFILE" \
             --target "${{ matrix.arch == 'aarch64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}" \
             --bundles "$BUNDLES" \
             --skip-notarize \
             --output-dir "${GITHUB_WORKSPACE}/desktop-macos-artifacts/${{ matrix.arch }}"
 
       - name: Smoke test (sidecar arch + DMG output)
+        env:
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
         run: |
           set -euo pipefail
-          BUNDLE_ROOT="desktop/src-tauri/target/${{ matrix.arch == 'aarch64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}/release/bundle"
+          PROFILE="${INPUT_PROFILE:-debug}"
+          BUNDLE_ROOT="desktop/src-tauri/target/${{ matrix.arch == 'aarch64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}/${PROFILE}/bundle"
           echo "--- bundle layout ---"
           find "$BUNDLE_ROOT" -type f | head -40 || true
           echo "--- sidecar architecture ---"

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -16,6 +16,14 @@ on:
         description: "Tauri bundle types"
         required: false
         default: "msi"
+      profile:
+        description: "Cargo profile"
+        type: choice
+        required: false
+        default: "debug"
+        options:
+          - debug
+          - release
   push:
     branches:
       - main
@@ -70,19 +78,25 @@ jobs:
         shell: bash
         env:
           INPUT_BUNDLES: ${{ github.event.inputs.bundles }}
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
           TAURI_BUILD_EXTRA: "--features devtools"
         run: |
           chmod +x packaging/desktop/windows-build-tauri-release.sh
+          PROFILE="${INPUT_PROFILE:-debug}"
           bash packaging/desktop/windows-build-tauri-release.sh \
+            --profile "$PROFILE" \
             --target "${{ matrix.arch == 'x64' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}" \
             --bundles "${INPUT_BUNDLES:-msi}" \
             --output-dir "${GITHUB_WORKSPACE}/desktop-windows-artifacts/${{ matrix.arch }}"
 
       - name: Smoke test (sidecar arch + MSI format)
         shell: bash
+        env:
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
         run: |
           set -euo pipefail
-          BUNDLE_DIR="desktop/src-tauri/target/${{ matrix.arch == 'x64' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}/release/bundle"
+          PROFILE="${INPUT_PROFILE:-debug}"
+          BUNDLE_DIR="desktop/src-tauri/target/${{ matrix.arch == 'x64' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}/${PROFILE}/bundle"
           echo "--- bundle layout ---"
           find "$BUNDLE_DIR" -type f 2>/dev/null | head -40 || true
           echo "--- sidecar architecture ---"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           chmod +x packaging/desktop/macos-build-tauri-release.sh
           packaging/desktop/macos-build-tauri-release.sh \
+            --profile release \
             --target "${{ matrix.target }}" \
             --bundles app,dmg \
             --with-updater \
@@ -189,6 +190,7 @@ jobs:
         run: |
           chmod +x packaging/desktop/windows-build-tauri-release.sh
           packaging/desktop/windows-build-tauri-release.sh \
+            --profile release \
             --target "${{ matrix.target }}" \
             --bundles msi \
             --with-updater \
@@ -321,6 +323,7 @@ jobs:
         run: |
           chmod +x packaging/desktop/linux-build-tauri-release.sh
           packaging/desktop/linux-build-tauri-release.sh \
+            --profile release \
             --target "${{ matrix.target }}" \
             --bundles "${{ matrix.bundles }}" \
             --with-updater \


### PR DESCRIPTION
## Summary
- add workflow_dispatch build profile controls to Desktop workflows
- default Desktop CI builds to debug profile for richer runtime diagnostics
- keep release workflow gated to release profile so debug logs do not leak into release artifacts

## Validation
- local branch rebased to latest main with a single commit delta
- checked changed workflow files and branch diff scope
- CI will validate cross-platform workflow behavior on PR