### PR TITLE
Refine client config state semantics and board form flow

### DIFF
--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -20,9 +20,7 @@ use crate::api::models::client::{
 use crate::api::routes::AppState;
 use crate::audit::{AuditAction, AuditEvent, AuditStatus};
 use crate::clients::document::{get_config_last_modified, infer_format_from_path, parse_config_to_json_value};
-use crate::clients::models::{
-    AttachmentState, CapabilitySource, ClientCapabilityConfigState, ClientConnectionMode, ClientGovernanceKind,
-};
+use crate::clients::models::{AttachmentState, CapabilitySource, ClientCapabilityConfigState, ClientGovernanceKind};
 use crate::clients::service::core::{ClientStateRow, RuntimeClientMetadata};
 use crate::clients::service::settings::ActiveClientSettingsUpdate;
 use crate::clients::{
@@ -116,7 +114,7 @@ fn should_include_default_client(descriptor: &ClientDescriptor) -> bool {
     let state = &descriptor.state;
     match state.governance_kind() {
         ClientGovernanceKind::Active => true,
-        ClientGovernanceKind::Passive => state.connection_mode() == ClientConnectionMode::RemoteHttp,
+        ClientGovernanceKind::Passive => state.runtime_observed(),
     }
 }
 
@@ -367,8 +365,9 @@ pub async fn config_details(
         .as_ref()
         .map(|state| state.custom_profile_missing)
         .unwrap_or(false);
-    let governance_kind = Some(state.governance_kind().as_str().to_string());
-    let connection_mode = Some(state.connection_mode().as_str().to_string());
+    let config_file_state = state.config_file_state();
+    let registration_origin = state.registration_origin();
+    let runtime_observed = state.runtime_observed();
     let governed_by_default_policy = state.governed_by_default_policy();
     let approval_status = Some(state.approval_status().to_string());
     let attachment_state = derive_attachment_state(&state, &configured_servers_analysis);
@@ -406,8 +405,9 @@ pub async fn config_details(
         custom_profile_missing,
         approval_status,
         attachment_state: Some(attachment_state),
-        governance_kind,
-        connection_mode,
+        config_file_state,
+        registration_origin,
+        runtime_observed,
         governed_by_default_policy,
         writable_config,
         config_file_parse_effective,
@@ -781,7 +781,7 @@ pub async fn update_settings(
         transport = ?request.transport,
         client_version = ?request.client_version,
         display_name = ?request.display_name,
-        connection_mode = ?request.connection_mode,
+        config_file_state = ?request.config_file_state,
         config_path = ?request.config_path,
         clear_config_file_parse = %request.clear_config_file_parse,
         "update_settings: received request"
@@ -802,7 +802,7 @@ pub async fn update_settings(
                 config_mode: request.config_mode.clone(),
                 transport: request.transport.clone(),
                 client_version: request.client_version.clone(),
-                connection_mode: request.connection_mode.clone(),
+                config_file_state: request.config_file_state,
                 config_path: request.config_path.clone(),
                 description: request.description.clone(),
                 homepage_url: request.homepage_url.clone(),
@@ -871,7 +871,9 @@ pub async fn update_settings(
         config_mode: mode,
         transport,
         client_version: version,
-        connection_mode: Some(state.connection_mode().as_str().to_string()),
+        config_file_state: state.config_file_state(),
+        registration_origin: state.registration_origin(),
+        runtime_observed: state.runtime_observed(),
         config_path: state.config_path().map(str::to_string),
         transports,
         description: runtime_metadata.description.clone(),
@@ -885,7 +887,7 @@ pub async fn update_settings(
         setting_sources: crate::api::models::client::ClientSettingsSourceData {
             display_name: settings_result.display_name_source.to_string(),
             approval_status: settings_result.approval_status_source.to_string(),
-            connection_mode: settings_result.connection_mode_source.to_string(),
+            config_file_state: settings_result.config_file_state_source.to_string(),
         },
     };
 
@@ -901,7 +903,7 @@ pub async fn update_settings(
             "transport": data.transport,
             "client_version": data.client_version,
             "display_name": data.display_name,
-            "connection_mode": data.connection_mode,
+            "config_file_state": data.config_file_state,
             "config_path": data.config_path,
             "transports": data.transports,
             "config_file_parse_effective": data.config_file_parse_effective,
@@ -1233,8 +1235,9 @@ async fn descriptor_to_client_info(
     let last_modified = descriptor.config_path.as_deref().and_then(get_config_last_modified);
 
     let approval_status = Some(state.approval_status().to_string());
-    let governance_kind = Some(state.governance_kind().as_str().to_string());
-    let connection_mode = Some(state.connection_mode().as_str().to_string());
+    let config_file_state = state.config_file_state();
+    let registration_origin = state.registration_origin();
+    let runtime_observed = state.runtime_observed();
     let governed_by_default_policy = state.governed_by_default_policy();
 
     let (config_mode, transport, client_version) = service
@@ -1282,8 +1285,9 @@ async fn descriptor_to_client_info(
         template: build_template_metadata_from_state(&state, &runtime_metadata),
         approval_status,
         attachment_state: Some(attachment_state),
-        governance_kind,
-        connection_mode,
+        config_file_state,
+        registration_origin,
+        runtime_observed,
         governed_by_default_policy,
         writable_config,
         pending_approval,
@@ -1413,6 +1417,7 @@ mod tests {
     use super::*;
     use crate::api::models::client::{ClientConfigFileParseData, ClientFormatRuleData, ClientSettingsUpdateReq};
     use crate::api::routes::AppState;
+    use crate::clients::models::{ClientConfigFileState, ClientRegistrationOrigin};
     use crate::clients::{
         CapabilitySource,
         source::{ClientConfigSource, DbTemplateSource, FileTemplateSource, TemplateRoot},
@@ -1590,7 +1595,7 @@ mod tests {
             transport: None,
             client_version: None,
             display_name: None,
-            connection_mode: None,
+            config_file_state: None,
             config_path: None,
             description: None,
             homepage_url: None,
@@ -2819,7 +2824,7 @@ mod tests {
                 "custom.runtime",
                 ActiveClientSettingsUpdate {
                     config_mode: Some("hosted".to_string()),
-                    connection_mode: Some("manual".to_string()),
+                    config_file_state: Some(ClientConfigFileState::WithoutConfigFile),
                     description: Some("Runtime-only client".to_string()),
                     ..ActiveClientSettingsUpdate::default()
                 },
@@ -2838,7 +2843,6 @@ mod tests {
 
         assert!(response.success);
         let data = response.data.expect("response data");
-        assert_eq!(data.governance_kind.as_deref(), Some("active"));
         assert!(!data.governed_by_default_policy);
         assert!(!data.writable_config);
         assert!(data.warnings.is_empty());
@@ -2858,7 +2862,6 @@ mod tests {
                 Some("Test Passive Runtime"),
                 Some("1.0.0"),
                 Some("streamable_http"),
-                Some("remote_http"),
                 None,
                 None,
                 None,
@@ -2878,14 +2881,21 @@ mod tests {
         .expect("list managed clients");
 
         assert!(default_response.success);
-        assert!(
-            default_response
-                .data
-                .expect("default data")
-                .client
-                .into_iter()
-                .any(|client| client.identifier == "test.passive-runtime"
-                    && client.governance_kind.as_deref() == Some("passive"))
+        let runtime_client = default_response
+            .data
+            .expect("default data")
+            .client
+            .into_iter()
+            .find(|client| client.identifier == "test.passive-runtime")
+            .expect("runtime-observed passive client should be visible by default");
+        assert_eq!(
+            runtime_client.registration_origin,
+            ClientRegistrationOrigin::RuntimeInitialize
+        );
+        assert!(runtime_client.runtime_observed);
+        assert_eq!(
+            runtime_client.config_file_state,
+            ClientConfigFileState::WithoutConfigFile
         );
     }
 
@@ -2936,15 +2946,19 @@ mod tests {
         .expect("list detected candidates");
 
         assert!(include_response.success);
-        assert!(
-            include_response
-                .data
-                .expect("include data")
-                .client
-                .iter()
-                .any(|client| client.identifier == "test.passive-detected"
-                    && client.governance_kind.as_deref() == Some("passive"))
+        let detected_client = include_response
+            .data
+            .expect("include data")
+            .client
+            .into_iter()
+            .find(|client| client.identifier == "test.passive-detected")
+            .expect("detected passive client should be visible when requested");
+        assert_eq!(
+            detected_client.registration_origin,
+            ClientRegistrationOrigin::ConfigDetection
         );
+        assert!(!detected_client.runtime_observed);
+        assert_eq!(detected_client.config_file_state, ClientConfigFileState::WithConfigFile);
     }
 
     #[tokio::test]
@@ -2982,7 +2996,7 @@ mod tests {
             .set_active_client_settings(
                 "codex",
                 ActiveClientSettingsUpdate {
-                    connection_mode: Some("local_config_detected".to_string()),
+                    config_file_state: Some(ClientConfigFileState::WithConfigFile),
                     config_path: Some(config_path.to_string_lossy().to_string()),
                     clear_config_file_parse: true,
                     ..ActiveClientSettingsUpdate::default()
@@ -3039,7 +3053,7 @@ mod tests {
                 transport: Some("streamable_http".to_string()),
                 client_version: Some("1.2.3".to_string()),
                 display_name: Some("Custom Runtime".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
                 description: Some("Custom runtime client".to_string()),
                 homepage_url: Some("https://example.com".to_string()),
@@ -3055,7 +3069,7 @@ mod tests {
         assert!(response.success);
         let data = response.data.expect("response data");
         assert_eq!(data.display_name, "Custom Runtime");
-        assert_eq!(data.connection_mode.as_deref(), Some("local_config_detected"));
+        assert_eq!(data.config_file_state, ClientConfigFileState::WithConfigFile);
         assert!(data.transports.is_none());
         assert_eq!(data.description.as_deref(), Some("Custom runtime client"));
 
@@ -3096,7 +3110,7 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("stdio".to_string()),
                 display_name: Some("Client A".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
                 config_file_parse: Some(json_object_parse("mcpServers")),
                 transports: Some(HashMap::from([("streamable_http".to_string(), streamable_http_rule())])),
@@ -3178,7 +3192,7 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("stdio".to_string()),
                 display_name: Some("Zed Strict Inspect".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
                 config_file_parse: Some(json_object_parse("context_servers")),
                 transports: Some(HashMap::from([(
@@ -3248,7 +3262,7 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("stdio".to_string()),
                 display_name: Some("Already Imported Client".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
                 config_file_parse: Some(json_object_parse("mcpServers")),
                 transports: Some(HashMap::from([(
@@ -3305,7 +3319,7 @@ mod tests {
                     display_name: Some("Inspect Existing Client".to_string()),
                     config_mode: Some("hosted".to_string()),
                     transport: Some("stdio".to_string()),
-                    connection_mode: Some("local_config_detected".to_string()),
+                    config_file_state: Some(ClientConfigFileState::WithConfigFile),
                     config_path: Some(config_path.to_string_lossy().to_string()),
                     ..ActiveClientSettingsUpdate::default()
                 },
@@ -3376,7 +3390,7 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("streamable_http".to_string()),
                 display_name: Some("Invalid Runtime".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(missing_path.to_string_lossy().to_string()),
                 ..settings_update_req("custom.runtime.invalid")
             }),
@@ -3401,8 +3415,10 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("streamable_http".to_string()),
                 display_name: Some("Clear Runtime".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
+                config_file_parse: Some(json_object_parse("mcpServers")),
+                transports: Some(HashMap::from([("streamable_http".to_string(), streamable_http_rule())])),
                 ..settings_update_req("custom.runtime.clear")
             }),
         )
@@ -3416,13 +3432,19 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("streamable_http".to_string()),
                 display_name: Some("Clear Runtime".to_string()),
-                connection_mode: Some("manual".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithoutConfigFile),
                 ..settings_update_req("custom.runtime.clear")
             }),
         )
         .await
         .expect("manual update succeeds");
         assert!(clear_response.success);
+        let clear_data = clear_response.data.expect("response data");
+        assert_eq!(clear_data.config_file_state, ClientConfigFileState::WithoutConfigFile);
+        assert!(clear_data.config_path.is_none());
+        assert!(clear_data.config_file_parse_effective.is_none());
+        assert!(clear_data.config_file_parse_override.is_none());
+        assert!(clear_data.transports.is_none());
 
         let state = context
             .client_service
@@ -3432,6 +3454,8 @@ mod tests {
             .expect("state exists");
         assert_eq!(state.connection_mode().as_str(), "manual");
         assert_eq!(state.config_path(), None);
+        assert!(state.effective_config_file_parse().expect("config parse").is_none());
+        assert!(state.parsed_transports().expect("transports").is_empty());
     }
 
     #[tokio::test]
@@ -3446,7 +3470,7 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("streamable_http".to_string()),
                 display_name: Some("Empty Clear Runtime".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
                 ..settings_update_req("custom.runtime.empty-clear")
             }),
@@ -3544,7 +3568,7 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("streamable_http".to_string()),
                 display_name: Some("Cherry Studio".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(kv_dir.to_string_lossy().to_string()),
                 ..settings_update_req("cherry_studio")
             }),
@@ -3575,7 +3599,7 @@ mod tests {
                 config_mode: Some("hosted".to_string()),
                 transport: Some("streamable_http".to_string()),
                 display_name: Some("Cherry Studio".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(kv_dir.to_string_lossy().to_string()),
                 ..settings_update_req("cherry_studio")
             }),
@@ -3606,7 +3630,7 @@ mod tests {
                     display_name: Some("Suspended Client".to_string()),
                     config_mode: Some("hosted".to_string()),
                     transport: Some("streamable_http".to_string()),
-                    connection_mode: Some("local_config_detected".to_string()),
+                    config_file_state: Some(ClientConfigFileState::WithConfigFile),
                     config_path: Some(config_path.to_string_lossy().to_string()),
                     ..ActiveClientSettingsUpdate::default()
                 },
@@ -3627,7 +3651,7 @@ mod tests {
                 transport: Some("streamable_http".to_string()),
                 client_version: Some("2.0.0".to_string()),
                 display_name: Some("Suspended Client".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
                 description: Some("Still editable while denied".to_string()),
                 ..settings_update_req("client-a")
@@ -3662,7 +3686,7 @@ mod tests {
                 transport: Some("streamable_http".to_string()),
                 client_version: Some("9.9.9".to_string()),
                 display_name: Some("Runtime Apply Client".to_string()),
-                connection_mode: Some("local_config_detected".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
                 config_path: Some(config_path.to_string_lossy().to_string()),
                 description: Some("Runtime apply test client".to_string()),
                 config_file_parse: Some(json_object_parse("mcpServers")),

--- a/backend/src/api/handlers/onboarding.rs
+++ b/backend/src/api/handlers/onboarding.rs
@@ -16,7 +16,7 @@ use crate::common::constants::database::tables;
 use crate::common::server::ServerType;
 use crate::config::server::import::build_import_plan_from_entries;
 use crate::macros::resp::api_resp;
-use crate::runtime::{RuntimeDetection, RuntimeDetector, RuntimeProbe, ResolveSource};
+use crate::runtime::{ResolveSource, RuntimeDetection, RuntimeDetector, RuntimeProbe};
 
 #[derive(Debug, Serialize, JsonSchema)]
 #[schemars(description = "Onboarding action result")]
@@ -276,10 +276,7 @@ const UVX_RUNTIME_PROBES: &[RuntimeProbe<'_>] = &[RuntimeProbe {
 }];
 
 fn runtime_detection_to_entry(detection: RuntimeDetection) -> RuntimeEntry {
-    let source = detection
-        .resolve_source
-        .as_ref()
-        .map(resolve_source_to_label);
+    let source = detection.resolve_source.as_ref().map(resolve_source_to_label);
 
     RuntimeEntry {
         name: detection.name,
@@ -350,6 +347,7 @@ mod tests {
     use crate::api::models::client::{ClientConfigFileParseData, ClientConfigType};
     use crate::api::models::onboarding::{OnboardingCompleteReq, OnboardingServerScanClient, OnboardingServerScanReq};
     use crate::api::routes::AppState;
+    use crate::clients::models::ClientConfigFileState;
     use crate::clients::{
         ClientConfigService,
         service::settings::ActiveClientSettingsUpdate,
@@ -593,7 +591,7 @@ mod tests {
                 "custom.client",
                 ActiveClientSettingsUpdate {
                     display_name: Some("Custom Client".to_string()),
-                    connection_mode: Some("local_config_detected".to_string()),
+                    config_file_state: Some(ClientConfigFileState::WithConfigFile),
                     config_path: Some(config_path.to_string_lossy().to_string()),
                     clear_config_file_parse: true,
                     ..ActiveClientSettingsUpdate::default()
@@ -644,7 +642,7 @@ mod tests {
                 "custom.client",
                 ActiveClientSettingsUpdate {
                     display_name: Some("Custom Client".to_string()),
-                    connection_mode: Some("local_config_detected".to_string()),
+                    config_file_state: Some(ClientConfigFileState::WithConfigFile),
                     config_path: Some(config_path.to_string_lossy().to_string()),
                     clear_config_file_parse: true,
                     ..ActiveClientSettingsUpdate::default()

--- a/backend/src/api/models/client.rs
+++ b/backend/src/api/models/client.rs
@@ -1,7 +1,7 @@
 use crate::clients::analyzer::InspectedServerEntry;
 use crate::clients::models::{
-    CapabilitySource, UnifyDirectCapabilityIds, UnifyDirectExposureConfig, UnifyDirectExposureDiagnostics,
-    UnifyDirectExposureIntent,
+    CapabilitySource, ClientConfigFileState, ClientRegistrationOrigin, UnifyDirectCapabilityIds,
+    UnifyDirectExposureConfig, UnifyDirectExposureDiagnostics, UnifyDirectExposureIntent,
 };
 use crate::common::ClientCategory;
 use crate::macros::resp::api_resp;
@@ -126,12 +126,15 @@ pub struct ClientInfo {
     #[schemars(description = "External client attachment state (attached/detached/not_applicable)")]
     #[serde(default)]
     pub attachment_state: Option<String>,
-    #[schemars(description = "Runtime governance kind (passive or active)")]
+    #[schemars(description = "Product-facing config file state: with_config_file or without_config_file")]
     #[serde(default)]
-    pub governance_kind: Option<String>,
-    #[schemars(description = "Runtime connection mode (local_config_detected, remote_http, or manual)")]
+    pub config_file_state: ClientConfigFileState,
+    #[schemars(description = "First registration origin: manual, config_detection, or runtime_initialize")]
     #[serde(default)]
-    pub connection_mode: Option<String>,
+    pub registration_origin: ClientRegistrationOrigin,
+    #[schemars(description = "Whether this client has been observed through the MCP runtime boundary")]
+    #[serde(default)]
+    pub runtime_observed: bool,
     #[schemars(description = "Whether current governance state is inherited from default policy")]
     #[serde(default)]
     pub governed_by_default_policy: bool,
@@ -370,12 +373,15 @@ pub struct ClientConfigData {
     #[schemars(description = "External client attachment state (attached/detached/not_applicable)")]
     #[serde(default)]
     pub attachment_state: Option<String>,
-    #[schemars(description = "Runtime governance kind (passive or active)")]
+    #[schemars(description = "Product-facing config file state: with_config_file or without_config_file")]
     #[serde(default)]
-    pub governance_kind: Option<String>,
-    #[schemars(description = "Runtime connection mode (local_config_detected, remote_http, or manual)")]
+    pub config_file_state: ClientConfigFileState,
+    #[schemars(description = "First registration origin: manual, config_detection, or runtime_initialize")]
     #[serde(default)]
-    pub connection_mode: Option<String>,
+    pub registration_origin: ClientRegistrationOrigin,
+    #[schemars(description = "Whether this client has been observed through the MCP runtime boundary")]
+    #[serde(default)]
+    pub runtime_observed: bool,
     #[schemars(description = "Whether current governance state is inherited from default policy")]
     #[serde(default)]
     pub governed_by_default_policy: bool,
@@ -670,9 +676,9 @@ pub struct ClientSettingsUpdateReq {
     #[schemars(description = "Optional display name for active runtime client records")]
     #[serde(default)]
     pub display_name: Option<String>,
-    #[schemars(description = "Runtime connection mode: local_config_detected|remote_http|manual")]
+    #[schemars(description = "Product-facing config file state to persist")]
     #[serde(default)]
-    pub connection_mode: Option<String>,
+    pub config_file_state: Option<ClientConfigFileState>,
     #[schemars(description = "Runtime config path when the client uses a local config target")]
     #[serde(default)]
     pub config_path: Option<String>,
@@ -717,8 +723,11 @@ pub struct ClientSettingsUpdateData {
     pub transport: String,
     #[serde(default)]
     pub client_version: Option<String>,
+    pub config_file_state: ClientConfigFileState,
     #[serde(default)]
-    pub connection_mode: Option<String>,
+    pub registration_origin: ClientRegistrationOrigin,
+    #[serde(default)]
+    pub runtime_observed: bool,
     #[serde(default)]
     pub config_path: Option<String>,
     #[serde(default)]
@@ -750,8 +759,8 @@ pub struct ClientSettingsSourceData {
     pub display_name: String,
     #[schemars(description = "Source for approval_status: provided|stored|default")]
     pub approval_status: String,
-    #[schemars(description = "Source for connection_mode: provided|derived|stored")]
-    pub connection_mode: String,
+    #[schemars(description = "Source for config_file_state: provided|derived|stored")]
+    pub config_file_state: String,
 }
 
 api_resp!(

--- a/backend/src/clients/models.rs
+++ b/backend/src/clients/models.rs
@@ -192,7 +192,6 @@ impl std::error::Error for ParseOnboardingPolicyError {}
 pub enum ClientConnectionMode {
     #[default]
     LocalConfigDetected,
-    RemoteHttp,
     Manual,
 }
 
@@ -200,7 +199,6 @@ impl ClientConnectionMode {
     pub fn as_str(&self) -> &'static str {
         match self {
             ClientConnectionMode::LocalConfigDetected => "local_config_detected",
-            ClientConnectionMode::RemoteHttp => "remote_http",
             ClientConnectionMode::Manual => "manual",
         }
     }
@@ -221,7 +219,6 @@ impl FromStr for ClientConnectionMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "local_config_detected" => Ok(ClientConnectionMode::LocalConfigDetected),
-            "remote_http" => Ok(ClientConnectionMode::RemoteHttp),
             "manual" => Ok(ClientConnectionMode::Manual),
             _ => Err(ParseClientConnectionModeError),
         }
@@ -405,6 +402,87 @@ impl fmt::Display for ParseClientGovernanceKindError {
 
 impl std::error::Error for ParseClientGovernanceKindError {}
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientConfigFileState {
+    WithConfigFile,
+    #[default]
+    WithoutConfigFile,
+}
+
+impl ClientConfigFileState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ClientConfigFileState::WithConfigFile => "with_config_file",
+            ClientConfigFileState::WithoutConfigFile => "without_config_file",
+        }
+    }
+}
+
+impl fmt::Display for ClientConfigFileState {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientRegistrationOrigin {
+    #[default]
+    Manual,
+    ConfigDetection,
+    RuntimeInitialize,
+}
+
+impl ClientRegistrationOrigin {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ClientRegistrationOrigin::Manual => "manual",
+            ClientRegistrationOrigin::ConfigDetection => "config_detection",
+            ClientRegistrationOrigin::RuntimeInitialize => "runtime_initialize",
+        }
+    }
+}
+
+impl fmt::Display for ClientRegistrationOrigin {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for ClientRegistrationOrigin {
+    type Err = ParseClientRegistrationOriginError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "manual" => Ok(ClientRegistrationOrigin::Manual),
+            "config_detection" => Ok(ClientRegistrationOrigin::ConfigDetection),
+            "runtime_initialize" => Ok(ClientRegistrationOrigin::RuntimeInitialize),
+            _ => Err(ParseClientRegistrationOriginError),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseClientRegistrationOriginError;
+
+impl fmt::Display for ParseClientRegistrationOriginError {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "invalid client registration origin")
+    }
+}
+
+impl std::error::Error for ParseClientRegistrationOriginError {}
+
 /// Default governance when a new client identifier is observed (dashboard + MCP proxy).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
@@ -557,13 +635,10 @@ mod tests {
             ClientConnectionMode::LocalConfigDetected
         );
         assert_eq!(
-            ClientConnectionMode::from_str("remote_http").expect("parse remote http"),
-            ClientConnectionMode::RemoteHttp
-        );
-        assert_eq!(
             ClientConnectionMode::from_str("manual").expect("parse manual"),
             ClientConnectionMode::Manual
         );
+        assert!(ClientConnectionMode::from_str("remote_http").is_err());
     }
 
     #[test]

--- a/backend/src/clients/service/core.rs
+++ b/backend/src/clients/service/core.rs
@@ -4,8 +4,9 @@ use crate::clients::engine::TemplateExecutionResult;
 use crate::clients::error::{ConfigError, ConfigResult};
 use crate::clients::models::{
     AttachmentState, BackupPolicySetting, CONFIG_TRANSPORT_PRIORITY, ClientCapabilityConfig, ClientConfigFileParse,
-    ClientConnectionMode, ClientGovernanceKind, ClientRenderDefinition, ClientTemplate, ConfigMapping, ConfigMode,
-    FormatRule, ManagedEndpointConfig, MergeStrategy, ServerTemplateInput, StorageConfig, StorageKind, TemplateFormat,
+    ClientConfigFileState, ClientConnectionMode, ClientGovernanceKind, ClientRegistrationOrigin,
+    ClientRenderDefinition, ClientTemplate, ConfigMapping, ConfigMode, FormatRule, ManagedEndpointConfig,
+    MergeStrategy, ServerTemplateInput, StorageConfig, StorageKind, TemplateFormat,
 };
 #[cfg(test)]
 use crate::clients::source::FileTemplateSource;
@@ -112,6 +113,8 @@ pub struct ClientStateRow {
     pub(super) capability_source: Option<String>,
     pub(super) governance_kind: Option<String>,
     pub(super) connection_mode: Option<String>,
+    pub(super) registration_origin: Option<String>,
+    pub(super) runtime_observed: Option<i64>,
     pub(super) template_identifier: Option<String>,
     pub(super) selected_profile_ids: Option<String>,
     pub(super) custom_profile_id: Option<String>,
@@ -324,6 +327,21 @@ impl ClientStateRow {
             .unwrap_or_default()
     }
 
+    pub fn registration_origin(&self) -> ClientRegistrationOrigin {
+        self.registration_origin
+            .as_deref()
+            .and_then(|value| value.parse::<ClientRegistrationOrigin>().ok())
+            .unwrap_or_else(|| {
+                if self.runtime_observed() {
+                    ClientRegistrationOrigin::RuntimeInitialize
+                } else if self.has_config_file_target() {
+                    ClientRegistrationOrigin::ConfigDetection
+                } else {
+                    ClientRegistrationOrigin::Manual
+                }
+            })
+    }
+
     pub fn display_name(&self) -> &str {
         self.display_name
             .as_deref()
@@ -341,6 +359,22 @@ impl ClientStateRow {
 
     pub fn has_local_config_target(&self) -> bool {
         self.connection_mode() == ClientConnectionMode::LocalConfigDetected && self.config_path().is_some()
+    }
+
+    pub fn has_config_file_target(&self) -> bool {
+        self.config_path().is_some()
+    }
+
+    pub fn config_file_state(&self) -> ClientConfigFileState {
+        if self.has_config_file_target() {
+            ClientConfigFileState::WithConfigFile
+        } else {
+            ClientConfigFileState::WithoutConfigFile
+        }
+    }
+
+    pub fn runtime_observed(&self) -> bool {
+        self.runtime_observed.unwrap_or_default() != 0
     }
 
     #[allow(dead_code)]
@@ -1025,6 +1059,8 @@ impl ClientConfigService {
             capability_source: Some("activated".to_string()),
             governance_kind: Some("passive".to_string()),
             connection_mode: Some("local_config_detected".to_string()),
+            registration_origin: Some("config_detection".to_string()),
+            runtime_observed: Some(0),
             approval_status: Some("pending".to_string()),
             attachment_state: Some("detached".to_string()),
             template_identifier: Some(template.identifier.clone()),

--- a/backend/src/clients/service/list.rs
+++ b/backend/src/clients/service/list.rs
@@ -209,6 +209,7 @@ mod tests {
 
         assert_eq!(fetched_state.identifier, "test.unknown");
         assert_eq!(fetched_state.approval_status.as_deref(), Some("pending"));
+        assert!(!fetched_state.runtime_observed());
     }
 
     #[tokio::test]

--- a/backend/src/clients/service/settings.rs
+++ b/backend/src/clients/service/settings.rs
@@ -1,12 +1,12 @@
 use super::ClientConfigService;
 use crate::clients::error::{ConfigError, ConfigResult};
 use crate::clients::models::{
-    CapabilitySource, ClientCapabilityConfig, ClientCapabilityConfigState, ClientConfigFileParse, ContainerType,
-    FormatRule, UnifyDirectCapabilityIds, UnifyDirectExposureConfig, UnifyDirectExposureDiagnostics,
-    UnifyDirectExposureIntent, UnifyDirectPromptSurface, UnifyDirectPromptSurfaceDiagnostic,
-    UnifyDirectResourceSurface, UnifyDirectResourceSurfaceDiagnostic, UnifyDirectTemplateSurface,
-    UnifyDirectTemplateSurfaceDiagnostic, UnifyDirectToolSurface, UnifyDirectToolSurfaceDiagnostic,
-    canonical_config_transport_key,
+    CapabilitySource, ClientCapabilityConfig, ClientCapabilityConfigState, ClientConfigFileParse,
+    ClientConfigFileState, ContainerType, FormatRule, UnifyDirectCapabilityIds, UnifyDirectExposureConfig,
+    UnifyDirectExposureDiagnostics, UnifyDirectExposureIntent, UnifyDirectPromptSurface,
+    UnifyDirectPromptSurfaceDiagnostic, UnifyDirectResourceSurface, UnifyDirectResourceSurfaceDiagnostic,
+    UnifyDirectTemplateSurface, UnifyDirectTemplateSurfaceDiagnostic, UnifyDirectToolSurface,
+    UnifyDirectToolSurfaceDiagnostic, canonical_config_transport_key,
 };
 use crate::clients::service::core::{ClientStateRow, RuntimeClientMetadata};
 use crate::common::profile::{ProfileRole, ProfileType};
@@ -21,13 +21,27 @@ use std::sync::Arc;
 use tokio::fs::OpenOptions;
 
 const VALID_TRANSPORTS: &[&str] = &["auto", "sse", "stdio", "streamable_http"];
-const VALID_CONNECTION_MODES: &[&str] = &["local_config_detected", "remote_http", "manual"];
 
 fn sanitize_optional(value: Option<&str>) -> Option<String> {
     value
         .map(str::trim)
         .filter(|trimmed| !trimmed.is_empty())
         .map(str::to_string)
+}
+
+fn validate_observed_transport(value: Option<&str>) -> ConfigResult<()> {
+    let Some(transport) = value else {
+        return Ok(());
+    };
+
+    if canonical_config_transport_key(transport).is_some() {
+        return Ok(());
+    }
+
+    Err(ConfigError::DataAccessError(format!(
+        "Invalid observed transport '{}'; expected canonical transport key",
+        transport.trim()
+    )))
 }
 
 #[derive(Debug, Clone, Default)]
@@ -55,7 +69,7 @@ pub struct ActiveClientSettingsUpdate {
     pub config_mode: Option<String>,
     pub transport: Option<String>,
     pub client_version: Option<String>,
-    pub connection_mode: Option<String>,
+    pub config_file_state: Option<ClientConfigFileState>,
     pub config_path: Option<String>,
     pub description: Option<String>,
     pub homepage_url: Option<String>,
@@ -68,13 +82,20 @@ pub struct ActiveClientSettingsUpdate {
     pub clear_transports: bool,
 }
 
+fn config_file_state_to_connection_mode(state: ClientConfigFileState) -> &'static str {
+    match state {
+        ClientConfigFileState::WithConfigFile => "local_config_detected",
+        ClientConfigFileState::WithoutConfigFile => "manual",
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActiveClientSettingsResult {
     pub old_effective_mode: String,
     pub new_effective_mode: String,
     pub display_name_source: &'static str,
     pub approval_status_source: &'static str,
-    pub connection_mode_source: &'static str,
+    pub config_file_state_source: &'static str,
 }
 
 impl ActiveClientSettingsResult {
@@ -158,7 +179,6 @@ impl ClientConfigService {
         observed_name: Option<&str>,
         client_version: Option<&str>,
         transport: Option<&str>,
-        connection_mode: Option<&str>,
         description: Option<&str>,
         homepage_url: Option<&str>,
         logo_url: Option<&str>,
@@ -166,28 +186,15 @@ impl ClientConfigService {
         let display_name = sanitize_optional(observed_name);
         let client_version = sanitize_optional(client_version);
         let transport = sanitize_optional(transport);
-        let connection_mode = sanitize_optional(connection_mode);
         let description = sanitize_optional(description);
         let homepage_url = sanitize_optional(homepage_url);
         let logo_url = sanitize_optional(logo_url);
 
-        if [
-            display_name.as_deref(),
-            client_version.as_deref(),
-            transport.as_deref(),
-            connection_mode.as_deref(),
-            description.as_deref(),
-            homepage_url.as_deref(),
-            logo_url.as_deref(),
-        ]
-        .iter()
-        .all(|value| value.is_none())
-        {
-            return Ok(());
-        }
+        validate_observed_transport(transport.as_deref())?;
 
         let observed_name = display_name.as_deref().unwrap_or(identifier);
         let existing_state = if let Some(state) = self.fetch_state(identifier).await? {
+            self.mark_runtime_observed(identifier).await?;
             if !can_apply_first_initialize_observation(&state)? {
                 return Ok(());
             }
@@ -197,7 +204,7 @@ impl ClientConfigService {
             if self.template_source.get_template(identifier, platform).await?.is_some() {
                 return Ok(());
             }
-            self.ensure_passive_observed_row(identifier, observed_name, None)
+            self.ensure_passive_runtime_observed_row(identifier, observed_name)
                 .await?
         };
 
@@ -211,11 +218,6 @@ impl ClientConfigService {
 
         if let Some(transport) = transport.as_deref() {
             self.update_transport(identifier, transport).await?;
-        }
-
-        if let Some(connection_mode) = connection_mode.as_deref() {
-            self.update_runtime_target(identifier, None, Some(connection_mode), false)
-                .await?;
         }
 
         if description.is_some() || homepage_url.is_some() || logo_url.is_some() {
@@ -320,7 +322,7 @@ impl ClientConfigService {
                 })?;
                 self.validate_existing_config_target(raw_path).await?;
             }
-            Some("manual") | Some("remote_http") => {
+            Some("manual") => {
                 if normalized_path.is_some() {
                     return Err(ConfigError::DataAccessError(
                         "Only clients with a local config target may store a config file path.".to_string(),
@@ -405,7 +407,7 @@ impl ClientConfigService {
             config_mode = ?update.config_mode,
             transport = ?update.transport,
             client_version = ?update.client_version,
-            connection_mode = ?update.connection_mode,
+            config_file_state = ?update.config_file_state,
             config_path = ?update.config_path,
             clear_config_file_parse = %update.clear_config_file_parse,
             "set_active_client_settings: entry"
@@ -419,18 +421,6 @@ impl ClientConfigService {
                     VALID_TRANSPORTS.join(", ")
                 );
                 tracing::error!(client = %identifier, transport = %tr, "{}", err);
-                return Err(ConfigError::DataAccessError(err));
-            }
-        }
-
-        if let Some(ref mode) = update.connection_mode {
-            if !VALID_CONNECTION_MODES.contains(&mode.as_str()) {
-                let err = format!(
-                    "Invalid connection_mode value '{}', must be one of: {}",
-                    mode,
-                    VALID_CONNECTION_MODES.join(", ")
-                );
-                tracing::error!(client = %identifier, connection_mode = %mode, "{}", err);
                 return Err(ConfigError::DataAccessError(err));
             }
         }
@@ -454,10 +444,16 @@ impl ClientConfigService {
 
         let raw_config_path = update.config_path.as_deref().map(str::trim);
         let normalized_config_path = raw_config_path.filter(|value| !value.is_empty()).map(str::to_string);
+        let clear_config_artifacts = matches!(update.config_file_state, Some(ClientConfigFileState::WithoutConfigFile));
+        let clear_config_file_parse = update.clear_config_file_parse || clear_config_artifacts;
+        let clear_transports = update.clear_transports || clear_config_artifacts;
 
-        let (resolved_connection_mode, connection_mode_source): (Option<String>, &'static str) =
-            if let Some(mode) = update.connection_mode.clone() {
-                (Some(mode), "provided")
+        let (resolved_connection_mode, config_file_state_source): (Option<String>, &'static str) =
+            if let Some(state) = update.config_file_state {
+                (
+                    Some(config_file_state_to_connection_mode(state).to_string()),
+                    "provided",
+                )
             } else {
                 match raw_config_path {
                     Some("") => (Some("manual".to_string()), "derived"),
@@ -471,7 +467,7 @@ impl ClientConfigService {
 
         let effective_parse_for_validation = match existing_state.as_ref() {
             Some(state) => state
-                .effective_config_file_parse_with(update.config_file_parse.as_ref(), update.clear_config_file_parse)?
+                .effective_config_file_parse_with(update.config_file_parse.as_ref(), clear_config_file_parse)?
                 .or_else(|| update.config_file_parse.clone()),
             None => update.config_file_parse.clone(),
         };
@@ -479,9 +475,7 @@ impl ClientConfigService {
             .as_deref()
             .or_else(|| existing_state.as_ref().and_then(|state| state.config_path()));
 
-        if !update.clear_config_file_parse
-            && matches!(resolved_connection_mode.as_deref(), Some("local_config_detected"))
-        {
+        if !clear_config_file_parse && matches!(resolved_connection_mode.as_deref(), Some("local_config_detected")) {
             if let (Some(path), Some(parse)) = (validation_path, effective_parse_for_validation.as_ref()) {
                 self.validate_config_file_parse_rule(path, parse).await?;
             }
@@ -556,17 +550,15 @@ impl ClientConfigService {
                 .await?;
         }
 
-        if update.clear_config_file_parse || update.config_file_parse.is_some() {
-            self.update_config_file_parse(
-                identifier,
-                update.config_file_parse.as_ref(),
-                update.clear_config_file_parse,
-            )
-            .await?;
+        if clear_config_artifacts {
+            self.clear_config_file_artifacts(identifier).await?;
+        } else if clear_config_file_parse || update.config_file_parse.is_some() {
+            self.update_config_file_parse(identifier, update.config_file_parse.as_ref(), clear_config_file_parse)
+                .await?;
         }
 
-        if update.clear_transports || update.transports.is_some() {
-            self.update_transports(identifier, update.transports.as_ref(), update.clear_transports)
+        if !clear_config_artifacts && (clear_transports || update.transports.is_some()) {
+            self.update_transports(identifier, update.transports.as_ref(), clear_transports)
                 .await?;
         }
 
@@ -582,7 +574,7 @@ impl ClientConfigService {
             new_effective_mode,
             display_name_source,
             approval_status_source,
-            connection_mode_source,
+            config_file_state_source,
         })
     }
 
@@ -715,7 +707,7 @@ impl ClientConfigService {
             UPDATE client
             SET config_path = CASE
                     WHEN ? IS NOT NULL THEN NULLIF(?, '')
-                    WHEN ? IN ('manual', 'remote_http') THEN NULL
+                    WHEN ? = 'manual' THEN NULL
                     ELSE NULLIF(?, '')
                 END,
                 connection_mode = CASE
@@ -832,6 +824,30 @@ impl ClientConfigService {
         .bind(config_format)
         .bind(container_type)
         .bind(container_keys)
+        .bind(identifier)
+        .execute(&*self.db_pool)
+        .await
+        .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn clear_config_file_artifacts(
+        &self,
+        identifier: &str,
+    ) -> ConfigResult<()> {
+        sqlx::query(
+            r#"
+            UPDATE client
+            SET config_file_parse = NULL,
+                config_format = NULL,
+                container_type = NULL,
+                container_keys = NULL,
+                transports = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE identifier = ?
+            "#,
+        )
         .bind(identifier)
         .execute(&*self.db_pool)
         .await

--- a/backend/src/clients/service/state.rs
+++ b/backend/src/clients/service/state.rs
@@ -1,7 +1,8 @@
 use super::core::{ClientConfigService, ClientStateRow, PersistedTemplateConfig};
 use crate::clients::error::{ConfigError, ConfigResult};
 use crate::clients::models::{
-    AttachmentState, BackupPolicySetting, ClientConnectionMode, ClientGovernanceKind, FirstContactBehavior,
+    AttachmentState, BackupPolicySetting, ClientConnectionMode, ClientGovernanceKind, ClientRegistrationOrigin,
+    FirstContactBehavior,
 };
 use std::collections::HashMap;
 
@@ -16,7 +17,7 @@ fn approval_status_for_first_contact_behavior(behavior: FirstContactBehavior) ->
 impl ClientConfigService {
     pub(super) async fn fetch_client_states(&self) -> ConfigResult<HashMap<String, ClientStateRow>> {
         let rows = sqlx::query_as::<_, ClientStateRow>(
-            "SELECT id, identifier, name, display_name, config_path, config_mode, transport, client_version, backup_policy, backup_limit, capability_source, governance_kind, connection_mode, template_identifier, selected_profile_ids, custom_profile_id, unify_direct_exposure_intent, approval_status, attachment_state, template_id, template_version, approval_metadata, config_format, protocol_revision, container_type, container_keys, storage_kind, storage_adapter, storage_path_strategy, merge_strategy, keep_original_config, managed_source, transports, config_file_parse FROM client",
+            "SELECT id, identifier, name, display_name, config_path, config_mode, transport, client_version, backup_policy, backup_limit, capability_source, governance_kind, connection_mode, registration_origin, runtime_observed, template_identifier, selected_profile_ids, custom_profile_id, unify_direct_exposure_intent, approval_status, attachment_state, template_id, template_version, approval_metadata, config_format, protocol_revision, container_type, container_keys, storage_kind, storage_adapter, storage_path_strategy, merge_strategy, keep_original_config, managed_source, transports, config_file_parse FROM client",
         )
         .fetch_all(&*self.db_pool)
         .await
@@ -45,8 +46,16 @@ impl ClientConfigService {
         let first_contact_behavior = self.get_first_contact_behavior().await?;
         let approval_status = approval_status_for_first_contact_behavior(first_contact_behavior);
 
-        self.create_state_row(identifier, name, ClientGovernanceKind::Passive, approval_status, None)
-            .await
+        self.create_state_row(
+            identifier,
+            name,
+            ClientGovernanceKind::Passive,
+            approval_status,
+            None,
+            ClientRegistrationOrigin::Manual,
+            false,
+        )
+        .await
     }
 
     pub async fn fetch_state(
@@ -54,7 +63,7 @@ impl ClientConfigService {
         identifier: &str,
     ) -> ConfigResult<Option<ClientStateRow>> {
         sqlx::query_as::<_, ClientStateRow>(
-            "SELECT id, identifier, name, display_name, config_path, config_mode, transport, client_version, backup_policy, backup_limit, capability_source, governance_kind, connection_mode, template_identifier, selected_profile_ids, custom_profile_id, unify_direct_exposure_intent, approval_status, attachment_state, template_id, template_version, approval_metadata, config_format, protocol_revision, container_type, container_keys, storage_kind, storage_adapter, storage_path_strategy, merge_strategy, keep_original_config, managed_source, transports, config_file_parse FROM client WHERE identifier = ?",
+            "SELECT id, identifier, name, display_name, config_path, config_mode, transport, client_version, backup_policy, backup_limit, capability_source, governance_kind, connection_mode, registration_origin, runtime_observed, template_identifier, selected_profile_ids, custom_profile_id, unify_direct_exposure_intent, approval_status, attachment_state, template_id, template_version, approval_metadata, config_format, protocol_revision, container_type, container_keys, storage_kind, storage_adapter, storage_path_strategy, merge_strategy, keep_original_config, managed_source, transports, config_file_parse FROM client WHERE identifier = ?",
         )
         .bind(identifier)
         .fetch_optional(&*self.db_pool)
@@ -320,7 +329,7 @@ impl ClientConfigService {
         Ok(())
     }
 
-    /// Used by detection/list and by the MCP proxy when registering an unknown client under `review` policy.
+    /// Used by detection/list when registering a client candidate discovered from local configuration metadata.
     pub async fn ensure_passive_observed_row(
         &self,
         identifier: &str,
@@ -339,6 +348,40 @@ impl ClientConfigService {
             ClientGovernanceKind::Passive,
             approval_status,
             config_path,
+            if config_path.is_some() {
+                ClientRegistrationOrigin::ConfigDetection
+            } else {
+                ClientRegistrationOrigin::Manual
+            },
+            false,
+        )
+        .await
+    }
+
+    /// Used by the MCP proxy when an unknown client reaches MCPMate through the runtime boundary.
+    pub async fn ensure_passive_runtime_observed_row(
+        &self,
+        identifier: &str,
+        name: &str,
+    ) -> ConfigResult<ClientStateRow> {
+        if let Some(existing) = self.fetch_state(identifier).await? {
+            self.refresh_existing_state_name(identifier, name, existing).await?;
+            self.mark_runtime_observed(identifier).await?;
+            return self.fetch_state(identifier).await?.ok_or_else(|| {
+                ConfigError::DataAccessError(format!("Failed to reload runtime-observed client {}", identifier))
+            });
+        }
+        let first_contact_behavior = self.get_first_contact_behavior().await?;
+        let approval_status = approval_status_for_first_contact_behavior(first_contact_behavior);
+
+        self.create_state_row(
+            identifier,
+            name,
+            ClientGovernanceKind::Passive,
+            approval_status,
+            None,
+            ClientRegistrationOrigin::RuntimeInitialize,
+            true,
         )
         .await
     }
@@ -349,7 +392,7 @@ impl ClientConfigService {
         name: &str,
     ) -> ConfigResult<ClientStateRow> {
         let Some(existing) = self.fetch_state(identifier).await? else {
-            return self.ensure_passive_observed_row(identifier, name, None).await;
+            return self.ensure_passive_runtime_observed_row(identifier, name).await;
         };
 
         if existing.governance_kind() != ClientGovernanceKind::Passive {
@@ -359,6 +402,7 @@ impl ClientConfigService {
         let first_contact_behavior = self.get_first_contact_behavior().await?;
         let approval_status = approval_status_for_first_contact_behavior(first_contact_behavior);
         self.refresh_existing_state_name(identifier, name, existing).await?;
+        self.mark_runtime_observed(identifier).await?;
 
         sqlx::query(
             r#"
@@ -397,9 +441,38 @@ impl ClientConfigService {
                 ClientGovernanceKind::Active,
                 approval_status.unwrap_or("approved"),
                 None,
+                ClientRegistrationOrigin::Manual,
+                false,
             )
             .await
         }
+    }
+
+    pub(crate) async fn mark_runtime_observed(
+        &self,
+        identifier: &str,
+    ) -> ConfigResult<()> {
+        sqlx::query(
+            r#"
+            UPDATE client
+            SET runtime_observed = 1,
+                registration_origin = CASE
+                    WHEN registration_origin IS NULL
+                        OR registration_origin = ''
+                        OR (registration_origin = 'manual' AND governance_kind = 'passive')
+                    THEN 'runtime_initialize'
+                    ELSE registration_origin
+                END,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE identifier = ?
+            "#,
+        )
+        .bind(identifier)
+        .execute(&*self.db_pool)
+        .await
+        .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
+
+        Ok(())
     }
 
     async fn refresh_existing_state_name(
@@ -468,6 +541,8 @@ impl ClientConfigService {
         governance_kind: ClientGovernanceKind,
         approval_status: &str,
         observed_config_path: Option<&str>,
+        registration_origin: ClientRegistrationOrigin,
+        runtime_observed: bool,
     ) -> ConfigResult<ClientStateRow> {
         let platform = crate::system::paths::PathService::get_current_platform();
         let template = self.template_source.get_template(identifier, platform).await?;
@@ -501,12 +576,12 @@ impl ClientConfigService {
             r#"
             INSERT INTO client (
                 id, name, display_name, identifier, config_path, backup_policy, backup_limit,
-                approval_status, governance_kind, connection_mode, template_identifier,
+                approval_status, governance_kind, connection_mode, registration_origin, runtime_observed, template_identifier,
                 config_format, protocol_revision, container_type, container_keys,
                 storage_kind, storage_adapter, storage_path_strategy,
                 merge_strategy, keep_original_config, managed_source, transports, config_file_parse, attachment_state
             )
-            VALUES (?, ?, ?, ?, ?, 'keep_n', 5, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, 'keep_n', 5, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(&generated_id)
@@ -517,6 +592,8 @@ impl ClientConfigService {
         .bind(approval_status)
         .bind(governance_kind.as_str())
         .bind(connection_mode)
+        .bind(registration_origin.as_str())
+        .bind(if runtime_observed { 1_i64 } else { 0_i64 })
         .bind(template_identifier)
         .bind(persisted_config.config_format)
         .bind(persisted_config.protocol_revision)
@@ -729,6 +806,11 @@ mod tests {
             .expect("reapply allow policy");
         assert_eq!(approved.approval_status(), "approved");
         assert_eq!(approved.governance_kind(), ClientGovernanceKind::Passive);
+        assert!(approved.runtime_observed());
+        assert_eq!(
+            approved.registration_origin(),
+            ClientRegistrationOrigin::RuntimeInitialize
+        );
 
         set_onboarding_policy(&service, OnboardingPolicy::Manual)
             .await
@@ -739,6 +821,7 @@ mod tests {
             .expect("reapply deny policy");
         assert_eq!(suspended.approval_status(), "suspended");
         assert_eq!(suspended.governance_kind(), ClientGovernanceKind::Passive);
+        assert!(suspended.runtime_observed());
     }
 
     #[tokio::test]
@@ -826,7 +909,6 @@ mod tests {
                 Some("Observed App"),
                 Some("1.2.3"),
                 Some("streamable_http"),
-                Some("remote_http"),
                 Some("Observed description"),
                 Some("https://example.com"),
                 Some("https://example.com/logo.png"),
@@ -840,7 +922,6 @@ mod tests {
                 Some("Changed App"),
                 Some("9.9.9"),
                 Some("sse"),
-                Some("remote_http"),
                 Some("Changed description"),
                 Some("https://changed.example.com"),
                 Some("https://changed.example.com/logo.png"),
@@ -858,7 +939,9 @@ mod tests {
         assert_eq!(state.display_name.as_deref(), Some("Observed App"));
         assert_eq!(state.client_version.as_deref(), Some("1.2.3"));
         assert_eq!(state.transport.as_deref(), Some("streamable_http"));
-        assert_eq!(state.connection_mode.as_deref(), Some("remote_http"));
+        assert_eq!(state.connection_mode.as_deref(), Some("manual"));
+        assert!(state.runtime_observed());
+        assert_eq!(state.registration_origin(), ClientRegistrationOrigin::RuntimeInitialize);
 
         let metadata = state.runtime_client_metadata();
         assert_eq!(metadata.description.as_deref(), Some("Observed description"));
@@ -899,7 +982,6 @@ mod tests {
                 Some("Changed Template"),
                 Some("9.9.9"),
                 Some("streamable_http"),
-                Some("remote_http"),
                 Some("Changed description"),
                 Some("https://changed.example.com"),
                 Some("https://changed.example.com/logo.png"),
@@ -925,6 +1007,11 @@ mod tests {
             .ensure_passive_observed_row("test.observed", "Observed", None)
             .await
             .expect("create passive observed row");
+        let before = service
+            .fetch_state("test.observed")
+            .await
+            .expect("fetch initial state")
+            .expect("state exists");
 
         let error = service
             .persist_handshake_observation(
@@ -932,7 +1019,6 @@ mod tests {
                 Some("Observed App"),
                 Some("1.2.3"),
                 Some("http"),
-                Some("remote_http"),
                 Some("Observed description"),
                 Some("https://example.com"),
                 Some("https://example.com/logo.png"),
@@ -945,6 +1031,41 @@ mod tests {
             message.contains("Invalid") || message.contains("transport"),
             "unexpected error: {message}"
         );
+
+        let state = service
+            .fetch_state("test.observed")
+            .await
+            .expect("fetch state")
+            .expect("state exists");
+        assert_eq!(state.display_name, before.display_name);
+        assert_eq!(state.client_version, before.client_version);
+        assert_eq!(state.transport, before.transport);
+        assert_eq!(state.runtime_client_metadata(), before.runtime_client_metadata());
+        assert_eq!(state.runtime_observed(), before.runtime_observed());
+    }
+
+    #[tokio::test]
+    async fn handshake_observation_without_metadata_still_marks_runtime_observed() {
+        let (_temp_dir, service) = create_test_service().await;
+
+        service
+            .ensure_passive_observed_row("test.empty-observed", "Empty Observed", None)
+            .await
+            .expect("create passive observed row");
+
+        service
+            .persist_handshake_observation("test.empty-observed", None, None, None, None, None, None)
+            .await
+            .expect("persist empty handshake observation");
+
+        let state = service
+            .fetch_state("test.empty-observed")
+            .await
+            .expect("fetch state")
+            .expect("state exists");
+        assert!(state.runtime_observed());
+        assert_eq!(state.registration_origin(), ClientRegistrationOrigin::RuntimeInitialize);
+        assert_eq!(state.display_name(), "Empty Observed");
     }
 
     #[tokio::test]

--- a/backend/src/config/client/init.rs
+++ b/backend/src/config/client/init.rs
@@ -9,6 +9,7 @@ const DEFAULT_BACKUP_LIMIT: i64 = 5;
 const DEFAULT_CAPABILITY_SOURCE: &str = "activated";
 const DEFAULT_CONNECTION_MODE: &str = "local_config_detected";
 const DEFAULT_GOVERNANCE_KIND: &str = "passive";
+const DEFAULT_REGISTRATION_ORIGIN: &str = "manual";
 pub(crate) const CLIENT_RUNTIME_SETTINGS_TABLE: &str = "client_runtime_settings";
 pub(crate) const CLIENT_TEMPLATE_RUNTIME_TABLE: &str = "client_template_runtime";
 pub(crate) const DEFAULT_CONFIG_MODE_SETTING_KEY: &str = "default_config_mode";
@@ -49,8 +50,12 @@ pub async fn initialize_client_table(pool: &Pool<Sqlite>) -> Result<()> {
                 governance_kind IN ('passive', 'active')
             ),
             connection_mode TEXT NOT NULL DEFAULT '{default_connection_mode}' CHECK (
-                connection_mode IN ('local_config_detected', 'remote_http', 'manual')
+                connection_mode IN ('local_config_detected', 'manual')
             ),
+            registration_origin TEXT NOT NULL DEFAULT '{default_registration_origin}' CHECK (
+                registration_origin IN ('manual', 'config_detection', 'runtime_initialize')
+            ),
+            runtime_observed INTEGER NOT NULL DEFAULT 0 CHECK (runtime_observed IN (0, 1)),
             template_identifier TEXT,
             selected_profile_ids TEXT,
             custom_profile_id TEXT,
@@ -71,6 +76,7 @@ pub async fn initialize_client_table(pool: &Pool<Sqlite>) -> Result<()> {
         default_capability_source = DEFAULT_CAPABILITY_SOURCE,
         default_governance_kind = DEFAULT_GOVERNANCE_KIND,
         default_connection_mode = DEFAULT_CONNECTION_MODE,
+        default_registration_origin = DEFAULT_REGISTRATION_ORIGIN,
     ))
     .execute(pool)
     .await
@@ -102,7 +108,21 @@ pub async fn initialize_client_table(pool: &Pool<Sqlite>) -> Result<()> {
         pool,
         tables::CLIENT,
         "connection_mode",
-        "TEXT NOT NULL DEFAULT 'local_config_detected' CHECK (connection_mode IN ('local_config_detected', 'remote_http', 'manual'))",
+        "TEXT NOT NULL DEFAULT 'local_config_detected' CHECK (connection_mode IN ('local_config_detected', 'manual'))",
+    )
+    .await?;
+    ensure_column(
+        pool,
+        tables::CLIENT,
+        "registration_origin",
+        "TEXT NOT NULL DEFAULT 'manual' CHECK (registration_origin IN ('manual', 'config_detection', 'runtime_initialize'))",
+    )
+    .await?;
+    ensure_column(
+        pool,
+        tables::CLIENT,
+        "runtime_observed",
+        "INTEGER NOT NULL DEFAULT 0 CHECK (runtime_observed IN (0, 1))",
     )
     .await?;
     ensure_column(pool, tables::CLIENT, "template_identifier", "TEXT").await?;
@@ -267,18 +287,40 @@ WHEN backup_limit IS NOT NULL AND backup_limit <> {default_backup_limit} THEN 'a
     })?;
 
     sqlx::query(&format!(
-        "UPDATE {table} SET connection_mode = ? WHERE connection_mode IS NULL OR connection_mode = ''",
-        table = tables::CLIENT
+        "UPDATE {table} SET \
+            runtime_observed = CASE \
+                WHEN connection_mode = 'remote_http' THEN 1 \
+                ELSE COALESCE(runtime_observed, 0) \
+            END, \
+            registration_origin = CASE \
+                WHEN connection_mode = 'remote_http' THEN 'runtime_initialize' \
+                WHEN registration_origin IS NULL OR registration_origin = '' OR registration_origin = ? THEN \
+                    CASE \
+                        WHEN COALESCE(runtime_observed, 0) = 1 THEN 'runtime_initialize' \
+                        WHEN config_path IS NOT NULL AND TRIM(config_path) <> '' THEN 'config_detection' \
+                        ELSE ? \
+                    END \
+                ELSE registration_origin \
+            END, \
+            connection_mode = CASE \
+                WHEN connection_mode = 'local_config_detected' \
+                    AND config_path IS NOT NULL \
+                    AND TRIM(config_path) <> '' \
+                THEN 'local_config_detected' \
+                ELSE 'manual' \
+            END",
+        table = tables::CLIENT,
     ))
-    .bind(DEFAULT_CONNECTION_MODE)
+    .bind(DEFAULT_REGISTRATION_ORIGIN)
+    .bind(DEFAULT_REGISTRATION_ORIGIN)
     .execute(pool)
     .await
     .map_err(|e| {
-        tracing::error!("Failed to backfill {} connection_mode: {}", tables::CLIENT, e);
-        anyhow::anyhow!("Failed to backfill {} connection_mode: {}", tables::CLIENT, e)
+        tracing::error!("Failed to normalize {} connection state: {}", tables::CLIENT, e);
+        anyhow::anyhow!("Failed to normalize {} connection state: {}", tables::CLIENT, e)
     })?;
 
-    migrate_client_table_for_sse_transport(pool).await?;
+    migrate_client_table_constraints(pool).await?;
 
     tracing::debug!("{} table initialized", tables::CLIENT);
     Ok(())
@@ -413,7 +455,7 @@ async fn migrate_client_table_for_optional_config_mode(pool: &Pool<Sqlite>) -> R
     }
 }
 
-async fn migrate_client_table_for_sse_transport(pool: &Pool<Sqlite>) -> Result<()> {
+async fn migrate_client_table_constraints(pool: &Pool<Sqlite>) -> Result<()> {
     let create_sql: Option<String> = sqlx::query_scalar(&format!(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='{}'",
         tables::CLIENT
@@ -425,15 +467,24 @@ async fn migrate_client_table_for_sse_transport(pool: &Pool<Sqlite>) -> Result<(
         return Ok(());
     };
 
-    if !create_sql.contains("transport IN ('auto', 'stdio', 'streamable_http')") {
+    let needs_sse_transport = create_sql.contains("transport IN ('auto', 'stdio', 'streamable_http')");
+    let needs_connection_mode_cleanup = create_sql.contains("'remote_http'");
+
+    if !needs_sse_transport && !needs_connection_mode_cleanup {
         return Ok(());
     }
 
-    tracing::info!("Migrating {} transport constraint to include sse", tables::CLIENT);
+    tracing::info!("Migrating {} client table constraints", tables::CLIENT);
+
+    let transports_source_expression = if column_exists(pool, tables::CLIENT, "format_rules").await? {
+        "COALESCE(NULLIF(transports, ''), format_rules)"
+    } else {
+        "transports"
+    };
 
     let migration_result = async {
         let mut tx = pool.begin().await?;
-        let temp_table = format!("{}_transport_with_sse", tables::CLIENT);
+        let temp_table = format!("{}_constraints_current", tables::CLIENT);
 
         sqlx::query(&format!(
             r#"
@@ -459,8 +510,12 @@ async fn migrate_client_table_for_sse_transport(pool: &Pool<Sqlite>) -> Result<(
                     governance_kind IN ('passive', 'active')
                 ),
                 connection_mode TEXT NOT NULL DEFAULT '{default_connection_mode}' CHECK (
-                    connection_mode IN ('local_config_detected', 'remote_http', 'manual')
+                    connection_mode IN ('local_config_detected', 'manual')
                 ),
+                registration_origin TEXT NOT NULL DEFAULT '{default_registration_origin}' CHECK (
+                    registration_origin IN ('manual', 'config_detection', 'runtime_initialize')
+                ),
+                runtime_observed INTEGER NOT NULL DEFAULT 0 CHECK (runtime_observed IN (0, 1)),
                 template_identifier TEXT,
                 selected_profile_ids TEXT,
                 custom_profile_id TEXT,
@@ -496,6 +551,7 @@ async fn migrate_client_table_for_sse_transport(pool: &Pool<Sqlite>) -> Result<(
             default_capability_source = DEFAULT_CAPABILITY_SOURCE,
             default_governance_kind = DEFAULT_GOVERNANCE_KIND,
             default_connection_mode = DEFAULT_CONNECTION_MODE,
+            default_registration_origin = DEFAULT_REGISTRATION_ORIGIN,
         ))
         .execute(&mut *tx)
         .await?;
@@ -505,7 +561,8 @@ async fn migrate_client_table_for_sse_transport(pool: &Pool<Sqlite>) -> Result<(
             INSERT INTO {temp_table} (
                 id, name, display_name, identifier, config_path, config_mode, transport,
                 client_version, backup_policy, backup_limit, capability_source, governance_kind,
-                connection_mode, template_identifier, selected_profile_ids, custom_profile_id,
+                connection_mode, registration_origin, runtime_observed,
+                template_identifier, selected_profile_ids, custom_profile_id,
                 unify_direct_exposure_intent,
                 approval_status, template_id, template_version, approval_metadata, config_format, protocol_revision,
                 container_type, container_keys, storage_kind, storage_adapter, storage_path_strategy,
@@ -516,17 +573,33 @@ async fn migrate_client_table_for_sse_transport(pool: &Pool<Sqlite>) -> Result<(
             SELECT
                 id, name, display_name, identifier, config_path, config_mode, transport,
                 client_version, backup_policy, backup_limit, capability_source, governance_kind,
-                connection_mode, template_identifier, selected_profile_ids, custom_profile_id,
+                CASE
+                    WHEN connection_mode = 'local_config_detected'
+                        AND config_path IS NOT NULL
+                        AND TRIM(config_path) <> ''
+                    THEN 'local_config_detected'
+                    ELSE 'manual'
+                END,
+                CASE
+                    WHEN connection_mode = 'remote_http' THEN 'runtime_initialize'
+                    ELSE registration_origin
+                END,
+                CASE
+                    WHEN connection_mode = 'remote_http' THEN 1
+                    ELSE runtime_observed
+                END,
+                template_identifier, selected_profile_ids, custom_profile_id,
                 unify_direct_exposure_intent,
                 approval_status, template_id, template_version, approval_metadata, config_format, protocol_revision,
                 container_type, container_keys, storage_kind, storage_adapter, storage_path_strategy,
-                merge_strategy, keep_original_config, managed_source, format_rules, config_file_parse,
+                merge_strategy, keep_original_config, managed_source, {transports_source_expression}, config_file_parse,
                 attachment_state,
                 created_at, updated_at
             FROM {table}
             "#,
             temp_table = temp_table,
             table = tables::CLIENT,
+            transports_source_expression = transports_source_expression,
         ))
         .execute(&mut *tx)
         .await?;
@@ -583,6 +656,22 @@ async fn ensure_column(
     }
 }
 
+async fn column_exists(
+    pool: &Pool<Sqlite>,
+    table: &str,
+    column: &str,
+) -> Result<bool> {
+    let rows: Vec<String> = sqlx::query_scalar(&format!(
+        "SELECT name FROM pragma_table_info('{}')",
+        table.replace('\'', "''")
+    ))
+    .fetch_all(pool)
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to inspect {} columns: {}", table, e))?;
+
+    Ok(rows.into_iter().any(|name| name == column))
+}
+
 /// Ensures the on-disk system settings store exists (JSON). Does not create or touch any SQLite
 /// `system_settings` table; schema changes for existing installs are handled out-of-band.
 pub async fn initialize_system_settings(pool: &Pool<Sqlite>) -> Result<()> {
@@ -600,14 +689,19 @@ mod tests {
         set_default_client_config_mode,
     };
     use crate::clients::models::FirstContactBehavior;
+    use crate::common::constants::database::tables;
     use sqlx::sqlite::SqlitePoolOptions;
 
-    async fn setup_pool() -> sqlx::Pool<sqlx::Sqlite> {
-        let pool = SqlitePoolOptions::new()
+    async fn setup_raw_pool() -> sqlx::Pool<sqlx::Sqlite> {
+        SqlitePoolOptions::new()
             .max_connections(1)
             .connect("sqlite::memory:")
             .await
-            .expect("failed to create sqlite pool");
+            .expect("failed to create sqlite pool")
+    }
+
+    async fn setup_pool() -> sqlx::Pool<sqlx::Sqlite> {
+        let pool = setup_raw_pool().await;
 
         initialize_client_table(&pool)
             .await
@@ -668,5 +762,144 @@ mod tests {
         assert_eq!(settings.mcp_port, crate::common::constants::ports::MCP_PORT);
         assert_eq!(settings.inspector_timeout_ms, 8_000);
         assert_eq!(settings.default_config_mode, "unify");
+    }
+
+    #[tokio::test]
+    async fn initialize_client_table_normalizes_legacy_remote_http_rows() {
+        let pool = setup_raw_pool().await;
+
+        sqlx::query(&format!(
+            r#"
+            CREATE TABLE {table} (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                identifier TEXT NOT NULL UNIQUE,
+                config_mode TEXT CHECK (config_mode IN ('unify','hosted','transparent')),
+                transport TEXT NOT NULL DEFAULT 'auto' CHECK (
+                    transport IN ('auto', 'sse', 'stdio', 'streamable_http')
+                ),
+                client_version TEXT,
+                backup_policy TEXT NOT NULL DEFAULT 'keep_n' CHECK (
+                    backup_policy IN ('keep_last', 'keep_n', 'off')
+                ),
+                backup_limit INTEGER DEFAULT 5,
+                connection_mode TEXT NOT NULL DEFAULT 'local_config_detected' CHECK (
+                    connection_mode IN ('local_config_detected', 'remote_http', 'manual')
+                ),
+                registration_origin TEXT NOT NULL DEFAULT 'manual' CHECK (
+                    registration_origin IN ('manual', 'config_detection', 'runtime_initialize')
+                ),
+                runtime_observed INTEGER NOT NULL DEFAULT 0 CHECK (runtime_observed IN (0, 1)),
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+            table = tables::CLIENT,
+        ))
+        .execute(&pool)
+        .await
+        .expect("create legacy client table");
+
+        sqlx::query(&format!(
+            "INSERT INTO {table} (id, name, identifier, connection_mode) VALUES (?, ?, ?, ?)",
+            table = tables::CLIENT,
+        ))
+        .bind("client_legacy")
+        .bind("Legacy Runtime")
+        .bind("legacy.runtime")
+        .bind("remote_http")
+        .execute(&pool)
+        .await
+        .expect("insert legacy remote_http row");
+
+        initialize_client_table(&pool).await.expect("initialize client table");
+
+        let (connection_mode, registration_origin, runtime_observed): (String, String, i64) = sqlx::query_as(&format!(
+            "SELECT connection_mode, registration_origin, runtime_observed FROM {table} WHERE identifier = ?",
+            table = tables::CLIENT,
+        ))
+        .bind("legacy.runtime")
+        .fetch_one(&pool)
+        .await
+        .expect("fetch normalized row");
+
+        assert_eq!(connection_mode, "manual");
+        assert_eq!(registration_origin, "runtime_initialize");
+        assert_eq!(runtime_observed, 1);
+
+        let create_sql: String = sqlx::query_scalar(&format!(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='{}'",
+            tables::CLIENT,
+        ))
+        .fetch_one(&pool)
+        .await
+        .expect("fetch normalized schema");
+
+        assert!(!create_sql.contains("'remote_http'"));
+    }
+
+    #[tokio::test]
+    async fn initialize_client_table_preserves_legacy_format_rules_during_constraint_rebuild() {
+        let pool = setup_raw_pool().await;
+
+        sqlx::query(&format!(
+            r#"
+            CREATE TABLE {table} (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                identifier TEXT NOT NULL UNIQUE,
+                config_mode TEXT CHECK (config_mode IN ('unify','hosted','transparent')),
+                transport TEXT NOT NULL DEFAULT 'auto' CHECK (
+                    transport IN ('auto', 'sse', 'stdio', 'streamable_http')
+                ),
+                client_version TEXT,
+                backup_policy TEXT NOT NULL DEFAULT 'keep_n' CHECK (
+                    backup_policy IN ('keep_last', 'keep_n', 'off')
+                ),
+                backup_limit INTEGER DEFAULT 5,
+                connection_mode TEXT NOT NULL DEFAULT 'local_config_detected' CHECK (
+                    connection_mode IN ('local_config_detected', 'remote_http', 'manual')
+                ),
+                registration_origin TEXT NOT NULL DEFAULT 'manual' CHECK (
+                    registration_origin IN ('manual', 'config_detection', 'runtime_initialize')
+                ),
+                runtime_observed INTEGER NOT NULL DEFAULT 0 CHECK (runtime_observed IN (0, 1)),
+                format_rules TEXT,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+            table = tables::CLIENT,
+        ))
+        .execute(&pool)
+        .await
+        .expect("create legacy client table");
+
+        let legacy_format_rules = r#"{"stdio":{"command_field":"command","args_field":"args","env_field":"env"}}"#;
+        sqlx::query(&format!(
+            "INSERT INTO {table} (id, name, identifier, connection_mode, format_rules) VALUES (?, ?, ?, ?, ?)",
+            table = tables::CLIENT,
+        ))
+        .bind("client_legacy_rules")
+        .bind("Legacy Format Rules")
+        .bind("legacy.rules")
+        .bind("manual")
+        .bind(legacy_format_rules)
+        .execute(&pool)
+        .await
+        .expect("insert legacy format rules row");
+
+        initialize_client_table(&pool).await.expect("initialize client table");
+
+        let transports: String = sqlx::query_scalar(&format!(
+            "SELECT transports FROM {table} WHERE identifier = ?",
+            table = tables::CLIENT,
+        ))
+        .bind("legacy.rules")
+        .fetch_one(&pool)
+        .await
+        .expect("fetch migrated transports");
+
+        assert_eq!(transports, legacy_format_rules);
     }
 }

--- a/backend/src/config/client/init.rs
+++ b/backend/src/config/client/init.rs
@@ -303,9 +303,7 @@ WHEN backup_limit IS NOT NULL AND backup_limit <> {default_backup_limit} THEN 'a
                 ELSE registration_origin \
             END, \
             connection_mode = CASE \
-                WHEN connection_mode = 'local_config_detected' \
-                    AND config_path IS NOT NULL \
-                    AND TRIM(config_path) <> '' \
+                WHEN config_path IS NOT NULL AND TRIM(config_path) <> '' \
                 THEN 'local_config_detected' \
                 ELSE 'manual' \
             END",
@@ -574,9 +572,7 @@ async fn migrate_client_table_constraints(pool: &Pool<Sqlite>) -> Result<()> {
                 id, name, display_name, identifier, config_path, config_mode, transport,
                 client_version, backup_policy, backup_limit, capability_source, governance_kind,
                 CASE
-                    WHEN connection_mode = 'local_config_detected'
-                        AND config_path IS NOT NULL
-                        AND TRIM(config_path) <> ''
+                    WHEN config_path IS NOT NULL AND TRIM(config_path) <> ''
                     THEN 'local_config_detected'
                     ELSE 'manual'
                 END,
@@ -839,6 +835,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn initialize_client_table_derives_local_mode_from_legacy_config_path() {
+        let pool = setup_raw_pool().await;
+
+        sqlx::query(&format!(
+            r#"
+            CREATE TABLE {table} (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                identifier TEXT NOT NULL UNIQUE,
+                config_path TEXT,
+                config_mode TEXT CHECK (config_mode IN ('unify','hosted','transparent')),
+                transport TEXT NOT NULL DEFAULT 'auto' CHECK (
+                    transport IN ('auto', 'sse', 'stdio', 'streamable_http')
+                ),
+                client_version TEXT,
+                backup_policy TEXT NOT NULL DEFAULT 'keep_n' CHECK (
+                    backup_policy IN ('keep_last', 'keep_n', 'off')
+                ),
+                backup_limit INTEGER DEFAULT 5,
+                connection_mode TEXT NOT NULL DEFAULT 'manual' CHECK (
+                    connection_mode IN ('local_config_detected', 'manual')
+                ),
+                registration_origin TEXT NOT NULL DEFAULT 'manual' CHECK (
+                    registration_origin IN ('manual', 'config_detection', 'runtime_initialize')
+                ),
+                runtime_observed INTEGER NOT NULL DEFAULT 0 CHECK (runtime_observed IN (0, 1)),
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+            table = tables::CLIENT,
+        ))
+        .execute(&pool)
+        .await
+        .expect("create legacy client table");
+
+        let legacy_config_path = "/tmp/mcpmate-legacy-client.json";
+        sqlx::query(&format!(
+            "INSERT INTO {table} (id, name, identifier, config_path, connection_mode) VALUES (?, ?, ?, ?, ?)",
+            table = tables::CLIENT,
+        ))
+        .bind("client_legacy_path")
+        .bind("Legacy Config Path")
+        .bind("legacy.path")
+        .bind(legacy_config_path)
+        .bind("manual")
+        .execute(&pool)
+        .await
+        .expect("insert legacy config path row");
+
+        initialize_client_table(&pool).await.expect("initialize client table");
+
+        let (connection_mode, registration_origin, config_path): (String, String, String) = sqlx::query_as(&format!(
+            "SELECT connection_mode, registration_origin, config_path FROM {table} WHERE identifier = ?",
+            table = tables::CLIENT,
+        ))
+        .bind("legacy.path")
+        .fetch_one(&pool)
+        .await
+        .expect("fetch normalized row");
+
+        assert_eq!(connection_mode, "local_config_detected");
+        assert_eq!(registration_origin, "config_detection");
+        assert_eq!(config_path, legacy_config_path);
+    }
+
+    #[tokio::test]
     async fn initialize_client_table_preserves_legacy_format_rules_during_constraint_rebuild() {
         let pool = setup_raw_pool().await;
 
@@ -848,6 +911,7 @@ mod tests {
                 id TEXT PRIMARY KEY,
                 name TEXT NOT NULL,
                 identifier TEXT NOT NULL UNIQUE,
+                config_path TEXT,
                 config_mode TEXT CHECK (config_mode IN ('unify','hosted','transparent')),
                 transport TEXT NOT NULL DEFAULT 'auto' CHECK (
                     transport IN ('auto', 'sse', 'stdio', 'streamable_http')
@@ -876,13 +940,15 @@ mod tests {
         .expect("create legacy client table");
 
         let legacy_format_rules = r#"{"stdio":{"command_field":"command","args_field":"args","env_field":"env"}}"#;
+        let legacy_config_path = "/tmp/mcpmate-legacy-rules.json";
         sqlx::query(&format!(
-            "INSERT INTO {table} (id, name, identifier, connection_mode, format_rules) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO {table} (id, name, identifier, config_path, connection_mode, format_rules) VALUES (?, ?, ?, ?, ?, ?)",
             table = tables::CLIENT,
         ))
         .bind("client_legacy_rules")
         .bind("Legacy Format Rules")
         .bind("legacy.rules")
+        .bind(legacy_config_path)
         .bind("manual")
         .bind(legacy_format_rules)
         .execute(&pool)
@@ -891,15 +957,16 @@ mod tests {
 
         initialize_client_table(&pool).await.expect("initialize client table");
 
-        let transports: String = sqlx::query_scalar(&format!(
-            "SELECT transports FROM {table} WHERE identifier = ?",
+        let (connection_mode, transports): (String, String) = sqlx::query_as(&format!(
+            "SELECT connection_mode, transports FROM {table} WHERE identifier = ?",
             table = tables::CLIENT,
         ))
         .bind("legacy.rules")
         .fetch_one(&pool)
         .await
-        .expect("fetch migrated transports");
+        .expect("fetch migrated row");
 
+        assert_eq!(connection_mode, "local_config_detected");
         assert_eq!(transports, legacy_format_rules);
     }
 }

--- a/backend/src/core/proxy/server/gateway.rs
+++ b/backend/src/core/proxy/server/gateway.rs
@@ -266,7 +266,7 @@ impl ProxyServer {
                 None,
             )),
             FirstContactBehavior::Review => {
-                svc.ensure_passive_observed_row(&client.client_id, display_name, None)
+                svc.ensure_passive_runtime_observed_row(&client.client_id, display_name)
                     .await
                     .map_err(|e| {
                         rmcp::ErrorData::internal_error(format!("Failed to register client for review: {e}"), None)
@@ -328,9 +328,9 @@ impl ProxyServer {
             .observed_client_info
             .as_ref()
             .and_then(|info| info.logo_url.as_deref());
-        let (transport, connection_mode) = match client.transport {
-            super::common::ClientTransport::StreamableHttp => (Some("streamable_http"), Some("remote_http")),
-            super::common::ClientTransport::Other => (None, None),
+        let transport = match client.transport {
+            super::common::ClientTransport::StreamableHttp => Some("streamable_http"),
+            super::common::ClientTransport::Other => None,
         };
 
         if let Err(err) = service
@@ -339,7 +339,6 @@ impl ProxyServer {
                 observed_display_name,
                 client_version,
                 transport,
-                connection_mode,
                 observed_description,
                 observed_homepage_url,
                 observed_logo_url,

--- a/board/src/components/client-form-drawer.tsx
+++ b/board/src/components/client-form-drawer.tsx
@@ -37,7 +37,6 @@ import type {
 	ClientConfigFileParseInspectExistingReq,
 	ClientConfigFileParseInspectResp,
 	ClientConfigFileParseInspectReq,
-	ClientConnectionMode,
 	TransportRuleData,
 	ClientInfo,
 } from "../lib/types";
@@ -77,7 +76,7 @@ import { Textarea } from "./ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
 type ClientFormMode = "create" | "edit";
-type ClientConnectionShape = "local_with_config" | "local_without_config" | "remote_http";
+type ClientConfigFileChoice = "with_config_file" | "without_config_file";
 const SUPPORTED_TRANSPORT_VALUES = ["streamable_http", "sse", "stdio"] as const;
 type SupportedTransportValue = (typeof SUPPORTED_TRANSPORT_VALUES)[number];
 const CONFIG_PARSE_FORMAT_VALUES = ["json", "json5", "toml", "yaml"] as const;
@@ -85,29 +84,34 @@ type ConfigParseFormatValue = (typeof CONFIG_PARSE_FORMAT_VALUES)[number];
 const CONFIG_PARSE_CONTAINER_TYPE_VALUES = ["standard", "array"] as const;
 
 function createFormSchema(t: TFunction) {
-	return z.object({
-		identifier: z.string().min(1),
-		displayName: z.string().min(1),
-		connectionShape: z.enum(["local_with_config", "local_without_config", "remote_http"]),
-		supportedTransports: z
-			.array(z.enum(SUPPORTED_TRANSPORT_VALUES))
-			.min(
-				1,
-				t("detail.form.transportSupport.validation.required", {
-					defaultValue: "Select at least one supported transport before saving.",
-				}),
-			),
-		configPath: z.string().optional(),
-		configFileParseFormat: z.enum(CONFIG_PARSE_FORMAT_VALUES),
-		configFileParseContainerType: z.enum(CONFIG_PARSE_CONTAINER_TYPE_VALUES),
-		configFileParseContainerKeysText: z.string().optional(),
-		clientVersion: z.string().optional(),
-		description: z.string().optional(),
-		homepageUrl: z.string().optional(),
-		docsUrl: z.string().optional(),
-		supportUrl: z.string().optional(),
-		logoUrl: z.string().optional(),
-	});
+	return z
+		.object({
+			identifier: z.string().min(1),
+			displayName: z.string().min(1),
+			configFileChoice: z.enum(["with_config_file", "without_config_file"]),
+			supportedTransports: z.array(z.enum(SUPPORTED_TRANSPORT_VALUES)),
+			configPath: z.string().optional(),
+			configFileParseFormat: z.enum(CONFIG_PARSE_FORMAT_VALUES),
+			configFileParseContainerType: z.enum(CONFIG_PARSE_CONTAINER_TYPE_VALUES),
+			configFileParseContainerKeysText: z.string().optional(),
+			clientVersion: z.string().optional(),
+			description: z.string().optional(),
+			homepageUrl: z.string().optional(),
+			docsUrl: z.string().optional(),
+			supportUrl: z.string().optional(),
+			logoUrl: z.string().optional(),
+		})
+		.superRefine((values, ctx) => {
+			if (values.configFileChoice === "with_config_file" && values.supportedTransports.length === 0) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["supportedTransports"],
+					message: t("detail.form.transportSupport.validation.required", {
+						defaultValue: "Select at least one supported transport before saving.",
+					}),
+				});
+			}
+		});
 }
 
 interface ClientFormDrawerProps {
@@ -492,28 +496,18 @@ function normalizeIdentifier(value: string): string {
 	return value.trim().toLowerCase().replace(/\s+/g, "-");
 }
 
-function connectionShapeToMode(shape: ClientConnectionShape): ClientConnectionMode {
-	switch (shape) {
-		case "local_with_config":
-			return "local_config_detected";
-		case "remote_http":
-			return "remote_http";
-		default:
-			return "manual";
-	}
-}
-
-function connectionModeToShape(
-	connectionMode: ClientConnectionMode | null | undefined,
+function resolveConfigFileChoice(
+	configFileState?: ClientInfo["config_file_state"],
 	configPath?: string | null,
-): ClientConnectionShape {
-	if (connectionMode === "remote_http") return "remote_http";
-	if (connectionMode === "local_config_detected" && configPath?.trim()) return "local_with_config";
-	return "local_without_config";
+): ClientConfigFileChoice {
+	if (configFileState === "with_config_file") return "with_config_file";
+	if (configFileState === "without_config_file") return "without_config_file";
+	if (configPath?.trim()) return "with_config_file";
+	return "without_config_file";
 }
 
-function hasWritableConfig(values: Pick<ClientRecordFormValues, "connectionShape" | "configPath">): boolean {
-	return values.connectionShape === "local_with_config" && Boolean(values.configPath?.trim());
+function hasWritableConfig(values: Pick<ClientRecordFormValues, "configFileChoice" | "configPath">): boolean {
+	return values.configFileChoice === "with_config_file" && Boolean(values.configPath?.trim());
 }
 
 function parseSupportedTransportValue(value: unknown): SupportedTransportValue | null {
@@ -657,7 +651,7 @@ TransportSupportCombobox.displayName = "TransportSupportCombobox";
 
 function defaultValues(client?: ClientInfo | null): ClientRecordFormValues {
 	const identifier = client?.identifier ?? "";
-	const connectionShape = connectionModeToShape(client?.connection_mode, client?.config_path);
+	const configFileChoice = resolveConfigFileChoice(client?.config_file_state, client?.config_path);
 	const supportedTransports = (() => {
 		if (!client) return ["streamable_http", "stdio"] satisfies SupportedTransportValue[];
 		const fromRules = normalizeSupportedTransports(Object.keys(client?.transports ?? {}));
@@ -670,9 +664,9 @@ function defaultValues(client?: ClientInfo | null): ClientRecordFormValues {
 	return {
 		identifier,
 		displayName: client?.display_name ?? "",
-		connectionShape,
+		configFileChoice,
 		supportedTransports,
-		configPath: connectionShape === "local_with_config" ? client?.config_path || "" : "",
+		configPath: configFileChoice === "with_config_file" ? client?.config_path || "" : "",
 		configFileParseFormat: (effectiveParse?.format as ConfigParseFormatValue | undefined) ?? "json",
 		configFileParseContainerType: effectiveParse?.container_type === "array" ? "array" : "standard",
 		configFileParseContainerKeysText: effectiveParse?.container_keys?.join(", ") ?? "",
@@ -850,7 +844,7 @@ export function ClientFormDrawer({
 		defaultValues: defaultValues(client),
 	});
 
-	const connectionShape = form.watch("connectionShape");
+	const configFileChoice = form.watch("configFileChoice");
 	const identifier = form.watch("identifier");
 	const configPath = form.watch("configPath");
 	const configFileParseFormat = form.watch("configFileParseFormat");
@@ -955,22 +949,10 @@ export function ClientFormDrawer({
 		}
 	}, [identifier, form, isHydrating, mode]);
 
-	useEffect(() => {
-		if (connectionShape !== "local_with_config") {
-			if (form.getValues("configPath")) {
-				form.setValue("configPath", "", { shouldDirty: true });
-			}
-			setParseInspection(null);
-			setParseInspectionError(null);
-			setShowParseCodePreview(false);
-		}
-	}, [connectionShape, form]);
-
-	const connectionOptions: SegmentOption[] = useMemo(
+	const configFileOptions: SegmentOption[] = useMemo(
 		() => [
-			{ value: "local_with_config", label: t("detail.form.connectionShape.options.localWithConfig", { defaultValue: "Local + Config" }) },
-			{ value: "local_without_config", label: t("detail.form.connectionShape.options.localWithoutConfig", { defaultValue: "Local / Unknown Config" }) },
-			{ value: "remote_http", label: t("detail.form.connectionShape.options.remoteHttp", { defaultValue: "Remote HTTP" }) },
+			{ value: "with_config_file", label: t("detail.form.configFile.options.withConfigFile", { defaultValue: "With config file" }) },
+			{ value: "without_config_file", label: t("detail.form.configFile.options.withoutConfigFile", { defaultValue: "Without config file" }) },
 		],
 		[t],
 	);
@@ -1082,7 +1064,7 @@ export function ClientFormDrawer({
 	}, [inspectMutation.isPending, parseInspection, parseInspectionError]);
 
 	useEffect(() => {
-		if (!open || connectionShape !== "local_with_config") return;
+		if (!open || configFileChoice !== "with_config_file") return;
 		const trimmedPath = configPath?.trim();
 		if (!trimmedPath) {
 			lastParseInspectionSignatureRef.current = null;
@@ -1147,7 +1129,7 @@ export function ClientFormDrawer({
 		}, 350);
 
 		return () => window.clearTimeout(timer);
-	}, [open, connectionShape, configPath, parseDraft, inspectMutation.mutateAsync, mode, identifier, client?.config_path, t]);
+	}, [open, configFileChoice, configPath, parseDraft, inspectMutation.mutateAsync, mode, identifier, client?.config_path, t]);
 
 	const handleApplyDetectedRules = useCallback(() => {
 		const inferred = parseInspection?.inferred_parse;
@@ -1215,6 +1197,7 @@ export function ClientFormDrawer({
 			const normalizedIdentifier = normalizeIdentifier(values.identifier);
 			const parseForSave = parseDraftFromValues(values);
 			const hasWritableRules = hasWritableConfig(values);
+			const clearConfigFileOnSave = values.configFileChoice === "without_config_file";
 			const supportedTransportsChanged = !isSameSupportedTransports(
 				initialSupportedTransportsRef.current,
 				values.supportedTransports,
@@ -1224,21 +1207,24 @@ export function ClientFormDrawer({
 				transportRuleEditorsSignature(transportRuleEditors) !==
 				transportRuleEditorsSignature(transportRuleEditorsFromClient(client));
 			const shouldPersistTransports =
-				mode === "create" || supportedTransportsChanged || transportEditorsChanged;
-			const transports = shouldPersistTransports
-				? mode === "edit" && !supportedTransportsChanged && !transportEditorsChanged
-					? (client?.transports ?? undefined)
-					: mode === "edit" && !hasWritableRules
-						? filterCurrentTransportPayload(client?.transports, values.supportedTransports)
-						: buildTransportRulesPayload(
-							values.supportedTransports,
-							transportRuleEditors,
-							client,
-							t,
-							hasWritableRules,
-						)
-				: undefined;
-			if (hasWritableConfig(values) && (parseForSave.container_keys?.length ?? 0) === 0) {
+				!clearConfigFileOnSave && (mode === "create" || supportedTransportsChanged || transportEditorsChanged);
+			let transports: Record<string, TransportRuleData> | undefined;
+			if (!shouldPersistTransports) {
+				transports = undefined;
+			} else if (mode === "edit" && !supportedTransportsChanged && !transportEditorsChanged) {
+				transports = client?.transports ?? undefined;
+			} else if (mode === "edit" && !hasWritableRules) {
+				transports = filterCurrentTransportPayload(client?.transports, values.supportedTransports);
+			} else {
+				transports = buildTransportRulesPayload(
+					values.supportedTransports,
+					transportRuleEditors,
+					client,
+					t,
+					hasWritableRules,
+				);
+			}
+			if (hasWritableRules && (parseForSave.container_keys?.length ?? 0) === 0) {
 				throw new Error(
 					t("detail.form.fields.configFileParse.keysRequired", {
 						defaultValue: "Add at least one config node path before saving parse rules.",
@@ -1249,16 +1235,18 @@ export function ClientFormDrawer({
 			await clientsApi.update({
 				identifier: normalizedIdentifier,
 				display_name: values.displayName || undefined,
-				connection_mode: connectionShapeToMode(values.connectionShape),
-				config_path: hasWritableConfig(values) ? values.configPath?.trim() || undefined : undefined,
+				config_file_state: values.configFileChoice,
+				config_path: hasWritableRules ? values.configPath?.trim() || undefined : undefined,
 				client_version: values.clientVersion?.trim() || undefined,
 				description: values.description || undefined,
 				homepage_url: values.homepageUrl || undefined,
 				docs_url: values.docsUrl || undefined,
 				support_url: values.supportUrl || undefined,
 				logo_url: values.logoUrl || undefined,
-				config_file_parse: hasWritableConfig(values) ? parseForSave : undefined,
+				config_file_parse: hasWritableRules ? parseForSave : undefined,
+				clear_config_file_parse: clearConfigFileOnSave,
 				transports,
+				clear_transports: clearConfigFileOnSave,
 			});
 
 			if (
@@ -1386,7 +1374,7 @@ export function ClientFormDrawer({
 					</DrawerTitle>
 					<DrawerDescription>
 						{mode === "create"
-							? t("detail.form.descriptionCreate", { defaultValue: "Create a client record with its management shape and metadata." })
+							? t("detail.form.descriptionCreate", { defaultValue: "Create a client record with its configuration file state and metadata." })
 							: t("detail.form.descriptionEdit", { defaultValue: "Update this client record and its management settings." })}
 					</DrawerDescription>
 				</DrawerHeader>
@@ -1421,18 +1409,18 @@ export function ClientFormDrawer({
 									</p>
 								) : null}
 
-								<FormField control={form.control} name="connectionShape" render={({ field }) => (
+								<FormField control={form.control} name="configFileChoice" render={({ field }) => (
 									<FormItem className="space-y-0">
 										<div className="flex items-start gap-4">
 											<FormLabel className={`${CLIENT_FORM_ROW_LABEL_CLASS} pt-2`}>
-												{t("detail.form.connectionShape.label", { defaultValue: "Client Shape" })}
+												{t("detail.form.configFile.label", { defaultValue: "Configuration File" })}
 											</FormLabel>
 											<div className="min-w-0 flex-1">
 												<FormControl>
-													<Segment value={field.value} onValueChange={field.onChange} options={connectionOptions} showDots={false} />
+													<Segment value={field.value} onValueChange={field.onChange} options={configFileOptions} showDots={false} />
 												</FormControl>
 												<FormDescription>
-													{t("detail.form.connectionShape.description", { defaultValue: "Choose whether this client has a writable local config file or is a non-writable remote/unknown client." })}
+													{t("detail.form.configFile.description", { defaultValue: "Choose whether MCPMate should manage this client through a writable local config file." })}
 												</FormDescription>
 												<FormMessage />
 											</div>
@@ -1440,7 +1428,7 @@ export function ClientFormDrawer({
 									</FormItem>
 								)} />
 
-								{connectionShape === "local_with_config" ? (
+								{configFileChoice === "with_config_file" ? (
 									<FormField control={form.control} name="supportedTransports" render={({ field }) => (
 										<FormItem className="space-y-0">
 											<div className="flex items-start gap-4">
@@ -1455,7 +1443,7 @@ export function ClientFormDrawer({
 									)} />
 								) : null}
 
-								{connectionShape === "local_with_config" ? (
+								{configFileChoice === "with_config_file" ? (
 									<>
 										<FormField control={form.control} name="configPath" render={({ field }) => (
 											<FormItem className="space-y-0">

--- a/board/src/lib/api.ts
+++ b/board/src/lib/api.ts
@@ -17,20 +17,20 @@ import type {
 	ClientCapabilityConfigReq,
 	ClientCapabilityConfigResp,
 	ClientCheckResp,
- ClientConfigFileParse,
- ClientConfigFileParseInspectCall,
- ClientConfigFileParseInspectResp,
-ClientConfigResp,
+	ClientConfigFileParse,
+	ClientConfigFileParseInspectCall,
+	ClientConfigFileParseInspectResp,
+	ClientConfigFileState,
+	ClientConfigResp,
 	ClientConfigRestoreReq,
 	ClientConfigUpdateReq,
 	ClientConfigUpdateResp,
-	ClientDeleteResp,
 	ClientAttachResp,
+	ClientDeleteResp,
 	ClientDetachResp,
-	ServerEntryData,
- TransportRuleData,
 	ClientRecordLifecycleResp,
 	ClientRecordReviewReq,
+	TransportRuleData,
 	ConfigPreset,
 	ConfigSuit,
 	ConfigSuitListResponse,
@@ -2439,16 +2439,16 @@ export const clientsApi = {
 		display_name?: string;
 		config_mode?: string;
 		transport?: string;
-		connection_mode?: string;
+		config_file_state?: ClientConfigFileState;
 		config_path?: string;
 		client_version?: string;
-        description?: string;
-        homepage_url?: string;
-        docs_url?: string;
-        support_url?: string;
-        logo_url?: string;
+		description?: string;
+		homepage_url?: string;
+		docs_url?: string;
+		support_url?: string;
+		logo_url?: string;
 		config_file_parse?: ClientConfigFileParse;
-			clear_config_file_parse?: boolean;
+		clear_config_file_parse?: boolean;
 		transports?: Record<string, TransportRuleData>;
 		clear_transports?: boolean;
 	}) => {

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -946,7 +946,9 @@ export interface ClientTemplateMetadata {
 export interface ClientInfo {
   identifier: string;
   display_name: string;
-  connection_mode?: "local_config_detected" | "remote_http" | "manual" | string | null;
+  config_file_state?: ClientConfigFileState | null;
+  registration_origin?: ClientRegistrationOrigin | null;
+  runtime_observed?: boolean | null;
   category: ClientCategory;
   enabled: boolean;
   detected: boolean;
@@ -1036,11 +1038,8 @@ export interface ClientRecordReviewReq {
   identifier: string;
 }
 
-export type ClientConnectionMode =
-  | "local_config_detected"
-  | "remote_http"
-  | "manual"
-  | string;
+export type ClientConfigFileState = "with_config_file" | "without_config_file";
+export type ClientRegistrationOrigin = "manual" | "config_detection" | "runtime_initialize" | string;
 
 export interface DefaultClientPolicyData {
   config_mode: string;
@@ -1095,7 +1094,9 @@ export interface ClientConfigData {
   has_mcp_config: boolean;
   configured_server_entries?: ServerEntryData[];
   last_modified?: string | null;
-  connection_mode?: ClientConnectionMode | null;
+  config_file_state?: ClientConfigFileState | null;
+  registration_origin?: ClientRegistrationOrigin | null;
+  runtime_observed?: boolean | null;
   mcp_servers_count: number;
   approval_status?: "approved" | "pending" | "suspended" | string | null;
   attachment_state?: "attached" | "detached" | "not_applicable" | string | null;
@@ -1117,7 +1118,7 @@ export interface ClientConfigData {
 export interface ClientSettingsSourceData {
   display_name: "provided" | "stored" | "default" | string;
   approval_status: "provided" | "stored" | "default" | string;
-  connection_mode: "provided" | "derived" | "stored" | string;
+  config_file_state: "provided" | "derived" | "stored" | string;
 }
 
 export interface ClientSettingsUpdateData {
@@ -1126,7 +1127,9 @@ export interface ClientSettingsUpdateData {
   config_mode?: string | null;
   transport: string;
   client_version?: string | null;
-  connection_mode?: string | null;
+  config_file_state?: ClientConfigFileState | null;
+  registration_origin?: ClientRegistrationOrigin | null;
+  runtime_observed?: boolean | null;
   config_path?: string | null;
   description?: string | null;
   homepage_url?: string | null;

--- a/board/src/pages/clients/i18n/index.ts
+++ b/board/src/pages/clients/i18n/index.ts
@@ -215,16 +215,15 @@ export const clientsTranslations = {
       form: {
         titleCreate: "Add Client Record",
         titleEdit: "Edit Client Record",
-        descriptionCreate: "Create a client record with its management shape and metadata.",
+        descriptionCreate: "Create a client record with its configuration file state and metadata.",
         descriptionEdit: "Update this client record and its management settings.",
         tabs: { basic: "Basic", meta: "Meta" },
-        connectionShape: {
-          label: "Client Shape",
-          description: "Choose whether this client has a writable local config file or is a non-writable remote/unknown client.",
+        configFile: {
+          label: "Configuration File",
+          description: "Choose whether MCPMate should manage this client through a writable local config file.",
           options: {
-            localWithConfig: "Local + Config",
-            localWithoutConfig: "Local / Unknown Config",
-            remoteHttp: "Remote HTTP",
+            withConfigFile: "With config file",
+            withoutConfigFile: "Without config file",
           },
         },
         transportSupport: {
@@ -990,16 +989,15 @@ export const clientsTranslations = {
       form: {
         titleCreate: "新增客户端记录",
         titleEdit: "编辑客户端记录",
-        descriptionCreate: "创建一个带有管理形态与元数据的客户端记录。",
+        descriptionCreate: "创建一个带有配置文件状态与元数据的客户端记录。",
         descriptionEdit: "更新该客户端记录及其管理设置。",
         tabs: { basic: "基础", meta: "元数据" },
-        connectionShape: {
-          label: "客户端形态",
-          description: "选择该客户端是否具备可写本地配置文件，或属于不可写的远程/未知客户端。",
+        configFile: {
+          label: "配置文件",
+          description: "选择 MCPMate 是否通过可写本地配置文件管理该客户端。",
           options: {
-            localWithConfig: "本地 + 配置文件",
-            localWithoutConfig: "本地 / 未知配置",
-            remoteHttp: "远程 HTTP",
+            withConfigFile: "带配置文件",
+            withoutConfigFile: "不带配置文件",
           },
         },
         transportSupport: {
@@ -1751,16 +1749,15 @@ export const clientsTranslations = {
       form: {
         titleCreate: "クライアントレコードを追加",
         titleEdit: "クライアントレコードを編集",
-        descriptionCreate: "管理形態とメタデータを含むクライアントレコードを作成します。",
+        descriptionCreate: "設定ファイル状態とメタデータを含むクライアントレコードを作成します。",
         descriptionEdit: "このクライアントレコードと管理設定を更新します。",
         tabs: { basic: "基本", meta: "メタデータ" },
-        connectionShape: {
-          label: "クライアント形態",
-          description: "このクライアントが書き込み可能なローカル設定ファイルを持つか、書き込み不可のリモート/未知クライアントかを選択します。",
+        configFile: {
+          label: "設定ファイル",
+          description: "MCPMate が書き込み可能なローカル設定ファイルを通じてこのクライアントを管理するかを選択します。",
           options: {
-            localWithConfig: "ローカル + 設定ファイル",
-            localWithoutConfig: "ローカル / 不明な設定",
-            remoteHttp: "リモート HTTP",
+            withConfigFile: "設定ファイルあり",
+            withoutConfigFile: "設定ファイルなし",
           },
         },
         transportSupport: {

--- a/board/src/pages/onboarding/onboarding-page.tsx
+++ b/board/src/pages/onboarding/onboarding-page.tsx
@@ -426,7 +426,7 @@ export function OnboardingPage() {
           await clientsApi.update({
             identifier: client.identifier,
             display_name: client.display_name || client.identifier,
-            connection_mode: "local_config_detected",
+            config_file_state: "with_config_file",
             config_path: client.config_path,
             description: client.description ?? client.template?.description ?? undefined,
             homepage_url: client.homepage_url ?? client.template?.homepage_url ?? undefined,


### PR DESCRIPTION
## Summary
- Simplify client-facing config state to `with_config_file` / `without_config_file` and keep runtime observation separate from product shape semantics.
- Preserve legacy `format_rules` during client table rebuilds and normalize old legacy rows without losing config data.
- Update the board edit drawer so toggling config-file mode no longer wipes unsaved form state, and clearing happens on save.
- Tighten API and type contracts to match the new client config model.

## Testing
- Backend regression tests added for legacy `format_rules` preservation, legacy `manual + config_path` normalization, and `without_config_file` cleanup behavior.
- Existing backend client normalization tests passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- Board lint and build passed; lint still reports pre-existing warnings only.

Closes #61