### PR TITLE
Refine nightly release workflow and enable macOS notarization

### DIFF
--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -1,5 +1,4 @@
-# Builds the MCPMate Tauri desktop app for macOS (DMG), without codesigning or notarization.
-# Artifacts are suitable for local testing or internal distribution; Gatekeeper may warn on open.
+# Builds signed and notarized MCPMate Tauri desktop macOS DMG artifacts.
 
 name: Desktop (macOS)
 
@@ -23,7 +22,7 @@ on:
         description: "Cargo profile"
         type: choice
         required: false
-        default: "debug"
+        default: "release"
         options:
           - debug
           - release
@@ -76,28 +75,148 @@ jobs:
       - name: Inject app version
         uses: ./.github/actions/inject-version
 
-      - name: Build macOS DMG (no sign / no notarize)
+      - name: Validate macOS signing/notarization secrets
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          test -n "$APPLE_CERTIFICATE_P12_BASE64" || { echo "missing APPLE_CERTIFICATE_P12_BASE64" >&2; exit 1; }
+          test -n "$APPLE_CERTIFICATE_PASSWORD" || { echo "missing APPLE_CERTIFICATE_PASSWORD" >&2; exit 1; }
+          test -n "$KEYCHAIN_PASSWORD" || { echo "missing KEYCHAIN_PASSWORD" >&2; exit 1; }
+          test -n "$APPLE_SIGNING_IDENTITY" || { echo "missing APPLE_SIGNING_IDENTITY" >&2; exit 1; }
+
+          has_api_key=0
+          if [[ -n "$APPLE_API_KEY" && -n "$APPLE_API_ISSUER" && -n "$APPLE_API_PRIVATE_KEY" ]]; then
+            has_api_key=1
+          fi
+
+          has_apple_id=0
+          if [[ -n "$APPLE_ID" && -n "$APPLE_PASSWORD" && -n "$APPLE_TEAM_ID" ]]; then
+            has_apple_id=1
+          fi
+
+          if [[ "$has_api_key" -eq 0 && "$has_apple_id" -eq 0 ]]; then
+            echo "missing notarization credentials: set API key triple or Apple ID triple" >&2
+            exit 1
+          fi
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/mcpmate-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/mcpmate-signing-cert.p12"
+
+          if ! echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_PATH" 2>/dev/null; then
+            echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 -D > "$CERT_PATH"
+          fi
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Prepare notary API key file
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$APPLE_API_KEY" || -z "$APPLE_API_ISSUER" || -z "$APPLE_API_PRIVATE_KEY" ]]; then
+            echo "App Store Connect API key credentials not configured; using Apple ID notarization credentials."
+            exit 0
+          fi
+
+          KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Build signed and notarized macOS DMG
         env:
           INPUT_BUNDLES: ${{ github.event.inputs.bundles }}
-          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
-          TAURI_BUILD_EXTRA: "--features devtools"
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'release' }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         run: |
           BUNDLES="${INPUT_BUNDLES:-app,dmg}"
-          PROFILE="${INPUT_PROFILE:-debug}"
+          PROFILE="${INPUT_PROFILE:-release}"
           chmod +x packaging/desktop/macos-build-tauri-release.sh
           packaging/desktop/macos-build-tauri-release.sh \
             --profile "$PROFILE" \
             --target "${{ matrix.arch == 'aarch64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}" \
             --bundles "$BUNDLES" \
-            --skip-notarize \
-            --output-dir "${GITHUB_WORKSPACE}/desktop-macos-artifacts/${{ matrix.arch }}"
+            --output-dir "${GITHUB_WORKSPACE}/installers"
+
+      - name: Verify macOS notarization and codesign
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          dmgs=(installers/*.dmg)
+          if [[ ${#dmgs[@]} -eq 0 ]]; then
+            echo "no DMG generated for notarization verification" >&2
+            exit 1
+          fi
+
+          for dmg in "${dmgs[@]}"; do
+            echo "verify stapler for $dmg"
+            xcrun stapler validate "$dmg"
+
+            mount_dir="$RUNNER_TEMP/mcpmate-dmg-mount"
+            mkdir -p "$mount_dir"
+            hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_dir"
+            trap 'hdiutil detach "$mount_dir" -quiet || true' EXIT
+
+            app_path=$(find "$mount_dir" -maxdepth 2 -type d -name "*.app" | head -n 1)
+            if [[ -z "$app_path" ]]; then
+              echo "no .app found inside $dmg" >&2
+              exit 1
+            fi
+
+            echo "verify codesign for $app_path"
+            codesign --verify --deep --strict --verbose=2 "$app_path"
+            spctl --assess --type execute --verbose=4 "$app_path"
+
+            hdiutil detach "$mount_dir" -quiet || true
+            trap - EXIT
+          done
 
       - name: Smoke test (sidecar arch + DMG output)
         env:
-          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'debug' }}
+          INPUT_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'release' }}
         run: |
           set -euo pipefail
-          PROFILE="${INPUT_PROFILE:-debug}"
+          PROFILE="${INPUT_PROFILE:-release}"
           BUNDLE_ROOT="desktop/src-tauri/target/${{ matrix.arch == 'aarch64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}/${PROFILE}/bundle"
           echo "--- bundle layout ---"
           find "$BUNDLE_ROOT" -type f | head -40 || true
@@ -124,10 +243,22 @@ jobs:
           hdiutil imageinfo "$dmg" >/dev/null
           echo "SMOKE OK"
 
+      - name: Cleanup macOS signing materials
+        if: always()
+        run: |
+          set -euo pipefail
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/mcpmate-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/mcpmate-signing-cert.p12"
+
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -f "$CERT_PATH"
+          rm -f "$RUNNER_TEMP"/AuthKey_*.p8
+
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v6
         with:
           name: mcpmate-macos-${{ matrix.arch }}-dmg
-          path: desktop-macos-artifacts/${{ matrix.arch }}/*.dmg
+          path: installers/*.dmg
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -639,7 +639,7 @@ jobs:
           MANIFEST_ARGS=(
             --version "$APP_VERSION"
             --output artifacts/update.json
-            --notes "Nightly ${BUILD_ID}"
+            --notes "Nightly ${BUILD_DATE} (${SHORT_SHA})"
           )
 
           platform_for_asset() {

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 # Scheduled desktop dev channel. Successful runs update the fixed `nightly`
 # prerelease; failed runs remain visible only in GitHub Actions.
 
-name: Nightly Dev Build
+name: Nightly
 
 on:
   # Daily at 18:20 UTC / 02:20 Asia/Singapore.
@@ -9,7 +9,7 @@ on:
     - cron: "20 18 * * *"
 
 concurrency:
-  group: nightly-dev-build-${{ github.ref }}
+  group: nightly-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -23,7 +23,7 @@ env:
 
 jobs:
   prepare:
-    name: Prepare dev build metadata
+    name: Prepare nightly metadata
     runs-on: ubuntu-22.04
     outputs:
       build_id: ${{ steps.meta.outputs.build_id }}
@@ -69,7 +69,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           {
-            echo "### Nightly dev build"
+            echo "### Nightly"
             echo ""
             echo "- Build ID: \`${build_id}\`"
             echo "- Source: \`${source_ref}\`"
@@ -639,7 +639,7 @@ jobs:
           MANIFEST_ARGS=(
             --version "$APP_VERSION"
             --output artifacts/update.json
-            --notes "MCPMate nightly dev build ${BUILD_ID}"
+            --notes "Nightly ${BUILD_ID}"
           )
 
           platform_for_asset() {
@@ -685,8 +685,6 @@ jobs:
           set -euo pipefail
 
           cat > nightly-release-notes.md <<EOF
-          # MCPMate Nightly Dev Build
-
           Build ID: \`${BUILD_ID}\`
 
           App version: \`${APP_VERSION}\`
@@ -706,7 +704,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          title="MCPMate Nightly ${BUILD_DATE} (${SHORT_SHA})"
+          title="Nightly ${BUILD_DATE} (${SHORT_SHA})"
           assets=(artifacts/*)
 
           git tag -f "$DEV_CHANNEL_TAG" "$SOURCE_SHA"
@@ -740,7 +738,7 @@ jobs:
       - name: Summarize nightly channel
         run: |
           {
-            echo "### Published nightly dev build"
+            echo "### Published nightly"
             echo ""
             echo "- Build ID: \`${BUILD_ID}\`"
             echo "- Release: https://github.com/${RELEASE_REPO}/releases/tag/${DEV_CHANNEL_TAG}"


### PR DESCRIPTION
## Summary
- Renamed the scheduled dev build workflow to `nightly.yml` and simplified the workflow/release wording to `Nightly`.
- Removed the redundant `MCPMate` prefix from nightly release titles and notes so the release metadata matches the existing nightly tag style.
- Updated `desktop-macos.yml` to build signed and notarized DMGs instead of skipping notarization, using the same Apple signing flow as the release workflow.

## Testing
- `git diff --check`
- YAML parsing for `nightly.yml`, `desktop-macos.yml`, and `release.yml`
- `actionlint` passed for `nightly.yml` and `desktop-macos.yml`