### PR TITLE
fix(board): prioritize tauri oauth callback

### DIFF
--- a/board/src/lib/oauth-callback-access.ts
+++ b/board/src/lib/oauth-callback-access.ts
@@ -49,7 +49,7 @@ export function getOAuthRedirectUriForForm(storedRedirectUri?: string | null): s
 export async function resolveOAuthCallbackAccess(
 	serverId: string,
 ): Promise<OAuthCallbackAccessContract> {
-	if (isHttpCallbackSurface() || !isTauriEnvironmentSync()) {
+	if (!isTauriEnvironmentSync() && isHttpCallbackSurface()) {
 		return {
 			kind: "web",
 			redirect_uri: buildWebOAuthRedirectUri(),


### PR DESCRIPTION
## Summary
- Prioritize Tauri desktop callback access before web callback routing.
- Keep MCP server OAuth on loopback HTTP instead of custom URL scheme.
- Prevent Windows `http://tauri.localhost` from becoming the OAuth redirect URI.

## Validation
- Verified MCP server OAuth on macOS.
- Verified MCP server OAuth on Linux.
- Verified MCP server OAuth on Windows.
- Ran `bunx eslint src/lib/oauth-callback-access.ts`.

Closes #57