### PR TITLE
feat(backend): upgrade rmcp protocol sdk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@
 - If review shows that a lower layer is not delivery-ready, stop the higher-phase rollout, fix the foundation first, and only then resume the later phase.
 
 ## Protocol Standards & SDK Alignment
-- Follow the MCP specification dated 2025-06-18 (https://modelcontextprotocol.io/specification/2025-06-18) and use the official `rmcp` crate from crates.io for transports, clients, and capability helpers.
+- Follow the MCP specification dated 2025-11-25 (https://modelcontextprotocol.io/specification/2025-11-25) and use the official `rmcp` crate from crates.io for transports, clients, and capability helpers.
 
 ## MCP Tooling & Codex Capabilities
 - Prefer mounted MCP tools when they are available instead of re-implementing helpers. If a task depends on a specific external tool, first verify that tool is available in the current environment.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey" alt="Platform">
   <img src="https://img.shields.io/badge/Rust-1.75%2B-orange" alt="Rust">
   <img src="https://img.shields.io/badge/Node.js-18%2B-brightgreen" alt="Node.js">
-  <a href="https://modelcontextprotocol.io/specification/2025-06-18"><img src="https://img.shields.io/badge/MCP-2025--06--18-purple" alt="MCP Spec"></a>
+  <a href="https://modelcontextprotocol.io/specification/2025-11-25"><img src="https://img.shields.io/badge/MCP-2025--11--25-purple" alt="MCP Spec"></a>
 </p>
 
 ---
@@ -142,7 +142,7 @@ MCPMate sits between your AI clients and MCP servers as a transparent proxy. The
 
 ### Proxy
 
-A high-performance MCP proxy server that connects to multiple MCP servers and aggregates their tools. Implements stdio and Streamable HTTP transport protocols (aligned with MCP 2025-06-18 specification). Accepts legacy SSE-configured servers and automatically normalizes them to Streamable HTTP for backward compatibility.
+A high-performance MCP proxy server that connects to multiple MCP servers and aggregates their tools. Implements stdio and Streamable HTTP transport protocols aligned with the current MCP specification. Accepts legacy SSE-configured servers and automatically normalizes them to Streamable HTTP for backward compatibility.
 
 ### Bridge
 
@@ -220,7 +220,7 @@ Coming soon. An online environment will let you explore the dashboard, profiles,
 | **Desktop**         | Tauri 2, system tray, native notifications                          |
 | **Bridge**          | Rust binary, stdio-to-HTTP conversion                               |
 | **Runtime Manager** | Multi-runtime (Node.js, uv, Bun)                                    |
-| **Protocol**        | MCP 2025-06-18, stdio + Streamable HTTP                             |
+| **Protocol**        | MCP 2025-11-25, stdio + Streamable HTTP                             |
 
 ## 🚢 Deployment Modes
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -15,7 +15,7 @@
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey" alt="Platform">
   <img src="https://img.shields.io/badge/Rust-1.75%2B-orange" alt="Rust">
   <img src="https://img.shields.io/badge/Node.js-18%2B-brightgreen" alt="Node.js">
-  <a href="https://modelcontextprotocol.io/specification/2025-06-18"><img src="https://img.shields.io/badge/MCP-2025--06--18-purple" alt="MCP Spec"></a>
+  <a href="https://modelcontextprotocol.io/specification/2025-11-25"><img src="https://img.shields.io/badge/MCP-2025--11--25-purple" alt="MCP Spec"></a>
 </p>
 
 ---
@@ -142,7 +142,7 @@ MCPMate 作为透明代理位于 AI 客户端和 MCP 服务器之间。**Bridge*
 
 ### Proxy
 
-高性能 MCP 代理服务器，连接多个 MCP 服务器并聚合工具。实现 stdio 和 Streamable HTTP 传输协议（符合 MCP 2025-06-18 规范），接受旧版 SSE 配置并自动归一化为 Streamable HTTP 以保持向后兼容。
+高性能 MCP 代理服务器，连接多个 MCP 服务器并聚合工具。实现 stdio 和 Streamable HTTP 传输协议，并对齐当前 MCP 规范；接受旧版 SSE 配置并自动归一化为 Streamable HTTP 以保持向后兼容。
 
 ### Bridge
 
@@ -220,7 +220,7 @@ Coming soon。线上环境将允许你在无需本地部署的情况下，探索
 | **桌面应用**     | Tauri 2, 系统托盘, 原生通知                              |
 | **Bridge**       | Rust 二进制, stdio → HTTP 转换                           |
 | **运行时管理器** | 多运行时 (Node.js, uv, Bun)                              |
-| **协议**         | MCP 2025-06-18, stdio + Streamable HTTP                  |
+| **协议**         | MCP 2025-11-25, stdio + Streamable HTTP                  |
 
 ## 🚢 部署模式
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2974,7 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -3569,7 +3569,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http 1.3.1",
@@ -4483,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4518,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6444,7 +6444,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -51,7 +51,7 @@ reqwest = { version = "0.13", features = [
   "stream",
   "rustls",
 ], default-features = false }
-rmcp = { version = "1.3.0", features = [
+rmcp = { version = "1.7.0", features = [
   "__reqwest",
   "auth",
   "client",

--- a/backend/README.md
+++ b/backend/README.md
@@ -189,7 +189,7 @@ npx @modelcontextprotocol/inspector --cli http://127.0.0.1:8000/mcp --transport 
 
 ## MCP Protocol
 
-Follows the [MCP specification (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18).
+Follows the [MCP specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25).
 
 Uses the official `rmcp` crate from crates.io for protocol implementation.
 

--- a/backend/src/api/handlers/server/crud.rs
+++ b/backend/src/api/handlers/server/crud.rs
@@ -235,6 +235,7 @@ pub async fn create_server(
     let server_id = crate::config::server::upsert_server(&db.pool, &server)
         .await
         .map_err(map_anyhow_error)?;
+    crate::core::capability::resolver::upsert(&server_id, &payload.name).await;
 
     if reusable_pending_server.is_some() {
         crate::config::server::delete_server_oauth_config(&db.pool, &server_id)
@@ -313,6 +314,13 @@ pub async fn create_server(
                 initial_enabled
             );
         }
+    }
+
+    if !server.pending_import {
+        let mut pool = state.connection_pool.lock().await;
+        pool.sync_servers_from_active_profile()
+            .await
+            .map_err(map_anyhow_error)?;
     }
 
     // Initial capability discovery + dual write (SQLite shadow + REDB)

--- a/backend/src/bin/bridge.rs
+++ b/backend/src/bin/bridge.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use mcpmate::common::constants::{branding, client_headers};
+use mcpmate::common::constants::{branding, client_headers, protocol};
 use reqwest::{
     Client as HttpClient,
     header::{HeaderMap, HeaderName, HeaderValue},
@@ -252,7 +252,10 @@ impl BridgeServer {
             tracing::error!("Invalid MCP protocol version header: {err}");
             McpError::internal_error("Invalid MCP protocol version header", None)
         })?;
-        default_headers.insert(HeaderName::from_static("mcp-protocol-version"), header_value);
+        default_headers.insert(
+            HeaderName::from_static(protocol::MCP_PROTOCOL_VERSION_HEADER_LOWER),
+            header_value,
+        );
 
         if let Ok(appid) = std::env::var("APPID") {
             let appid = appid.trim();

--- a/backend/src/common/constants.rs
+++ b/backend/src/common/constants.rs
@@ -121,6 +121,20 @@ pub mod client_headers {
     pub const MCPMATE_PROFILE_ID: &str = "x-mcpmate-profile-id";
 }
 
+/// MCP protocol constants shared across client and server boundaries.
+pub mod protocol {
+    pub const MCP_PROTOCOL_VERSION_HEADER: &str = "MCP-Protocol-Version";
+    pub const MCP_PROTOCOL_VERSION_HEADER_LOWER: &str = "mcp-protocol-version";
+
+    pub const V_2024_11_05: &str = "2024-11-05";
+    pub const V_2025_03_26: &str = "2025-03-26";
+    pub const V_2025_06_18: &str = "2025-06-18";
+    pub const V_2025_11_25: &str = "2025-11-25";
+
+    pub const CURRENT_VERSION: &str = V_2025_11_25;
+    pub const SUPPORTED_DOWNSTREAM_PROTOCOL_VERSIONS: &[&str] = &[CURRENT_VERSION, V_2025_06_18, V_2025_03_26];
+}
+
 /// Database constants for unified database operations
 pub mod database {
     /// Database table name constants

--- a/backend/src/core/capability/prompts.rs
+++ b/backend/src/core/capability/prompts.rs
@@ -398,28 +398,16 @@ pub async fn get_upstream_prompt(
                     server_id: server_key.to_string(),
                     affinity_key: selection.affinity_key.clone(),
                 };
-                if let Err(e) = pool.ensure_connected_with_selection(&scoped_selection).await {
-                    return Err(anyhow!(
-                        "Failed to ensure scoped connection for server '{}': {}",
-                        server_key,
-                        e
-                    ));
-                }
                 let iid = pool
-                    .select_instance_id(&scoped_selection)
-                    .map_err(|e| anyhow!("Failed to select scoped instance for server '{}': {}", server_key, e))?;
+                    .ensure_connected_with_selection(&scoped_selection)
+                    .await
+                    .map_err(|e| anyhow!("Failed to ensure scoped connection for server '{}': {}", server_key, e))?;
                 target_instance_id = Some(iid);
             } else {
-                if let Err(e) = pool.ensure_connected(server_key).await {
-                    return Err(anyhow!(
-                        "Failed to ensure connection for server '{}': {}",
-                        server_key,
-                        e
-                    ));
-                }
                 let iid = pool
-                    .get_default_instance_id(server_key)
-                    .map_err(|e| anyhow!("Failed to get default instance for server '{}': {}", server_key, e))?;
+                    .ensure_connected(server_key)
+                    .await
+                    .map_err(|e| anyhow!("Failed to ensure connection for server '{}': {}", server_key, e))?;
                 target_instance_id = Some(iid);
             }
         }

--- a/backend/src/core/capability/resources.rs
+++ b/backend/src/core/capability/resources.rs
@@ -433,24 +433,19 @@ pub async fn read_upstream_resource(
                     server_id: server_id.to_string(),
                     affinity_key: selection.affinity_key.clone(),
                 };
-                pool.ensure_connected_with_selection(&scoped_selection)
+                let iid = pool
+                    .ensure_connected_with_selection(&scoped_selection)
                     .await
                     .context(format!(
                         "Failed to ensure scoped connection for server '{}' (resource '{}')",
                         server_id, uri
                     ))?;
-                let iid = pool.select_instance_id(&scoped_selection).map_err(|e| {
-                    anyhow::anyhow!("Failed to select scoped instance for server '{}': {}", server_id, e)
-                })?;
                 target_instance_id = Some(iid);
             } else {
-                pool.ensure_connected(server_id).await.context(format!(
+                let iid = pool.ensure_connected(server_id).await.context(format!(
                     "Failed to ensure connection for server '{}' (resource '{}')",
                     server_id, uri
                 ))?;
-                let iid = pool
-                    .get_default_instance_id(server_id)
-                    .map_err(|e| anyhow::anyhow!("Failed to get default instance for server '{}': {}", server_id, e))?;
                 target_instance_id = Some(iid);
             }
         }

--- a/backend/src/core/capability/runtime.rs
+++ b/backend/src/core/capability/runtime.rs
@@ -1039,6 +1039,7 @@ async fn ensure_tool_unique_names(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::constants::protocol;
     use crate::core::cache::{CacheScope, CachedServerData, CachedToolInfo};
     use chrono::Utc;
 
@@ -1052,7 +1053,7 @@ mod tests {
             server_id: server_id.to_string(),
             server_name: "test-server".to_string(),
             server_version: Some("1.0.0".to_string()),
-            protocol_version: "2024-11-05".to_string(),
+            protocol_version: protocol::V_2024_11_05.to_string(),
             tools: (0..tool_count)
                 .map(|i| CachedToolInfo {
                     name: format!("tool_{}", i),

--- a/backend/src/core/foundation/pagination.rs
+++ b/backend/src/core/foundation/pagination.rs
@@ -3,7 +3,7 @@
 //! provides minimal pagination tools for MCPMate proxy servers
 //!
 //! this module provides basic pagination support for aggregated MCP resources,
-//! following the MCP specification 2025-03-26.
+//! following the MCP pagination model.
 
 use rmcp::ErrorData as McpError;
 use rmcp::model::{Cursor, PaginatedRequestParams};

--- a/backend/src/core/pool/executor.rs
+++ b/backend/src/core/pool/executor.rs
@@ -15,6 +15,7 @@ use tracing;
 use super::{FailureKind, UpstreamConnectionPool};
 use crate::{
     common::{
+        constants::protocol,
         server::{ServerType, TransportType},
         sync::SyncHelper,
     },
@@ -534,7 +535,7 @@ impl UpstreamConnectionPool {
                                         | "host"
                                         | "connection"
                                         | "transfer-encoding"
-                                        | "mcp-protocol-version"
+                                        | protocol::MCP_PROTOCOL_VERSION_HEADER_LOWER
                                 );
                                 if controlled {
                                     continue;

--- a/backend/src/core/proxy/server/gateway.rs
+++ b/backend/src/core/proxy/server/gateway.rs
@@ -3,6 +3,7 @@ use crate::{
     audit::AuditService,
     clients::models::FirstContactBehavior,
     clients::service::ClientConfigService,
+    common::constants::protocol,
     config::audit_database::AuditDatabase,
     config::database::Database,
     core::{pool::UpstreamConnectionPool, transport::TransportType},
@@ -612,13 +613,13 @@ impl ProxyServer {
         // 1. Header present and valid UTF-8 -> validate as normal
         // 2. Header present but invalid UTF-8 -> reject (do not silently fall back)
         // 3. Header absent -> fall back to negotiated version from initialize
-        let header_value = parts.headers.get("MCP-Protocol-Version");
+        let header_value = parts.headers.get(protocol::MCP_PROTOCOL_VERSION_HEADER);
         let (explicit_version, header_present) = match header_value {
             Some(v) => match v.to_str() {
                 Ok(s) => (Some(s), true),
                 Err(_) => {
                     return Err(rmcp::ErrorData::invalid_request(
-                        "Invalid MCP-Protocol-Version header encoding".to_string(),
+                        format!("Invalid {} header encoding", protocol::MCP_PROTOCOL_VERSION_HEADER),
                         None,
                     ));
                 }
@@ -635,7 +636,7 @@ impl ProxyServer {
         match Self::resolve_effective_protocol_version(explicit_version, negotiated_version) {
             Ok(Some(_)) => Ok(()),
             Ok(None) => Err(rmcp::ErrorData::invalid_request(
-                "Missing MCP-Protocol-Version header".to_string(),
+                format!("Missing {} header", protocol::MCP_PROTOCOL_VERSION_HEADER),
                 None,
             )),
             Err(error) => Err(error),
@@ -650,7 +651,7 @@ impl ProxyServer {
 
         let explicit_version: Option<String> = parts
             .headers
-            .get("MCP-Protocol-Version")
+            .get(protocol::MCP_PROTOCOL_VERSION_HEADER)
             .and_then(|v| v.to_str().ok())
             .map(ToString::to_string);
 
@@ -693,8 +694,7 @@ impl ProxyServer {
     }
 
     fn is_valid_protocol_version(protocol_version: &str) -> bool {
-        const REQUIRED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
-        REQUIRED_PROTOCOL_VERSIONS.contains(&protocol_version)
+        protocol::SUPPORTED_DOWNSTREAM_PROTOCOL_VERSIONS.contains(&protocol_version)
     }
 
     fn validate_protocol_version(protocol_version: &str) -> Result<(), rmcp::ErrorData> {
@@ -702,7 +702,11 @@ impl ProxyServer {
             return Ok(());
         }
         Err(rmcp::ErrorData::invalid_request(
-            format!("Unsupported MCP-Protocol-Version: {}", protocol_version),
+            format!(
+                "Unsupported {}: {}",
+                protocol::MCP_PROTOCOL_VERSION_HEADER,
+                protocol_version
+            ),
             None,
         ))
     }
@@ -1217,8 +1221,16 @@ impl ServerHandler for ProxyServer {
         );
 
         if let Some(parts) = context.extensions.get::<axum::http::request::Parts>() {
-            if let Some(v) = parts.headers.get("MCP-Protocol-Version").and_then(|h| h.to_str().ok()) {
-                tracing::debug!(header_mcp_protocol_version = %v, "HTTP header: MCP-Protocol-Version");
+            if let Some(v) = parts
+                .headers
+                .get(protocol::MCP_PROTOCOL_VERSION_HEADER)
+                .and_then(|h| h.to_str().ok())
+            {
+                tracing::debug!(
+                    header_mcp_protocol_version = %v,
+                    header = protocol::MCP_PROTOCOL_VERSION_HEADER,
+                    "HTTP header observed"
+                );
             }
             if let Some(v) = parts
                 .headers
@@ -1931,7 +1943,7 @@ mod tests {
 
     #[test]
     fn resolve_effective_protocol_version_prefers_explicit_header() {
-        let header_version = rmcp::model::ProtocolVersion::V_2025_06_18.to_string();
+        let header_version = protocol::CURRENT_VERSION.to_string();
         let negotiated_version = rmcp::model::ProtocolVersion::V_2025_03_26.to_string();
 
         let resolved =
@@ -1955,10 +1967,18 @@ mod tests {
     fn resolve_effective_protocol_version_rejects_unsupported_header() {
         let negotiated_version = rmcp::model::ProtocolVersion::V_2025_03_26.to_string();
 
-        let error = ProxyServer::resolve_effective_protocol_version(Some("2024-11-05"), Some(negotiated_version))
-            .expect_err("unsupported explicit header should fail");
+        let error =
+            ProxyServer::resolve_effective_protocol_version(Some(protocol::V_2024_11_05), Some(negotiated_version))
+                .expect_err("unsupported explicit header should fail");
 
-        assert_eq!(error.message, "Unsupported MCP-Protocol-Version: 2024-11-05");
+        assert_eq!(
+            error.message,
+            format!(
+                "Unsupported {}: {}",
+                protocol::MCP_PROTOCOL_VERSION_HEADER,
+                protocol::V_2024_11_05
+            )
+        );
     }
 
     #[test]

--- a/backend/src/core/transport/client.rs
+++ b/backend/src/core/transport/client.rs
@@ -45,7 +45,8 @@ impl UpstreamClientHandler {
 
 impl ClientHandler for UpstreamClientHandler {
     fn get_info(&self) -> ClientInfo {
-        // Use widely supported version for upstream compatibility; headers handle 2025-06-18 at proxy edge
+        // Use the older widely supported version for upstream compatibility;
+        // the proxy edge validates downstream protocol headers separately.
         ClientInfo::new(ClientCapabilities::default(), Self::build_client_impl())
             .with_protocol_version(ProtocolVersion::V_2025_03_26)
     }

--- a/backend/src/core/transport/http.rs
+++ b/backend/src/core/transport/http.rs
@@ -2,6 +2,7 @@
 // Provides abstractions for streamable HTTP transport
 
 use super::TransportType;
+use crate::common::constants::protocol;
 use crate::common::http::make_streamable_config;
 use crate::core::foundation::utils::{get_sse_connection_timeout, get_sse_service_timeout, get_sse_tools_timeout};
 use crate::core::models::MCPServerConfig;
@@ -128,7 +129,7 @@ pub async fn connect_http_server(
                             | "host"
                             | "connection"
                             | "transfer-encoding"
-                            | "mcp-protocol-version"
+                            | protocol::MCP_PROTOCOL_VERSION_HEADER_LOWER
                     );
                     if controlled {
                         continue;

--- a/backend/tests/inspector-rmcp-upgrade-plan.md
+++ b/backend/tests/inspector-rmcp-upgrade-plan.md
@@ -1,0 +1,66 @@
+# RMCP Upgrade Inspector Validation Plan
+
+Scope: validate the `rmcp` protocol SDK upgrade without changing MCPMate profile, unify, hosted, or API semantics.
+
+## Preconditions
+
+- Build from the `codex/rmcp-upgrade` worktree.
+- Start backend from `backend/` with the same config/home used for the smoke run.
+- Keep REST/API requests routed through approved tooling; do not use raw `curl` or `wget`.
+- Use MCP Inspector CLI through Bun:
+
+```sh
+bunx --bun @modelcontextprotocol/inspector --cli http://127.0.0.1:8000/mcp --transport http --method <method>
+```
+
+## Inspector Protocol Checks
+
+1. `initialize`
+   - Confirm the server accepts the current MCP protocol version.
+   - Confirm server implementation name/version and capability sections are present.
+2. `tools/list`
+   - Confirm built-in MCPMate tools are present.
+   - In `unify` mode, confirm unify guide/action tools are visible and non-unify-only tools remain hidden.
+   - In `hosted` mode, confirm hosted profile discovery/selection tools match the configured capability source.
+3. `prompts/list`
+   - Confirm expected MCPMate prompts are visible for the active mode.
+   - Confirm profile/source switching emits visible list changes where supported by the client.
+4. `resources/list` and `resources/templates/list`
+   - Confirm hosted/profile resources match API profile capability settings.
+   - Confirm disabled profile resources are absent from enabled-only surfaces.
+5. `tools/call`
+   - Call `mcpmate_profile_list`.
+   - Call `mcpmate_profile_preview` or the active hosted profile selector with a known shared profile.
+   - In `unify` mode, call the unify next-action tool and confirm it returns actionable JSON/text without direct unmanaged tool leakage.
+
+## API Cross-Checks
+
+1. Client management
+   - Create or select a test client.
+   - Switch `config_mode` across `transparent`, `hosted`, and `unify`.
+   - Confirm Inspector `tools/list`, `prompts/list`, and `resources/list` reflect each mode.
+2. Server lifecycle
+   - Add a test server using the management API.
+   - Confirm it appears in API list/detail responses.
+   - Remove the server and confirm it disappears from API and Inspector surfaces.
+3. Server capability toggles
+   - Toggle a server capability off.
+   - Confirm API state persists the disabled capability.
+   - Confirm Inspector no longer exposes that capability in enabled-only mode.
+   - Toggle it back on and confirm both API and Inspector surfaces recover.
+4. Profile capability switches
+   - Switch a profile server capability source for hosted mode.
+   - Confirm API profile capability state and Inspector visible surfaces agree.
+5. Origin/Host boundary
+   - Confirm existing MCPMate Origin handling remains unchanged in this PR.
+   - Record a follow-up if `/mcp` Origin/Host validation should move to `rmcp` transport config.
+
+## Completion Evidence
+
+Record:
+
+- Backend start command and commit SHA.
+- Inspector commands and pass/fail result.
+- API requests exercised and pass/fail result.
+- Any mismatch between API state and Inspector surfaces.
+- Any `rmcp` protocol behavior that needs a separate follow-up PR.

--- a/backend/tests/inspector_smoke.rs
+++ b/backend/tests/inspector_smoke.rs
@@ -1,17 +1,22 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use axum::body::to_bytes;
 use axum::routing::{Router, get, post};
 use futures_util::StreamExt;
 use hyper::{Request, StatusCode};
+use serde_json::{Value, json};
+use sqlx::sqlite::SqlitePoolOptions;
+use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tower::ServiceExt;
 
-use mcpmate::api::handlers::inspector;
+use mcpmate::api::handlers::{inspector, server};
 use mcpmate::api::routes::AppState;
-use mcpmate::core::cache::RedbCacheManager;
+use mcpmate::common::constants::protocol;
+use mcpmate::config::{database::Database, initialization::run_initialization};
+use mcpmate::core::cache::{RedbCacheManager, manager::CacheConfig};
 use mcpmate::core::models::Config;
 use mcpmate::core::pool::UpstreamConnectionPool;
 use mcpmate::core::profile::ConfigApplicationStateManager;
@@ -19,6 +24,11 @@ use mcpmate::inspector::{
     calls::InspectorCallRegistry, service as inspector_service, sessions::InspectorSessionManager,
 };
 use mcpmate::system::metrics::MetricsCollector;
+
+const CREATE_SERVER_PATH: &str = "/api/mcp/servers/create";
+const TOOL_LIST_PATH: &str = "/api/mcp/inspector/tool/list";
+const RESOURCE_LIST_PATH: &str = "/api/mcp/inspector/resource/list";
+const RESOURCE_READ_PATH: &str = "/api/mcp/inspector/resource/read";
 
 struct EnvVarGuard {
     key: &'static str,
@@ -69,6 +79,247 @@ fn build_test_state() -> Arc<AppState> {
         inspector_sessions,
         oauth_manager: None,
     })
+}
+
+async fn build_database_state(temp_dir: &TempDir) -> Arc<AppState> {
+    let db_pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+
+    sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&db_pool)
+        .await
+        .expect("enable foreign keys");
+    run_initialization(&db_pool).await.expect("initialize schema");
+    mcpmate::core::capability::naming::initialize(db_pool.clone());
+    mcpmate::core::capability::resolver::clear_cache().await;
+
+    let database = Arc::new(Database {
+        pool: db_pool,
+        path: temp_dir.path().join("mcpmate-test.db"),
+    });
+    let cache_path = temp_dir.path().join("capability.redb");
+    let redb_cache = Arc::new(RedbCacheManager::new(cache_path, CacheConfig::default()).expect("redb"));
+    let inspector_calls = Arc::new(InspectorCallRegistry::new());
+    inspector_service::set_call_registry(inspector_calls.clone());
+
+    Arc::new(AppState {
+        connection_pool: Arc::new(Mutex::new(UpstreamConnectionPool::new(
+            Arc::new(Config::default()),
+            Some(database.clone()),
+        ))),
+        metrics_collector: Arc::new(MetricsCollector::new(std::time::Duration::from_secs(1))),
+        http_proxy: None,
+        profile_merge_service: None,
+        database: Some(database),
+        audit_database: None,
+        audit_service: None,
+        config_application_state: Arc::new(ConfigApplicationStateManager::new()),
+        redb_cache,
+        unified_query: None,
+        client_service: None,
+        inspector_calls,
+        inspector_sessions: Arc::new(InspectorSessionManager::new()),
+        oauth_manager: None,
+    })
+}
+
+fn write_stdio_fixture(temp_dir: &TempDir) -> PathBuf {
+    let path = temp_dir.path().join("stdio_mcp_fixture.py");
+    let script = r#"
+import json
+import sys
+
+def reply(request_id, result):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}) + "\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    req = json.loads(line)
+    request_id = req.get("id")
+    method = req.get("method")
+    if request_id is None:
+        continue
+    if method == "initialize":
+        reply(request_id, {
+            "protocolVersion": "__PROTOCOL_VERSION__",
+            "capabilities": {
+                "tools": {},
+                "resources": {},
+                "prompts": {}
+            },
+            "serverInfo": {"name": "inspector-fixture", "version": "1.0.0"}
+        })
+    elif method == "tools/list":
+        reply(request_id, {
+            "tools": [{
+                "name": "echo",
+                "description": "Echo a message.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"]
+                }
+            }]
+        })
+    elif method == "tools/call":
+        message = req.get("params", {}).get("arguments", {}).get("message", "")
+        reply(request_id, {
+            "content": [{"type": "text", "text": "echo: " + message}],
+            "isError": False
+        })
+    elif method == "resources/list":
+        reply(request_id, {
+            "resources": [{
+                "uri": "test://hello",
+                "name": "hello",
+                "mimeType": "text/plain"
+            }]
+        })
+    elif method == "resources/read":
+        reply(request_id, {
+            "contents": [{
+                "uri": "test://hello",
+                "mimeType": "text/plain",
+                "text": "hello from resource"
+            }]
+        })
+    elif method == "prompts/list":
+        reply(request_id, {"prompts": []})
+    elif method == "resources/templates/list":
+        reply(request_id, {"resourceTemplates": []})
+    else:
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "method not found"}
+        }) + "\n")
+        sys.stdout.flush()
+"#
+    .replace("__PROTOCOL_VERSION__", protocol::CURRENT_VERSION);
+
+    std::fs::write(&path, script).expect("write stdio fixture");
+    path
+}
+
+async fn read_json_response(response: axum::response::Response) -> Value {
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("response body");
+    let body: Value = serde_json::from_slice(&bytes).expect("json response");
+    assert!(status.is_success(), "unexpected status {status}: {body}");
+    body
+}
+
+fn json_post_request(
+    uri: &str,
+    body: Value,
+) -> Request<axum::body::Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+fn get_request(uri: String) -> Request<axum::body::Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(axum::body::Body::empty())
+        .unwrap()
+}
+
+fn assert_api_success(body: &Value) {
+    assert_eq!(body.pointer("/success").and_then(Value::as_bool), Some(true));
+}
+
+fn data_str<'a>(
+    body: &'a Value,
+    pointer: &str,
+) -> &'a str {
+    body.pointer(pointer)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected string at {pointer}: {body}"))
+}
+
+fn data_u64(
+    body: &Value,
+    pointer: &str,
+) -> u64 {
+    body.pointer(pointer)
+        .and_then(Value::as_u64)
+        .unwrap_or_else(|| panic!("expected u64 at {pointer}: {body}"))
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn inspector_create_server_is_immediately_usable_without_restart() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let fixture = write_stdio_fixture(&temp_dir);
+    let python = which::which("python3").expect("python3 is required for stdio MCP fixture");
+    let state = build_database_state(&temp_dir).await;
+
+    let app = Router::new()
+        .route(CREATE_SERVER_PATH, post(server::create_server))
+        .route(TOOL_LIST_PATH, get(inspector::tools_list))
+        .route(RESOURCE_LIST_PATH, get(inspector::resources_list))
+        .route(RESOURCE_READ_PATH, get(inspector::resource_read))
+        .with_state(state);
+
+    let create_req = json_post_request(
+        CREATE_SERVER_PATH,
+        json!({
+            "name": "inspector-fixture",
+            "server_type": "stdio",
+            "command": python.to_string_lossy(),
+            "args": [fixture.to_string_lossy()]
+        }),
+    );
+
+    let create_body = read_json_response(app.clone().oneshot(create_req).await.unwrap()).await;
+    assert_api_success(&create_body);
+    let server_id = data_str(&create_body, "/data/id").to_string();
+    assert_eq!(
+        data_str(&create_body, "/data/protocol_version"),
+        protocol::CURRENT_VERSION
+    );
+
+    let tools_req = get_request(format!(
+        "{TOOL_LIST_PATH}?server_id={server_id}&mode=proxy&refresh=true"
+    ));
+    let tools_body = read_json_response(app.clone().oneshot(tools_req).await.unwrap()).await;
+    assert_api_success(&tools_body);
+    assert_eq!(data_u64(&tools_body, "/data/total"), 1);
+    let tool_name = data_str(&tools_body, "/data/tools/0/name");
+    assert!(
+        tool_name.ends_with("_echo"),
+        "proxy Inspector should expose the upstream echo tool with a stable unique name, got {tool_name}"
+    );
+
+    let resources_req = get_request(format!(
+        "{RESOURCE_LIST_PATH}?server_id={server_id}&mode=proxy&refresh=true"
+    ));
+    let resources_body = read_json_response(app.clone().oneshot(resources_req).await.unwrap()).await;
+    assert_api_success(&resources_body);
+    assert_eq!(data_u64(&resources_body, "/data/total"), 1);
+
+    let resource_read_req = get_request(format!(
+        "{RESOURCE_READ_PATH}?server_id={server_id}&mode=proxy&uri=test%3A%2F%2Fhello"
+    ));
+    let resource_read_body = read_json_response(app.oneshot(resource_read_req).await.unwrap()).await;
+    assert_eq!(
+        data_str(&resource_read_body, "/data/result/contents/0/text"),
+        "hello from resource"
+    );
+
+    mcpmate::core::capability::resolver::clear_cache().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Upgrade backend rmcp and rmcp-macros to 1.7.0.
- Centralize MCP protocol version/header constants and align downstream validation/docs with MCP 2025-11-25.
- Fix internal Inspector runtime visibility after server creation and upstream prompt/resource instance selection.
- Add closed-loop internal Inspector smoke coverage plus a reusable RMCP upgrade validation plan.

## Project
- MCPMate Project item: 0.2.1c: rmcp protocol SDK upgrade.

## Validation
- git diff --check
- cargo test -p mcpmate --test inspector_smoke
- cargo test -p mcpmate
- cargo clippy --all-targets --all-features -- -D warnings

## Notes
- Rebased on origin/main after the client first-contact hotfix.
- Manual richer hosted/profile Inspector run remains the follow-up before marking the Project item Done.