### PR TITLE
feat(import): mark managed servers in preview

### DIFF
--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -3,8 +3,8 @@
 use super::backups::parse_policy_payload;
 use super::inspection::{
     build_config_file_parse_inspect_data, build_parse_metadata, configured_server_entries_data,
-    derive_attachment_state, detect_mcpmate_in_client_config, inspect_client_config_lenient, parse_api_transports,
-    parse_rule_from_api_data, transports_data_from_state,
+    derive_attachment_state, detect_mcpmate_in_client_config, inspect_client_config_lenient,
+    mark_configured_server_managed_status, parse_api_transports, parse_rule_from_api_data, transports_data_from_state,
 };
 use super::runtime::sync_bound_client_runtime_state;
 use crate::api::models::client::{
@@ -291,10 +291,22 @@ pub async fn config_details(
             fallback_parsed_config_content(content.as_deref(), state.config_format(), config_path.as_deref())
         });
 
-    let (configured_servers_analysis, configured_server_entries) = inspected_config
+    let (configured_servers_analysis, mut configured_server_entries) = inspected_config
         .as_ref()
         .map(configured_server_entries_data)
         .unwrap_or_default();
+    if let Some(database) = app_state.database.as_ref() {
+        mark_configured_server_managed_status(&database.pool, &mut configured_server_entries)
+            .await
+            .map_err(|err| {
+                tracing::error!(
+                    client = %request.identifier,
+                    error = %err,
+                    "Failed to annotate configured server managed status"
+                );
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
 
     let last_modified = config_path.as_deref().and_then(get_config_last_modified);
 
@@ -3140,6 +3152,73 @@ mod tests {
         assert_eq!(details.configured_server_entries[1].import_status, "importable");
         assert_eq!(details.configured_server_entries[1].skip_reason, None);
         assert_eq!(details.mcp_servers_count, 2);
+    }
+
+    #[tokio::test]
+    async fn config_details_marks_managed_entries_by_fingerprint() {
+        let context = create_test_context().await;
+        let config_path = context._temp_dir.path().join("already-imported.json");
+        tokio::fs::write(
+            &config_path,
+            r#"{
+                "mcpServers": {
+                    "mcp-server-context7": {"url": "https://context7.com/mcp"}
+                }
+            }"#,
+        )
+        .await
+        .expect("seed client config file");
+
+        sqlx::query(&format!(
+            "INSERT INTO {} (id, name, server_type, url) VALUES (?, ?, ?, ?)",
+            crate::common::constants::database::tables::SERVER_CONFIG
+        ))
+        .bind("existing-context7")
+        .bind("mcp-server-context7")
+        .bind("streamable_http")
+        .bind("https://context7.com/mcp")
+        .execute(&context.db_pool)
+        .await
+        .expect("insert existing server");
+
+        let Json(update_response) = update_settings(
+            State(context.app_state.clone()),
+            Json(ClientSettingsUpdateReq {
+                config_mode: Some("hosted".to_string()),
+                transport: Some("stdio".to_string()),
+                display_name: Some("Already Imported Client".to_string()),
+                connection_mode: Some("local_config_detected".to_string()),
+                config_path: Some(config_path.to_string_lossy().to_string()),
+                config_file_parse: Some(json_object_parse("mcpServers")),
+                transports: Some(HashMap::from([(
+                    "streamable_http".to_string(),
+                    selected_streamable_http_rule(),
+                )])),
+                ..settings_update_req("already.imported.client")
+            }),
+        )
+        .await
+        .expect("update client settings");
+
+        assert!(update_response.success);
+
+        let Json(details_response) = config_details(
+            State(context.app_state.clone()),
+            Query(ClientConfigReq {
+                identifier: "already.imported.client".to_string(),
+            }),
+        )
+        .await
+        .expect("load client details");
+
+        assert!(details_response.success);
+        let details = details_response.data.expect("details data");
+        assert_eq!(details.configured_server_entries.len(), 1);
+        let entry = &details.configured_server_entries[0];
+        assert_eq!(entry.name, "mcp-server-context7");
+        assert_eq!(entry.import_status, "importable");
+        assert_eq!(entry.skip_reason, None);
+        assert!(entry.managed_by_mcpmate);
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/client/inspection.rs
+++ b/backend/src/api/handlers/client/inspection.rs
@@ -9,6 +9,7 @@ use crate::clients::models::{
 };
 use crate::clients::service::core::ClientStateRow;
 use crate::clients::service::rules::ConfigRuleInspection;
+use crate::config::server::import::{ImportOptions, build_import_plan_from_entries, find_import_conflicts};
 use std::collections::HashMap;
 
 fn parse_data_from_rule(rule: &ClientConfigFileParse) -> ClientConfigFileParseData {
@@ -102,6 +103,30 @@ pub(super) fn configured_server_entries_data(
         .map(ServerEntryData::from)
         .collect::<Vec<_>>();
     (report.analysis.clone(), entries)
+}
+
+pub(super) async fn mark_configured_server_managed_status(
+    db_pool: &sqlx::SqlitePool,
+    entries: &mut [ServerEntryData],
+) -> anyhow::Result<()> {
+    let plan = build_import_plan_from_entries(entries.iter().cloned().map(Into::into));
+    let conflicts = find_import_conflicts(
+        db_pool,
+        &plan.items,
+        &ImportOptions {
+            by_name: false,
+            ..ImportOptions::dashboard_import(true, None)
+        },
+    )
+    .await?;
+
+    for entry in entries {
+        entry.managed_by_mcpmate = conflicts
+            .get(&entry.name)
+            .is_some_and(|reason| reason.is_duplicate_fingerprint());
+    }
+
+    Ok(())
 }
 
 pub(crate) fn parse_rule_from_api_data(parse: &ClientConfigFileParseData) -> ClientConfigFileParse {

--- a/backend/src/api/models/client.rs
+++ b/backend/src/api/models/client.rs
@@ -484,6 +484,9 @@ pub struct ServerEntryData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Inspection issue code for malformed config entries")]
     pub issue: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Whether this entry is already managed by MCPMate")]
+    pub managed_by_mcpmate: bool,
     #[schemars(description = "Command to execute the server (stdio only)")]
     pub command: Option<String>,
     #[schemars(description = "Command line arguments (stdio only)")]
@@ -510,6 +513,7 @@ impl From<InspectedServerEntry> for ServerEntryData {
             import_status,
             skip_reason,
             issue: entry.issue,
+            managed_by_mcpmate: false,
             command: entry.command,
             args: entry.args,
             env: entry.env,

--- a/backend/src/api/models/server.rs
+++ b/backend/src/api/models/server.rs
@@ -904,16 +904,11 @@ pub struct SkippedServerData {
 impl From<SkippedServer> for SkippedServerData {
     fn from(source: SkippedServer) -> Self {
         let (reason, existing_query, incoming_query) = match source.reason {
-            SkipReason::DuplicateName => ("duplicate_name".to_string(), None, None),
-            SkipReason::DuplicateFingerprint => ("duplicate_fingerprint".to_string(), None, None),
-            SkipReason::ConfigInvalidEntry => ("config_invalid_entry".to_string(), None, None),
-            SkipReason::ConfigMissingCommand => ("config_missing_command".to_string(), None, None),
-            SkipReason::ConfigMissingUrl => ("config_missing_url".to_string(), None, None),
-            SkipReason::ConfigUnrecognized => ("config_unrecognized".to_string(), None, None),
             SkipReason::UrlQueryMismatch {
                 existing_query,
                 incoming_query,
             } => ("url_query_mismatch".to_string(), existing_query, incoming_query),
+            reason => (reason.code().to_string(), None, None),
         };
 
         Self {

--- a/backend/src/config/server/import.rs
+++ b/backend/src/config/server/import.rs
@@ -117,6 +117,24 @@ impl From<ConfigImportSkipReason> for SkipReason {
     }
 }
 
+impl SkipReason {
+    pub(crate) fn code(&self) -> &'static str {
+        match self {
+            Self::DuplicateName => "duplicate_name",
+            Self::DuplicateFingerprint => "duplicate_fingerprint",
+            Self::ConfigInvalidEntry => "config_invalid_entry",
+            Self::ConfigMissingCommand => "config_missing_command",
+            Self::ConfigMissingUrl => "config_missing_url",
+            Self::ConfigUnrecognized => "config_unrecognized",
+            Self::UrlQueryMismatch { .. } => "url_query_mismatch",
+        }
+    }
+
+    pub(crate) fn is_duplicate_fingerprint(&self) -> bool {
+        matches!(self, Self::DuplicateFingerprint)
+    }
+}
+
 pub struct ClientImportPlan {
     pub items: HashMap<String, ServersImportConfig>,
     pub skipped_servers: Vec<SkippedServer>,
@@ -142,6 +160,92 @@ fn record_conflict(
         }
         ConflictPolicy::Update => false,
     }
+}
+
+struct ImportCandidate {
+    server_type: ServerType,
+    persisted_kind: &'static str,
+    fingerprint: String,
+    url_signature: Option<fingerprint::UrlSignature>,
+}
+
+fn prepare_import_candidate(cfg: &ServersImportConfig) -> Result<ImportCandidate> {
+    let lc = cfg.kind.trim().to_ascii_lowercase();
+    let server_type = ServerType::from_client_format(&lc)
+        .map_err(|_| anyhow::anyhow!(format!("Invalid server type '{}'", cfg.kind)))?;
+    let persisted_kind = server_type.client_format();
+    validate_server_config(persisted_kind, &cfg.command, &cfg.url).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    let mut url_signature: Option<fingerprint::UrlSignature> = None;
+    let fp = match server_type {
+        ServerType::Stdio => fingerprint::fingerprint_for_stdio(
+            cfg.command.as_deref().unwrap_or_default(),
+            cfg.args.as_deref().unwrap_or(&[]),
+        ),
+        ServerType::Sse | ServerType::StreamableHttp => {
+            let sig = fingerprint::url_signature(cfg.url.as_deref().unwrap_or_default());
+            let key = format!("{}|{}", sig.fingerprint, persisted_kind);
+            url_signature = Some(sig);
+            key
+        }
+    };
+
+    Ok(ImportCandidate {
+        server_type,
+        persisted_kind,
+        fingerprint: fp,
+        url_signature,
+    })
+}
+
+fn import_conflict_reason(
+    existing: &ExistingIndex,
+    name: &str,
+    candidate: &ImportCandidate,
+    opts: &ImportOptions,
+) -> Option<SkipReason> {
+    if opts.by_fingerprint
+        && !candidate.fingerprint.is_empty()
+        && existing.fingerprints.contains(&candidate.fingerprint)
+    {
+        return Some(SkipReason::DuplicateFingerprint);
+    }
+
+    if opts.by_fingerprint {
+        if let Some(sig) = candidate.url_signature.as_ref() {
+            if existing.url_bases.contains(&sig.base) {
+                let existing_sig = existing.url_signatures.get(&sig.base);
+                return Some(SkipReason::UrlQueryMismatch {
+                    existing_query: existing_sig.and_then(|s| s.display_query()),
+                    incoming_query: sig.display_query(),
+                });
+            }
+        }
+    }
+
+    if opts.by_name && existing.names.contains(name) {
+        return Some(SkipReason::DuplicateName);
+    }
+
+    None
+}
+
+pub(crate) async fn find_import_conflicts(
+    db_pool: &Pool<Sqlite>,
+    items: &HashMap<String, ServersImportConfig>,
+    opts: &ImportOptions,
+) -> Result<HashMap<String, SkipReason>> {
+    let existing = ExistingIndex::build(db_pool).await?;
+    let mut conflicts = HashMap::new();
+
+    for (name, cfg) in items {
+        let candidate = prepare_import_candidate(cfg)?;
+        if let Some(reason) = import_conflict_reason(&existing, name, &candidate, opts) {
+            conflicts.insert(name.clone(), reason);
+        }
+    }
+
+    Ok(conflicts)
 }
 
 fn build_imported_server(
@@ -287,63 +391,11 @@ pub async fn import_batch(
     let existing = ExistingIndex::build(db_pool).await?;
 
     for (name, cfg) in items.into_iter() {
-        let lc = cfg.kind.trim().to_ascii_lowercase();
-        let server_type = ServerType::from_client_format(&lc)
-            .map_err(|_| anyhow::anyhow!(format!("Invalid server type '{}'", cfg.kind)))?;
-        let persisted_kind = server_type.client_format();
-        validate_server_config(persisted_kind, &cfg.command, &cfg.url).map_err(|e| anyhow::anyhow!(e.to_string()))?;
-
-        // Compute fingerprint
-        let mut url_signature: Option<fingerprint::UrlSignature> = None;
-        let fp = match server_type {
-            ServerType::Stdio => fingerprint::fingerprint_for_stdio(
-                cfg.command.as_deref().unwrap_or_default(),
-                cfg.args.as_deref().unwrap_or(&[]),
-            ),
-            ServerType::Sse | ServerType::StreamableHttp => {
-                let sig = fingerprint::url_signature(cfg.url.as_deref().unwrap_or_default());
-                let key = format!("{}|{}", sig.fingerprint, persisted_kind);
-                url_signature = Some(sig);
-                key
+        let candidate = prepare_import_candidate(&cfg)?;
+        if let Some(reason) = import_conflict_reason(&existing, &name, &candidate, &opts) {
+            if record_conflict(&mut outcome, &name, reason, opts.conflict_policy) {
+                continue;
             }
-        };
-
-        // Dedup
-        let by_name_dup = opts.by_name && existing.names.contains(&name);
-        let by_fp_dup = opts.by_fingerprint && !fp.is_empty() && existing.fingerprints.contains(&fp);
-
-        if by_fp_dup
-            && record_conflict(
-                &mut outcome,
-                &name,
-                SkipReason::DuplicateFingerprint,
-                opts.conflict_policy,
-            )
-        {
-            continue;
-        }
-
-        if opts.by_fingerprint && !by_fp_dup {
-            if let Some(sig) = url_signature.as_ref() {
-                if existing.url_bases.contains(&sig.base) {
-                    let existing_sig = existing.url_signatures.get(&sig.base);
-                    if record_conflict(
-                        &mut outcome,
-                        &name,
-                        SkipReason::UrlQueryMismatch {
-                            existing_query: existing_sig.and_then(|s| s.display_query()),
-                            incoming_query: sig.display_query(),
-                        },
-                        opts.conflict_policy,
-                    ) {
-                        continue;
-                    }
-                }
-            }
-        }
-
-        if by_name_dup && record_conflict(&mut outcome, &name, SkipReason::DuplicateName, opts.conflict_policy) {
-            continue;
         }
 
         // Normalize args/env once for both preview and apply.
@@ -354,14 +406,18 @@ pub async fn import_batch(
 
         // Preview: report would-be imported without DB side-effects
         if opts.preview {
-            outcome
-                .imported
-                .push(build_imported_server(name, &cfg, args_norm, env_norm, persisted_kind));
+            outcome.imported.push(build_imported_server(
+                name,
+                &cfg,
+                args_norm,
+                env_norm,
+                candidate.persisted_kind,
+            ));
             continue;
         }
 
         // Apply: upsert server, args, env, headers
-        let mut server = match server_type {
+        let mut server = match candidate.server_type {
             ServerType::Stdio => Server::new_stdio(name.clone(), cfg.command.clone()),
             ServerType::Sse => Server::new_sse(name.clone(), cfg.url.clone()),
             ServerType::StreamableHttp => Server::new_streamable_http(name.clone(), cfg.url.clone()),
@@ -500,7 +556,7 @@ pub async fn import_batch(
             &cfg,
             args_norm,
             env_norm,
-            server_type.client_format(),
+            candidate.persisted_kind,
         ));
     }
 

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -1073,6 +1073,7 @@ export interface ServerEntryData {
   import_status?: "importable" | "skipped" | string;
   skip_reason?: string | null;
   issue?: string | null;
+  managed_by_mcpmate?: boolean;
   command?: string | null;
   args: string[];
   env: Record<string, string>;

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -107,6 +107,7 @@ import { formatBackupTime } from "../../lib/utils";
 import { ClientImportReviewDrawer } from "./components/client-import-review-drawer";
 import { ConfigurationProfileTokenChart } from "./components/configuration-profile-token-chart";
 import { ServerEntryTransportBadge } from "./components/server-entry-transport-badge";
+import { formatTransportTag } from "./transport-labels";
 
 type UnifyRouteMode = "broker_only" | "server_level" | "capability_level";
 type DirectExposureRouteMode = Extract<
@@ -2005,10 +2006,10 @@ export function ClientDetailPage() {
                               (transport) => (
                                 <span
                                   key={transport}
-                                  className="inline-flex items-center rounded-full bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+                                  className="inline-flex items-center rounded-full bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-[10px] font-medium tracking-wide"
                                   title={transport}
                                 >
-                                  {transport}
+                                  {formatTransportTag(transport)}
                                 </span>
                               ),
                             )}

--- a/board/src/pages/clients/components/client-import-review-drawer.tsx
+++ b/board/src/pages/clients/components/client-import-review-drawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "../../../components/ui/button";
@@ -14,6 +15,30 @@ import type { ServerEntryData } from "../../../lib/types";
 import { ServerEntryTransportBadge } from "./server-entry-transport-badge";
 
 const REDACTED_VALUE = "[REDACTED]";
+const AVAILABILITY_CLASS_NAMES = {
+  importable:
+    "rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300",
+  managed:
+    "rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300",
+  notImportable:
+    "rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",
+} as const;
+const AVAILABILITY_LABELS = {
+  importable: {
+    defaultValue: "Importable",
+    key: "detail.importReview.fields.importable",
+  },
+  managed: {
+    defaultValue: "Managed",
+    key: "detail.importReview.fields.managedByMcpmate",
+  },
+  notImportable: {
+    defaultValue: "Not Importable",
+    key: "detail.importReview.fields.notImportable",
+  },
+} as const;
+
+type EntryAvailability = keyof typeof AVAILABILITY_CLASS_NAMES;
 
 interface ImportPreviewEntry {
   args: string[];
@@ -21,6 +46,7 @@ interface ImportPreviewEntry {
   env: Record<string, string>;
   headers: Record<string, string>;
   import_status?: string;
+  managed_by_mcpmate?: boolean;
   issue?: string | null;
   name: string;
   skip_reason?: string | null;
@@ -36,19 +62,41 @@ interface SkippedServerPreview {
 interface ImportPreviewSnapshot {
   entries: ImportPreviewEntry[];
   summary: {
+    detectedCount: number;
     failedCount: number;
     importableCount: number;
+    managedCount: number;
     skippedCount: number;
     skippedServers: SkippedServerPreview[];
   };
 }
 
 function isImportableEntry(entry: ServerEntryData): boolean {
-  return entry.import_status === "importable";
+  return (
+    entry.import_status === "importable" && entry.managed_by_mcpmate !== true
+  );
 }
 
 function isSkippedEntry(entry: ServerEntryData): boolean {
   return entry.import_status === "skipped";
+}
+
+function getEntryAvailability(entry: ServerEntryData): EntryAvailability {
+  if (entry.managed_by_mcpmate === true) {
+    return "managed";
+  }
+  if (isImportableEntry(entry)) {
+    return "importable";
+  }
+  return "notImportable";
+}
+
+function getAvailabilityLabel(
+  t: TFunction<"clients">,
+  availability: EntryAvailability,
+): string {
+  const label = AVAILABILITY_LABELS[availability];
+  return t(label.key, { defaultValue: label.defaultValue });
 }
 
 function redactSecrets(values: Record<string, string>): Record<string, string> {
@@ -62,6 +110,7 @@ function buildPreviewEntry(entry: ServerEntryData): ImportPreviewEntry {
     name: entry.name,
     transport: entry.transport,
     import_status: entry.import_status,
+    managed_by_mcpmate: entry.managed_by_mcpmate,
     skip_reason: entry.skip_reason,
     issue: entry.issue,
     command: entry.command,
@@ -87,6 +136,9 @@ interface ImportPreviewModel {
 }
 
 function buildImportPreviewModel(entries: ServerEntryData[]): ImportPreviewModel {
+  const managedCount = entries.filter(
+    (entry) => entry.managed_by_mcpmate === true,
+  ).length;
   const skippedServers = entries
     .filter(isSkippedEntry)
     .map(buildSkippedServerPreview);
@@ -99,8 +151,10 @@ function buildImportPreviewModel(entries: ServerEntryData[]): ImportPreviewModel
     snapshot: {
       entries: entries.map(buildPreviewEntry),
       summary: {
+        detectedCount: entries.length,
         failedCount: 0,
         importableCount: importableNames.length,
+        managedCount,
         skippedCount: skippedServers.length,
         skippedServers,
       },
@@ -130,7 +184,12 @@ export function ClientImportReviewDrawer({
     () => buildImportPreviewModel(entries),
     [entries],
   );
-  const { importableCount, skippedCount } = importPreviewSnapshot.summary;
+  const {
+    detectedCount,
+    importableCount,
+    managedCount,
+    skippedCount,
+  } = importPreviewSnapshot.summary;
   const importableKey = importableNames.join("\u0000");
   const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
   const selectedImportableCount = selectedNames.size;
@@ -182,8 +241,13 @@ export function ClientImportReviewDrawer({
                   </div>
                   <ul className="divide-y max-h-[30vh] overflow-auto">
                     {entries.map((entry) => {
-                      const importable = isImportableEntry(entry);
+                      const availability = getEntryAvailability(entry);
+                      const importable = availability === "importable";
                       const selected = selectedNames.has(entry.name);
+                      const availabilityLabel = getAvailabilityLabel(
+                        t,
+                        availability,
+                      );
                       return (
                         <li
                           key={entry.name}
@@ -201,7 +265,12 @@ export function ClientImportReviewDrawer({
                               {entry.name}
                             </span>
                           </label>
-                          <ServerEntryTransportBadge entry={entry} />
+                          <div className="flex shrink-0 items-center gap-2">
+                            <ServerEntryTransportBadge entry={entry} />
+                            <span className={AVAILABILITY_CLASS_NAMES[availability]}>
+                              {availabilityLabel}
+                            </span>
+                          </div>
                         </li>
                       );
                     })}
@@ -216,11 +285,23 @@ export function ClientImportReviewDrawer({
                 </div>
                 <div>{selectedImportableCount}</div>
                 <div className="text-slate-500">
+                  {t("detail.importReview.fields.detected", {
+                    defaultValue: "Detected",
+                  })}
+                </div>
+                <div>{detectedCount}</div>
+                <div className="text-slate-500">
                   {t("detail.importReview.fields.importable", {
                     defaultValue: "Importable",
                   })}
                 </div>
                 <div>{importableCount}</div>
+                <div className="text-slate-500">
+                  {t("detail.importReview.fields.managedByMcpmate", {
+                    defaultValue: "Managed",
+                  })}
+                </div>
+                <div>{managedCount}</div>
                 <div className="text-slate-500">
                   {t("detail.importReview.fields.skipped", {
                     defaultValue: "Skipped",

--- a/board/src/pages/clients/components/server-entry-transport-badge.tsx
+++ b/board/src/pages/clients/components/server-entry-transport-badge.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "../../../components/ui/badge";
 import type { ServerEntryData } from "../../../lib/types";
+import { formatTransportTag } from "../transport-labels";
 
 interface ServerEntryTransportBadgeProps {
   entry: ServerEntryData;
@@ -19,7 +20,7 @@ export function ServerEntryTransportBadge({
 
   return (
     <Badge variant={variant} className="text-[10px] px-1.5 py-0">
-      {entry.transport}
+      {formatTransportTag(entry.transport)}
     </Badge>
   );
 }

--- a/board/src/pages/clients/i18n/index.ts
+++ b/board/src/pages/clients/i18n/index.ts
@@ -627,7 +627,11 @@ export const clientsTranslations = {
         title: "Import Review",
         description: "Summary of servers detected from current client config.",
         fields: {
+          detected: "Detected",
           importable: "Importable",
+          managedByMcpmate: "Managed",
+          notImportable: "Not Importable",
+          selected: "Selected",
           skipped: "Skipped",
         },
         sections: {
@@ -1384,7 +1388,11 @@ export const clientsTranslations = {
         title: "导入复核",
         description: "概览当前客户端配置中检测到的服务器。",
         fields: {
+          detected: "已检测",
           importable: "可导入",
+          managedByMcpmate: "已托管",
+          notImportable: "不可导入",
+          selected: "已选择",
           skipped: "已跳过",
         },
         sections: {
@@ -2160,7 +2168,11 @@ export const clientsTranslations = {
         title: "インポート確認",
         description: "現在の設定から検出したサーバーの概要です。",
         fields: {
+          detected: "検出済み",
           importable: "インポート可能",
+          managedByMcpmate: "管理済み",
+          notImportable: "インポート不可",
+          selected: "選択済み",
           skipped: "スキップ",
         },
         sections: {

--- a/board/src/pages/clients/transport-labels.ts
+++ b/board/src/pages/clients/transport-labels.ts
@@ -1,0 +1,11 @@
+export function formatTransportTag(transport: string): string {
+  const parts = transport.split(/[_\s-]+/).filter(Boolean);
+
+  if (!parts.length) {
+    return transport;
+  }
+
+  return parts
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- Expose managed_by_mcpmate on configured server entries using fingerprint conflict detection.
- Mark managed servers in the client detail import review drawer and disable duplicate selection.
- Show detected, importable, managed, and skipped counts with localized labels.

## Validation
- rustfmt --edition 2024 --check backend/src/api/handlers/client/handlers.rs backend/src/api/handlers/client/inspection.rs backend/src/api/models/client.rs backend/src/api/models/server.rs backend/src/config/server/import.rs
- RUSTC_WRAPPER= cargo test config_details_marks_managed_entries_by_fingerprint -- --nocapture
- RUSTC_WRAPPER= cargo clippy --all-targets --all-features -- -D warnings
- BUN_TMPDIR=/private/tmp bun run lint
- BUN_TMPDIR=/private/tmp bun run build
- git diff --check

Refs #51.