### PR TITLE
chore(release): enforce macos notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,93 @@ jobs:
         with:
           release-tag: ${{ github.event.inputs.tag || github.ref_name }}
 
+      - name: Validate macOS signing/notarization secrets
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          test -n "$APPLE_CERTIFICATE_P12_BASE64" || { echo "missing APPLE_CERTIFICATE_P12_BASE64" >&2; exit 1; }
+          test -n "$APPLE_CERTIFICATE_PASSWORD" || { echo "missing APPLE_CERTIFICATE_PASSWORD" >&2; exit 1; }
+          test -n "$KEYCHAIN_PASSWORD" || { echo "missing KEYCHAIN_PASSWORD" >&2; exit 1; }
+          test -n "$APPLE_SIGNING_IDENTITY" || { echo "missing APPLE_SIGNING_IDENTITY" >&2; exit 1; }
+
+          has_api_key=0
+          if [[ -n "$APPLE_API_KEY" && -n "$APPLE_API_ISSUER" && -n "$APPLE_API_PRIVATE_KEY" ]]; then
+            has_api_key=1
+          fi
+
+          has_apple_id=0
+          if [[ -n "$APPLE_ID" && -n "$APPLE_PASSWORD" && -n "$APPLE_TEAM_ID" ]]; then
+            has_apple_id=1
+          fi
+
+          if [[ "$has_api_key" -eq 0 && "$has_apple_id" -eq 0 ]]; then
+            echo "missing notarization credentials: set API key triple or Apple ID triple" >&2
+            exit 1
+          fi
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/mcpmate-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/mcpmate-signing-cert.p12"
+
+          if ! echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_PATH" 2>/dev/null; then
+            echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 -D > "$CERT_PATH"
+          fi
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Prepare notary API key file
+        if: ${{ secrets.APPLE_API_KEY != '' && secrets.APPLE_API_ISSUER != '' && secrets.APPLE_API_PRIVATE_KEY != '' }}
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Build macOS DMG
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         run: |
           chmod +x packaging/desktop/macos-build-tauri-release.sh
           packaging/desktop/macos-build-tauri-release.sh \
@@ -89,8 +172,53 @@ jobs:
             --target "${{ matrix.target }}" \
             --bundles app,dmg \
             --with-updater \
-            --skip-notarize \
             --output-dir "${GITHUB_WORKSPACE}/installers"
+
+      - name: Verify macOS notarization and codesign
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          dmgs=(installers/*.dmg)
+          if [[ ${#dmgs[@]} -eq 0 ]]; then
+            echo "no DMG generated for notarization verification" >&2
+            exit 1
+          fi
+
+          for dmg in "${dmgs[@]}"; do
+            echo "verify stapler for $dmg"
+            xcrun stapler validate "$dmg"
+
+            mount_dir="$RUNNER_TEMP/mcpmate-dmg-mount"
+            mkdir -p "$mount_dir"
+            hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_dir"
+            trap 'hdiutil detach "$mount_dir" -quiet || true' EXIT
+
+            app_path=$(find "$mount_dir" -maxdepth 2 -type d -name "*.app" | head -n 1)
+            if [[ -z "$app_path" ]]; then
+              echo "no .app found inside $dmg" >&2
+              exit 1
+            fi
+
+            echo "verify codesign for $app_path"
+            codesign --verify --deep --strict --verbose=2 "$app_path"
+            spctl --assess --type execute --verbose=4 "$app_path"
+
+            hdiutil detach "$mount_dir" -quiet || true
+            trap - EXIT
+          done
+
+      - name: Cleanup macOS signing materials
+        if: always()
+        run: |
+          set -euo pipefail
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/mcpmate-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/mcpmate-signing-cert.p12"
+
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -f "$CERT_PATH"
+          rm -f "$RUNNER_TEMP"/AuthKey_*.p8
 
       - name: List macOS bundles (debug)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,12 +142,17 @@ jobs:
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
       - name: Prepare notary API key file
-        if: ${{ secrets.APPLE_API_KEY != '' && secrets.APPLE_API_ISSUER != '' && secrets.APPLE_API_PRIVATE_KEY != '' }}
         env:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
         run: |
           set -euo pipefail
+
+          if [[ -z "$APPLE_API_KEY" || -z "$APPLE_API_ISSUER" || -z "$APPLE_API_PRIVATE_KEY" ]]; then
+            echo "App Store Connect API key credentials not configured; using Apple ID notarization credentials."
+            exit 0
+          fi
 
           KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
           printf '%s' "$APPLE_API_PRIVATE_KEY" > "$KEY_PATH"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -80,7 +80,7 @@
 			"endpoints": [
 				"https://github.com/loocor/mcpmate/releases/latest/download/update.json"
 			],
-			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ4MTI2ODAwNTEyRTgwMjAKUldRZ2dDNVJBR2dTU1BGNUJxU2Y5SWt4OFJYeGJGTjhkaXhnUDhyeGtJUCtjKzhEMEJYQklyd3cK",
+			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENBQUFBQkI0NDdBMDBEMDUKUldRRkRhQkh0S3VxeW16WVhCM3JCWXR5OG9hdThEc1V1WXBtenpIRlVTZmFRRlFtc3NHU2RFemwK",
 			"windows": {
 				"installMode": "passive"
 			}


### PR DESCRIPTION
## Summary
- Enforce macOS Developer ID signing and notarization in the release workflow.
- Import the Developer ID certificate into a temporary CI keychain and prepare App Store Connect API key credentials.
- Verify generated DMGs with stapler, codesign, and spctl before upload.
- Configure the Tauri updater public key for release artifacts.

## Validation
- Release workflow run v0.1.14-alpha.3 completed successfully.
- macOS aarch64 and x64 signing, notarization, stapling, codesign, and Gatekeeper checks passed in CI.
- Linux arm64/x64, Windows arm64/x64, and Publish Release jobs completed successfully.
- Local /Applications/MCPMate.app verification passed with Developer ID Application signing, stapled notarization ticket, and spctl acceptance.

## Operator setup
- Requires GitHub Actions secrets for Apple certificate, notary credentials, keychain password, and Tauri updater signing key.
- Requires preserving the Developer ID certificate password and Tauri updater private-key password for future releases.
