### PR TITLE
fix(clients): restore first-contact governance flow

### DIFF
--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -20,7 +20,9 @@ use crate::api::models::client::{
 use crate::api::routes::AppState;
 use crate::audit::{AuditAction, AuditEvent, AuditStatus};
 use crate::clients::document::{get_config_last_modified, infer_format_from_path, parse_config_to_json_value};
-use crate::clients::models::{AttachmentState, CapabilitySource, ClientCapabilityConfigState};
+use crate::clients::models::{
+    AttachmentState, CapabilitySource, ClientCapabilityConfigState, ClientConnectionMode, ClientGovernanceKind,
+};
 use crate::clients::service::core::{ClientStateRow, RuntimeClientMetadata};
 use crate::clients::service::settings::ActiveClientSettingsUpdate;
 use crate::clients::{
@@ -106,6 +108,18 @@ fn fallback_parsed_config_content(
     Value::String(raw_content.to_string())
 }
 
+fn should_include_default_client(descriptor: &ClientDescriptor) -> bool {
+    if !descriptor.persisted {
+        return false;
+    }
+
+    let state = &descriptor.state;
+    match state.governance_kind() {
+        ClientGovernanceKind::Active => true,
+        ClientGovernanceKind::Passive => state.connection_mode() == ClientConnectionMode::RemoteHttp,
+    }
+}
+
 pub async fn config_file_parse_inspect(
     State(app_state): State<Arc<AppState>>,
     Json(request): Json<ClientConfigFileParseInspectReq>,
@@ -181,9 +195,10 @@ pub async fn list(
         })?;
 
     let mut client_infos = Vec::with_capacity(descriptors.len());
-    for descriptor in descriptors.into_iter().filter(|descriptor| {
-        request.include_detected || (descriptor.persisted && descriptor.state.governance_kind().as_str() == "active")
-    }) {
+    for descriptor in descriptors
+        .into_iter()
+        .filter(|descriptor| request.include_detected || should_include_default_client(descriptor))
+    {
         match descriptor_to_client_info(service.as_ref(), app_state.as_ref(), descriptor).await {
             Ok(info) => client_infos.push(info),
             Err(status) => return Err(status),
@@ -2834,13 +2849,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_excludes_passive_detected_candidates_by_default() {
+    async fn list_includes_passive_runtime_clients_by_default() {
         let context = create_test_context().await;
         context
             .client_service
-            .ensure_passive_observed_row("test.passive", "Test Passive", None)
+            .persist_handshake_observation(
+                "test.passive-runtime",
+                Some("Test Passive Runtime"),
+                Some("1.0.0"),
+                Some("streamable_http"),
+                Some("remote_http"),
+                None,
+                None,
+                None,
+            )
             .await
-            .expect("seed passive client");
+            .expect("seed passive runtime client");
 
         let Json(default_response) = list(
             State(context.app_state.clone()),
@@ -2860,7 +2884,44 @@ mod tests {
                 .expect("default data")
                 .client
                 .into_iter()
-                .all(|client| client.governance_kind.as_deref() == Some("active"))
+                .any(|client| client.identifier == "test.passive-runtime"
+                    && client.governance_kind.as_deref() == Some("passive"))
+        );
+    }
+
+    #[tokio::test]
+    async fn list_excludes_passive_detected_candidates_by_default() {
+        let context = create_test_context().await;
+        context
+            .client_service
+            .set_first_contact_behavior(crate::clients::models::FirstContactBehavior::Allow)
+            .await
+            .expect("set allow policy");
+        context
+            .client_service
+            .ensure_passive_observed_row("test.passive-detected", "Test Passive Detected", Some("/tmp/test.json"))
+            .await
+            .expect("seed passive detected client");
+
+        let Json(default_response) = list(
+            State(context.app_state.clone()),
+            Query(ClientCheckReq {
+                refresh: false,
+                persist_detected: false,
+                include_detected: false,
+            }),
+        )
+        .await
+        .expect("list managed clients");
+
+        assert!(default_response.success);
+        assert!(
+            default_response
+                .data
+                .expect("default data")
+                .client
+                .into_iter()
+                .all(|client| client.identifier != "test.passive-detected")
         );
 
         let Json(include_response) = list(
@@ -2881,7 +2942,7 @@ mod tests {
                 .expect("include data")
                 .client
                 .iter()
-                .any(|client| client.identifier == "test.passive"
+                .any(|client| client.identifier == "test.passive-detected"
                     && client.governance_kind.as_deref() == Some("passive"))
         );
     }

--- a/backend/src/clients/engine.rs
+++ b/backend/src/clients/engine.rs
@@ -895,8 +895,8 @@ mod tests {
 
         let expected_url = get_runtime_port_config().mcp_http_url();
         let rendered_url = entry.get("url").and_then(Value::as_str).expect("rendered url");
-        assert_eq!(entry.get("type").and_then(Value::as_str), Some("streamable_http"));
         assert!(rendered_url.starts_with(expected_url.as_str()));
+        assert!(entry.get("command").is_none());
         assert!(entry.get("metadata").is_none());
 
         // Regression test: managed URL must NOT be HTML-escaped

--- a/backend/src/clients/service/state.rs
+++ b/backend/src/clients/service/state.rs
@@ -5,6 +5,14 @@ use crate::clients::models::{
 };
 use std::collections::HashMap;
 
+fn approval_status_for_first_contact_behavior(behavior: FirstContactBehavior) -> &'static str {
+    match behavior {
+        FirstContactBehavior::Deny => "suspended",
+        FirstContactBehavior::Review => "pending",
+        FirstContactBehavior::Allow => "approved",
+    }
+}
+
 impl ClientConfigService {
     pub(super) async fn fetch_client_states(&self) -> ConfigResult<HashMap<String, ClientStateRow>> {
         let rows = sqlx::query_as::<_, ClientStateRow>(
@@ -35,11 +43,7 @@ impl ClientConfigService {
         }
 
         let first_contact_behavior = self.get_first_contact_behavior().await?;
-        let approval_status = match first_contact_behavior {
-            FirstContactBehavior::Deny => "suspended",
-            FirstContactBehavior::Review => "pending",
-            FirstContactBehavior::Allow => "approved",
-        };
+        let approval_status = approval_status_for_first_contact_behavior(first_contact_behavior);
 
         self.create_state_row(identifier, name, ClientGovernanceKind::Passive, approval_status, None)
             .await
@@ -327,11 +331,7 @@ impl ClientConfigService {
             return self.refresh_existing_state_name(identifier, name, existing).await;
         }
         let first_contact_behavior = self.get_first_contact_behavior().await?;
-        let approval_status = match first_contact_behavior {
-            FirstContactBehavior::Deny => "suspended",
-            FirstContactBehavior::Review => "pending",
-            FirstContactBehavior::Allow => "approved",
-        };
+        let approval_status = approval_status_for_first_contact_behavior(first_contact_behavior);
 
         self.create_state_row(
             identifier,
@@ -341,6 +341,44 @@ impl ClientConfigService {
             config_path,
         )
         .await
+    }
+
+    pub async fn apply_first_contact_behavior_to_passive_state(
+        &self,
+        identifier: &str,
+        name: &str,
+    ) -> ConfigResult<ClientStateRow> {
+        let Some(existing) = self.fetch_state(identifier).await? else {
+            return self.ensure_passive_observed_row(identifier, name, None).await;
+        };
+
+        if existing.governance_kind() != ClientGovernanceKind::Passive {
+            return self.refresh_existing_state_name(identifier, name, existing).await;
+        }
+
+        let first_contact_behavior = self.get_first_contact_behavior().await?;
+        let approval_status = approval_status_for_first_contact_behavior(first_contact_behavior);
+        self.refresh_existing_state_name(identifier, name, existing).await?;
+
+        sqlx::query(
+            r#"
+            UPDATE client
+            SET approval_status = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE identifier = ? AND governance_kind = 'passive'
+            "#,
+        )
+        .bind(approval_status)
+        .bind(identifier)
+        .execute(&*self.db_pool)
+        .await
+        .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
+
+        self.fetch_state(identifier).await?.ok_or_else(|| {
+            ConfigError::DataAccessError(format!(
+                "Failed to reload first-contact state for client {}",
+                identifier
+            ))
+        })
     }
 
     pub(crate) async fn ensure_active_state_row_with_name(
@@ -667,6 +705,65 @@ mod tests {
 
         assert_eq!(first.id, second.id);
         assert_eq!(second.approval_status.as_deref(), Some("approved"));
+    }
+
+    #[tokio::test]
+    async fn passive_first_contact_state_reapplies_current_policy() {
+        let (_temp_dir, service) = create_test_service().await;
+
+        set_onboarding_policy(&service, OnboardingPolicy::RequireApproval)
+            .await
+            .expect("set review policy");
+        let pending = service
+            .ensure_passive_observed_row("test.client", "Test Client", None)
+            .await
+            .expect("create pending passive client");
+        assert_eq!(pending.approval_status(), "pending");
+
+        set_onboarding_policy(&service, OnboardingPolicy::AutoManage)
+            .await
+            .expect("set allow policy");
+        let approved = service
+            .apply_first_contact_behavior_to_passive_state("test.client", "Test Client")
+            .await
+            .expect("reapply allow policy");
+        assert_eq!(approved.approval_status(), "approved");
+        assert_eq!(approved.governance_kind(), ClientGovernanceKind::Passive);
+
+        set_onboarding_policy(&service, OnboardingPolicy::Manual)
+            .await
+            .expect("set deny policy");
+        let suspended = service
+            .apply_first_contact_behavior_to_passive_state("test.client", "Test Client")
+            .await
+            .expect("reapply deny policy");
+        assert_eq!(suspended.approval_status(), "suspended");
+        assert_eq!(suspended.governance_kind(), ClientGovernanceKind::Passive);
+    }
+
+    #[tokio::test]
+    async fn active_client_approval_is_not_rewritten_by_first_contact_policy() {
+        let (_temp_dir, service) = create_test_service().await;
+
+        set_onboarding_policy(&service, OnboardingPolicy::RequireApproval)
+            .await
+            .expect("set review policy");
+        service
+            .ensure_passive_observed_row("test.client", "Test Client", None)
+            .await
+            .expect("create pending passive client");
+        service.approve_client("test.client").await.expect("approve client");
+
+        set_onboarding_policy(&service, OnboardingPolicy::Manual)
+            .await
+            .expect("set deny policy");
+        let active = service
+            .apply_first_contact_behavior_to_passive_state("test.client", "Test Client")
+            .await
+            .expect("reapply policy to active client");
+
+        assert_eq!(active.approval_status(), "approved");
+        assert_eq!(active.governance_kind(), ClientGovernanceKind::Active);
     }
 
     #[tokio::test]

--- a/backend/src/core/proxy/server/gateway.rs
+++ b/backend/src/core/proxy/server/gateway.rs
@@ -229,6 +229,19 @@ impl ProxyServer {
             .map_err(|e| rmcp::ErrorData::internal_error(format!("Failed to read client state: {e}"), None))?;
 
         if let Some(ref state) = state_opt {
+            let state = if state.governance_kind() == crate::clients::models::ClientGovernanceKind::Passive {
+                svc.apply_first_contact_behavior_to_passive_state(&client.client_id, display_name)
+                    .await
+                    .map_err(|e| {
+                        rmcp::ErrorData::internal_error(
+                            format!("Failed to refresh client first-contact state: {e}"),
+                            None,
+                        )
+                    })?
+            } else {
+                state.clone()
+            };
+
             return match state.approval_status() {
                 "approved" => Ok(()),
                 "suspended" => Err(rmcp::ErrorData::invalid_request(


### PR DESCRIPTION
## Summary
- Reapply the current Client First-contact Behavior to passive clients that have not been explicitly approved, suspended, or otherwise managed.
- Show passive remote clients in the default Clients list so first-contact review entries can be approved from the dashboard.
- Keep detected-only local candidates hidden from the default list unless include_detected is requested.
- Align the managed streamable HTTP render test with the current no-static-type contract.

## Validation
- cargo test -p mcpmate
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

Project item: 0.2.1c1: Client first-contact governance hotfix