### PR TITLE
Add MCPMate UAT acceptance skill

### DIFF
--- a/.agents/skills/uat-acceptance/SKILL.md
+++ b/.agents/skills/uat-acceptance/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: uat-acceptance
+description: Use this skill for MCPMate UI/UX review, UAT planning, Playwright acceptance, Admin Console acceptance, Board acceptance, Extension delivery acceptance, or any request to judge whether a page, flow, component, PR, or deliverable conforms to MCPMate product taste and acceptance standards. Use it even when the user does not say "UAT" if the task involves visual quality, interaction quality, acceptance criteria, release readiness, or product-facing workflow validation.
+---
+
+# UAT Acceptance
+
+Use this skill to judge MCPMate deliverables against the product's UI/UX reference and acceptance workflow. The goal is not generic design advice; it is a conforming/non-conforming decision backed by evidence from the current implementation, screenshots, tests, and the active GitHub Project item.
+
+## Start Here
+
+1. Confirm repository context before changing files or branch state:
+   - `git rev-parse --show-toplevel`
+   - `git remote get-url origin`
+   - `git status --short --branch`
+2. Identify the active GitHub Project item. If the user already names one, treat it as the delivery contract.
+3. Identify the touched surface:
+   - Board or Tauri-loaded Board UI
+   - Admin Console or admin-like workflow
+   - Extension UI or import flow
+   - Website/marketing surface
+   - Backend/API behavior that materially changes UI state or UAT paths
+4. Read only the bundled resource needed for the task:
+   - `references/mcpmate-ui-ux-reference.md` for UI/UX conformance, layout, component selection, visual taste, and interaction rules.
+   - `references/mcpmate-uat-strategy.md` for UAT roles, environments, seed/reset, severity, automation boundaries, and GitHub Project feedback.
+   - `playbooks/admin-console-uat.md` for Admin Console acceptance paths such as login, account maintenance, portal/client/server editor, publish, discovery, rollback, and audit review.
+
+## Evidence Collection
+
+Use real product evidence before judging a change.
+
+- Read the current code for the affected surface and nearby established components.
+- For Board-like UI, compare against these reference paths first:
+  - `board/src/index.css`
+  - `board/src/components/layout/`
+  - `board/src/components/ui/`
+  - `board/src/components/page-layout.tsx`
+  - `board/src/components/ui/page-toolbar.tsx`
+  - `board/src/components/entity-card.tsx`
+  - `board/src/components/status-badge.tsx`
+  - `board/src/pages/dashboard/`
+  - `board/src/pages/servers/`
+  - `board/src/pages/clients/`
+  - `board/src/pages/audit/`
+- For new UI, inspect the page in a browser or Playwright screenshot when the app can run locally.
+- For UAT, record exact setup, seed data, actor, path, expected result, observed result, severity, and follow-up owner.
+
+## Acceptance Output
+
+When reviewing or validating, report in this shape:
+
+```markdown
+## Decision
+Conforming | Partially conforming | Non-conforming | Blocked
+
+## Evidence
+- Surface:
+- Project item:
+- Code paths:
+- Screenshots/tests:
+
+## Findings
+- [P0/P1/P2/P3] Finding title
+  Evidence:
+  Expected MCPMate standard:
+  Required change:
+
+## UAT Coverage
+- Automated:
+- Manual/agent judgment:
+- Not covered:
+
+## Project Feedback
+- GitHub Project item update needed:
+- PR/readiness note:
+```
+
+## Decision Rules
+
+- Mark `Conforming` only when the implementation matches the relevant reference, the primary UAT path passes, and no P0/P1 issue remains.
+- Mark `Partially conforming` when the workflow works but visual hierarchy, interaction model, accessibility, or feedback loop still has P2 gaps.
+- Mark `Non-conforming` when the implementation invents a parallel design system, hides critical state, breaks the expected workflow, skips auditability, or makes destructive operations ambiguous.
+- Mark `Blocked` when the environment, seed data, missing route, missing API, or missing Project contract prevents a defensible judgment.
+
+## MCPMate-Specific Priorities
+
+- Prefer dense operational layouts over marketing-style hero sections.
+- Prefer reusable Board primitives and shadcn/Radix-compatible controls over custom one-off widgets.
+- Prefer explicit operational state: status badge, audit trace, refresh/loading state, empty state, and destructive confirmation.
+- Keep primary actions near the page or section toolbar. Keep row/card actions local to the entity they affect.
+- Treat i18n, keyboard access, stable layout dimensions, and auditability as acceptance requirements, not polish.
+- Do not add fallback behavior, silent substitution, compatibility shims, or hidden recovery paths unless the active Project item explicitly requires them.
+
+## Skill Maintenance
+
+When this skill is updated, keep `SKILL.md` as the trigger and workflow entrypoint. Move long examples, checklists, playbooks, and evidence matrices into bundled resources so future agents load only what they need.

--- a/.agents/skills/uat-acceptance/evals/evals.json
+++ b/.agents/skills/uat-acceptance/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "uat-acceptance",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Review a proposed MCPMate Board PR that adds a new Servers bulk-publish toolbar and decide whether it conforms to MCPMate UI/UX and UAT standards. Include findings, severity, automated checks, manual judgment, and GitHub Project feedback.",
+      "expected_output": "A conforming/non-conforming acceptance review that uses MCPMate Board UI patterns, toolbar/action placement rules, publish/audit UAT checks, and Project feedback requirements.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Create a UAT plan for the MCPMate Admin Console account maintenance and rollback flows. The output should include actors, environment, seed/reset preconditions, user paths, severity rules, and which checks can be automated with Playwright.",
+      "expected_output": "A practical Admin Console UAT plan using the bundled playbook, with local admin login, account maintenance, rollback, audit review, seed/reset, severity, and automation boundaries.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "A new Extension import review panel uses large rounded gradient cards, a hero headline, custom icons, and no audit/error state. Assess whether this matches MCPMate style and list required changes before acceptance.",
+      "expected_output": "A non-conforming UI/UX decision that identifies style mismatches against MCPMate operational density, component choices, icons, empty/error/audit requirements, and actionable required changes.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/uat-acceptance/playbooks/admin-console-uat.md
+++ b/.agents/skills/uat-acceptance/playbooks/admin-console-uat.md
@@ -1,0 +1,310 @@
+# Admin Console UAT Playbook
+
+This is the first acceptance playbook for MCPMate Admin Console or admin-like management surfaces. Use Board as the UI/UX taste reference, but verify actual routes, API names, and seed scripts from the active implementation before running the playbook.
+
+## Scope
+
+The playbook covers:
+
+- Local admin login
+- Account maintenance
+- Portal, client, and server editor
+- Publish
+- Public discovery endpoint
+- Rollback
+- Audit review
+
+## Preconditions
+
+Actor:
+
+- Operations Admin with local administrative access.
+
+Environment:
+
+- Local backend/API reachable.
+- Admin Console or admin-like UI reachable.
+- Board/Tauri reference available if UI conformance is in scope.
+- Browser automation or Playwright available for repeatable path checks.
+
+Seed:
+
+- One admin account or local admin session.
+- One non-admin or invalid session.
+- One portal/registry/discovery configuration.
+- One client record in each relevant governance state: allowed, pending, denied/suspended.
+- One server draft/import candidate.
+- One published server or portal record.
+- One rollback target.
+- Audit table initially empty or with a known fixture set.
+
+Reset:
+
+- Declare whether the run uses a fresh local database, fixture namespace, test account, or reversible API setup.
+- Do not run publish/rollback against production or public systems unless the Project item explicitly approves that environment.
+
+## Path 1: Local Admin Login
+
+Actor: Operations Admin
+
+Entry point:
+
+- Admin Console login route or account/session dialog.
+
+Steps:
+
+1. Open the Admin Console.
+2. Attempt access without an active session.
+3. Log in with local admin credentials or complete local admin bootstrap.
+4. Reload the page.
+5. Log out or expire the session if the implementation supports it.
+
+Expected:
+
+- Unauthenticated access is blocked or redirected with clear state.
+- Login form has labels, visible error state, and no placeholder-only required fields.
+- Successful login lands on the intended operational surface.
+- Header/sidebar/session affordance clearly shows account/admin state.
+- Failed login shows the backend error directly enough to diagnose.
+- Audit records login success/failure when the system owns that event.
+
+Conformance checks:
+
+- Dialog is acceptable for compact login; drawer is acceptable only if login includes multi-section setup.
+- No marketing-style landing page is inserted before the operational surface.
+- No silent fallback to guest/admin mode.
+
+Severity:
+
+- P0 if unauthorized users can access admin functionality.
+- P1 if admin cannot log in or session state is misleading.
+- P2 if the path works but lacks audit, labels, or clear errors.
+
+## Path 2: Account Maintenance
+
+Actor: Operations Admin
+
+Steps:
+
+1. Open account/user management.
+2. View admin profile/session details.
+3. Create, edit, suspend, or delete a test account as supported.
+4. Try an invalid edit.
+5. Confirm audit records.
+
+Expected:
+
+- Account list is searchable/filterable when it can contain many records.
+- Status uses badges, not only text.
+- Destructive actions use AlertDialog/ConfirmDialog with destructive styling.
+- Editing a complex account uses a drawer; short focused edits may use a dialog.
+- Suspended/deleted accounts cannot continue privileged actions after refresh.
+- Audit captures actor, target, action, status, and timestamp.
+
+Non-conforming:
+
+- Account actions hidden in unlabelled icon clusters.
+- Delete/suspend without confirmation.
+- Permission changes that appear successful before backend confirmation without pending state.
+
+## Path 3: Portal Editor
+
+Actor: Operations Admin
+
+Steps:
+
+1. Open portal/registry/discovery settings.
+2. Create or edit a portal record.
+3. Validate URL or registry metadata fields.
+4. Disable and re-enable the portal.
+5. Confirm list/detail state and audit records.
+
+Expected:
+
+- Portal records use list/table/card depending on density:
+  - table for many comparable records,
+  - card/list for a small number with descriptive metadata.
+- Editor groups identity, endpoint, credentials/secrets, and publication/discovery settings.
+- Sensitive fields are redacted after save.
+- Validation failures are inline and do not silently rewrite fields.
+- Toggle enablement uses Switch only for immediate reversible state.
+
+Public endpoint relation:
+
+- Portal changes that affect public discovery must be reflected in the public discovery endpoint path below.
+
+## Path 4: Client Editor
+
+Actor: Operations Admin
+
+Steps:
+
+1. Open client management.
+2. Review detected, allowed, pending, and denied/suspended clients.
+3. Approve or suspend a client.
+4. Edit client metadata or configuration when supported.
+5. Refresh and verify stable ordering.
+
+Expected:
+
+- Client ordering is stable by display name then identifier unless the UI clearly exposes another sort.
+- Governance state is visible as badge/status and switch state.
+- Pending clients cannot be treated as allowed without explicit approval.
+- Writable/non-writable config is visible.
+- Refresh does not reorder unchanged records unexpectedly.
+- Audit records governance changes.
+
+Conformance checks:
+
+- Uses Board-like client list/card affordances.
+- Switch is acceptable for allowed/suspended if operation is immediate and reversible.
+- Confirmation is required if the change can break a client or remove configuration.
+
+## Path 5: Server Editor
+
+Actor: Operations Admin
+
+Steps:
+
+1. Open server management.
+2. Create a stdio or HTTP server draft.
+3. Edit server identity, transport, auth, default headers, and capability-related fields.
+4. Trigger preview/discovery if supported.
+5. Save and refresh.
+
+Expected:
+
+- Long server editor uses drawer/full-height side panel, not cramped modal.
+- Transport-specific fields appear only when relevant and preserve valid existing values.
+- OAuth/headers/secrets are clearly labelled and redacted where appropriate.
+- Capability discovery has loading, success, failure, and empty states.
+- Saved server appears with status badge and correct enabled/runtime state.
+- Audit records create/update/discovery events.
+
+Non-conforming:
+
+- Hidden default values that publish or enable a server without explicit choice.
+- No visible distinction between draft, saved, enabled, connected, failed, and discovered states.
+
+## Path 6: Publish
+
+Actor: Operations Admin
+
+Steps:
+
+1. Open a draft portal/server/public listing candidate.
+2. Review all publish-critical fields.
+3. Attempt publish with missing required fields.
+4. Publish a valid candidate.
+5. Refresh list/detail and query public discovery endpoint.
+6. Review audit.
+
+Expected:
+
+- Publish is a primary action only in the review context.
+- Missing fields block publish with specific errors.
+- Valid publish has pending/loading state and clear success/failure notification.
+- Published state is visible in badge/metadata.
+- Public discovery endpoint returns the published item after refresh.
+- Audit records actor, target, published state, and status.
+
+Severity:
+
+- P0 if publish exposes wrong data or bypasses authorization.
+- P1 if publish succeeds but public discovery/audit state is wrong.
+- P2 if publish works but UI hierarchy or error copy is weak.
+
+## Path 7: Public Discovery Endpoint
+
+Actor: External User or Operations Admin
+
+Steps:
+
+1. Identify the public discovery endpoint from the active implementation.
+2. Query empty/no-record state.
+3. Publish a record and query again.
+4. Query invalid parameters or unsupported filters.
+5. Disable/rollback the record and query again.
+
+Expected:
+
+- Response shape is documented or inspectable.
+- Empty state is explicit and not confused with server error.
+- Published item appears with correct metadata and no secret leakage.
+- Invalid request returns an appropriate error response.
+- Disabled/rolled-back item no longer appears or is clearly marked according to the contract.
+
+Automation:
+
+- This path should be scriptable with API/client tooling once the endpoint is implemented.
+
+## Path 8: Rollback
+
+Actor: Operations Admin
+
+Steps:
+
+1. Open a published record with previous version/history.
+2. Inspect current and rollback target.
+3. Trigger rollback.
+4. Confirm destructive/risky action.
+5. Verify UI, API/public endpoint, and audit state.
+
+Expected:
+
+- Rollback target is explicit.
+- Confirmation copy names the target and consequence.
+- Rollback has pending, success, and failure states.
+- UI and endpoint reflect the rolled-back version after refresh.
+- Audit records rollback actor, source version, target version, and result.
+
+Non-conforming:
+
+- Rollback button beside unrelated row action without confirmation.
+- Rollback that succeeds in UI but leaves public endpoint stale.
+- Rollback that cannot be tied to an audit event.
+
+## Path 9: Audit Review
+
+Actor: Operations Admin or Reviewer
+
+Steps:
+
+1. Open audit/logs.
+2. Filter by category, status, target, account, client, server, or publish/rollback action.
+3. Expand a row.
+4. Open raw details.
+5. Refresh and paginate.
+6. Verify live/disconnected state if WebSocket/live stream exists.
+
+Expected:
+
+- Audit table follows Board density: sticky header, fixed widths, truncation, row expansion, pagination.
+- Empty/no-match states are distinct.
+- Status uses semantic badges.
+- Raw details open in drawer or clear detail panel.
+- Long target/route/session values do not break layout.
+- Refresh and pagination preserve user context where reasonable.
+
+Conformance checks:
+
+- Audit is not a decorative timeline when table density is needed.
+- Raw detail view redacts sensitive values.
+- Failed events are not hidden by default without a visible filter state.
+
+## Final Acceptance Gate
+
+Admin Console is not ready for acceptance when any of these remain:
+
+- Unauthenticated admin access or privilege confusion.
+- Publish/rollback/account changes without audit evidence.
+- Missing seed/reset plan for state-changing tests.
+- Public discovery exposes secrets or stale/wrong records.
+- Major workflows use a design system that diverges from Board.
+- P0 or P1 findings remain unresolved.
+
+Admin Console may be marked partially conforming when:
+
+- Core paths complete, but Playwright coverage, screenshot evidence, or Project feedback is incomplete.
+- Visual hierarchy is close to Board but has P2 density/control issues.
+- Manual product judgment is needed for copy, risk framing, or component choice.

--- a/.agents/skills/uat-acceptance/references/mcpmate-uat-strategy.md
+++ b/.agents/skills/uat-acceptance/references/mcpmate-uat-strategy.md
@@ -1,0 +1,217 @@
+# MCPMate UAT Strategy
+
+Use this strategy for acceptance planning and release-readiness review across MCPMate subprojects. It applies to Board, Tauri-loaded Board UI, Admin Console, Extension flows, website operational surfaces, and backend/API changes that affect user-facing workflows.
+
+## UAT Principles
+
+MCPMate UAT checks whether a real operator can complete the workflow safely, understand state, recover from visible errors, and leave an auditable trace. It is not only a browser smoke test.
+
+Acceptance should answer:
+
+- Can the intended actor complete the path without hidden assumptions?
+- Is the UI consistent with MCPMate's compact operational style?
+- Are state, risk, and ownership visible at the point of action?
+- Does the system avoid silent fallback behavior unless explicitly required?
+- Can a future reviewer find evidence in tests, screenshots, logs, audit events, or GitHub Project notes?
+
+## Test Roles
+
+Use the minimum set that covers the touched workflow.
+
+- Product Owner: judges product intent, wording, flow order, risk framing, and whether the behavior matches the Project item.
+- Operations Admin: manages accounts, clients, servers, profiles, registry/portal settings, publish/rollback, and audit review.
+- Runtime Consumer: uses MCPMate through a client or agent and validates that UI changes do not break runtime expectations.
+- Developer/Reviewer: validates implementation, test coverage, i18n, accessibility, and failure surfaces.
+- External User: only when public discovery, marketing, website, or public endpoint behavior is in scope.
+
+## Test Environments
+
+Choose the smallest realistic environment.
+
+- Local Web Board: Vite Board connected to local backend at `http://localhost:8080`.
+- Desktop Shell: Tauri app loading Board when shell events, deep links, desktop readiness, or runtime source discovery matters.
+- Extension: Chrome extension import/discovery flow when browser-based server import is involved.
+- Admin Console: future/admin-like control surface for account, portal, client, server, publish, rollback, and audit tasks.
+- Backend/API: direct API/Inspector checks when UI depends on endpoints, status, or event streams.
+
+Record exact commands and versions. Use Bun for frontend package commands.
+
+## Seed And Reset Preconditions
+
+Define seed/reset before executing UAT. Do not rely on unknown local state.
+
+Minimum seed dimensions:
+
+- Account/session: unauthenticated, local admin, active admin, expired/invalid session.
+- Clients: no clients, detected unmanaged client, allowed client, pending client, denied/suspended client, writable and non-writable config.
+- Servers: no servers, stdio server, streamable HTTP server, OAuth server, disabled server, connected server, failed server, server with discovered capabilities.
+- Profiles: empty profile, profile with server associations, profile with tools/resources/prompts/templates enabled.
+- Registry/portal/discovery: no results, published result, draft/import preview, failed discovery, public endpoint response.
+- Audit: no events, success event, failed event, rollback event, publish event, account/admin event.
+
+Reset expectations:
+
+- State-changing UAT must declare how the local database/config is reset or which fixture namespace is used.
+- Avoid editing user home config directly unless the workflow under test is specifically about client config management.
+- Prefer deterministic scripts or API setup when repeated UAT is expected.
+- If reset cannot be made deterministic yet, mark the run `Blocked` or `Partially conforming` and create a Project follow-up.
+
+## User Path Format
+
+Write UAT paths in this format:
+
+```markdown
+### Path: [name]
+
+Actor:
+Environment:
+Seed:
+Entry point:
+
+Steps:
+1. ...
+2. ...
+
+Expected:
+- UI:
+- Data/API:
+- Audit/log:
+- Error/rollback:
+
+Evidence:
+- Screenshot:
+- Test/log:
+- Project item note:
+
+Result: Pass | Partial | Fail | Blocked
+Severity if failed: P0 | P1 | P2 | P3
+```
+
+## Acceptance Dimensions
+
+### Workflow Completion
+
+- Entry point is discoverable.
+- Required data is present at the point of action.
+- The user can finish the path without leaving the interface unexpectedly.
+- Success, failure, pending, and retry states are visible.
+
+### UI/UX Conformance
+
+- Layout, density, controls, color, typography, spacing, and icon usage follow `mcpmate-ui-ux-reference.md`.
+- Data surfaces have search/filter/sort/pagination when needed.
+- Long values truncate or expand predictably.
+- Actions stay near their object of control.
+
+### Accessibility And Internationalization
+
+- Interactive controls have labels or accessible names.
+- Keyboard path works for toolbar, table expansion, dialog/drawer, and destructive confirmation.
+- Board-like UI uses `t()` with `defaultValue` and page translations.
+- Language changes do not leave memoized labels stale.
+
+### Data And State Integrity
+
+- UI state matches backend/API state after refresh.
+- Mutations invalidate/refetch relevant queries or receive event updates.
+- No hidden fallback creates misleading data.
+- Optimistic or pending states are clear and reversible only when the underlying operation is reversible.
+
+### Security, Risk, And Audit
+
+- Destructive operations require explicit confirmation.
+- Publish/rollback/account/admin actions are auditable.
+- Sensitive values are redacted where appropriate.
+- Permission/session boundaries are visible.
+
+### Performance And Stability
+
+- Initial route load, refresh, and pagination are responsive enough for the local environment.
+- Large lists do not freeze the shell.
+- Loading skeletons preserve layout and do not create jarring shifts.
+- WebSocket/live streams degrade visibly when disconnected.
+
+## Severity
+
+- P0: Blocks the core workflow, corrupts or exposes sensitive data, bypasses authorization, or prevents safe rollback/publish/account control.
+- P1: Major workflow cannot be completed by the target actor, critical state is misleading, destructive action is ambiguous, or audit evidence is missing for a required action.
+- P2: Workflow completes but has significant UI/UX, accessibility, i18n, consistency, seed/reset, or evidence gaps that should be fixed before broad use.
+- P3: Minor polish, copy, spacing, or documentation issue that does not block acceptance but should be tracked.
+
+Use the highest severity that reflects user impact. Do not downgrade because a workaround exists unless the workaround is the documented intended path.
+
+## Automation Boundary
+
+Automate when the assertion is objective and repeatable:
+
+- Route loads and renders expected controls.
+- Search/filter/sort/pagination changes visible row/card sets.
+- Dialog/drawer opens and closes.
+- Form validation blocks invalid submit and shows error.
+- Publish/rollback/API call creates expected response and audit event.
+- Public discovery endpoint returns expected status/body/schema.
+- Accessibility labels exist for icon-only controls.
+- No console error occurs during a scripted path.
+
+Use human or agent product judgment when the assertion is qualitative:
+
+- Visual density feels aligned with Board.
+- Information hierarchy is clear enough for an operations admin.
+- Copy sets the right risk expectation.
+- Component choice matches MCPMate taste.
+- A new flow belongs in dialog, drawer, tab, table, card, or toolbar.
+- A workflow should be accepted despite a lower-level limitation.
+
+Hybrid checks should combine screenshot/video evidence with written judgment.
+
+## GitHub Project Feedback Loop
+
+The GitHub Project item is the canonical acceptance record.
+
+For each UAT pass or review:
+
+1. Link the relevant PR or branch.
+2. Record environment, seed/reset, commands, screenshots, and path results.
+3. Add findings with severity and owner.
+4. Keep unresolved P0/P1 issues out of "done" status.
+5. Convert P2/P3 items into follow-up Project items only when they are not required by the current acceptance contract.
+6. Attach Playwright, lint/build, backend/API, Inspector, or manual evidence before reporting ready for Loocor/Copilot review.
+
+## Recommended Report
+
+```markdown
+## UAT Decision
+[Conforming | Partially conforming | Non-conforming | Blocked]
+
+## Scope
+- Project item:
+- Surface:
+- Actor:
+- Environment:
+- Seed/reset:
+
+## Results
+- Passed:
+- Failed:
+- Blocked:
+
+## Findings
+- [P?] ...
+
+## Automation
+- Ran:
+- Missing:
+
+## Project Feedback
+- Updated:
+- Still needed:
+```
+
+## Stop Conditions
+
+Stop and ask for clarification when:
+
+- The active Project item and requested acceptance scope conflict.
+- The requested flow requires a migration, fallback, or compatibility layer not approved by the Project item.
+- Seed/reset would alter user data or client config outside the declared test namespace.
+- The UI path does not exist and the task is to judge implementation readiness rather than draft a playbook.

--- a/.agents/skills/uat-acceptance/references/mcpmate-ui-ux-reference.md
+++ b/.agents/skills/uat-acceptance/references/mcpmate-ui-ux-reference.md
@@ -1,0 +1,384 @@
+# MCPMate UI/UX Reference
+
+This reference is derived from the current Board implementation, which is the web management interface and the UI loaded by the Tauri shell. Use it as the taste baseline for MCPMate operational surfaces.
+
+## Evidence Sample
+
+The first version was sampled from:
+
+- `board/src/index.css`
+- `board/tailwind.config.js`
+- `board/src/App.tsx`
+- `board/src/components/layout/layout.tsx`
+- `board/src/components/layout/sidebar.tsx`
+- `board/src/components/layout/header.tsx`
+- `board/src/components/page-layout.tsx`
+- `board/src/components/ui/button.tsx`
+- `board/src/components/ui/card.tsx`
+- `board/src/components/ui/badge.tsx`
+- `board/src/components/ui/tabs.tsx`
+- `board/src/components/ui/segment.tsx`
+- `board/src/components/ui/select.tsx`
+- `board/src/components/ui/dialog.tsx`
+- `board/src/components/ui/alert-dialog.tsx`
+- `board/src/components/ui/drawer.tsx`
+- `board/src/components/entity-card.tsx`
+- `board/src/components/status-badge.tsx`
+- `board/src/components/audit-logs-panel.tsx`
+- `board/src/pages/dashboard/dashboard-page.tsx`
+- `board/src/pages/servers/server-list-page.tsx`
+- `board/src/pages/servers/server-detail-page.tsx`
+- `board/src/pages/clients/clients-page.tsx`
+- `board/src/pages/audit/audit-page.tsx`
+
+## Product Taste
+
+MCPMate should feel like a compact control plane for repeated operational work. The interface should be quiet, structured, and information-dense. It should not feel like a landing page, marketing site, showcase dashboard, or decorative SaaS mockup.
+
+Conforming:
+
+- Uses a persistent left sidebar plus fixed top header for navigation and context.
+- Keeps page content inside a viewport-height shell with internal scrolling.
+- Uses compact descriptions, tables, cards, badges, and toolbars to support scanning.
+- Makes state and ownership explicit: enabled/disabled, connected/disconnected, pending/allowed/denied, live/disconnected, success/failed/cancelled.
+- Uses icon buttons for compact tools and text buttons for clear commands.
+- Keeps data surfaces stable under refresh, toggles, filters, pagination, and language changes.
+
+Non-conforming:
+
+- Large hero sections, oversized marketing copy, decorative illustrations, or empty whitespace as the primary screen.
+- One-off palettes, gradients, oversized shadows, novelty controls, or unframed interaction patterns that do not match Board.
+- Hidden primary state, ambiguous destructive actions, missing loading/error/empty states, or workflow completion without audit visibility.
+- UI text that is hardcoded in Board-like React surfaces instead of using page translations and `defaultValue`.
+
+## Layout Density
+
+Board layout is dense but not cramped.
+
+- Shell: fixed sidebar (`w-64` expanded, `w-16` collapsed), fixed header (`h-16`), page padding `p-4`.
+- Page body: `space-y-4`, `gap-4`, cards and tables in a single scrollable content column.
+- Page header: compact one-line description on the left, toolbar/actions on the right.
+- Cards: generally `p-4`, `pb-2`, `pt-0`, or `pt-2`; card grids use `gap-4`.
+- Tables: `text-sm`, `py-2` header cells, `py-3` body cells, sticky headers for scrollable audit tables.
+- Toolbars: controls generally `h-9`; icon actions generally `h-9 w-9`.
+
+Conforming:
+
+- Use compact toolbar rows with search, filters, sort, refresh, and primary add/publish action.
+- Use internal scroll areas for long tables and detail tabs rather than growing the whole shell.
+- Use `min-w-0`, `truncate`, `whitespace-nowrap`, fixed colgroups, or stable widths where data can overflow.
+
+Non-conforming:
+
+- Page-level panels that float inside decorative wrappers.
+- Cards nested inside cards for layout decoration.
+- Controls that jump in size when loading, filtering, expanding rows, switching language, or changing route.
+- Dense data rendered as a sparse card gallery when a table or list is the clearer operational form.
+
+## Color
+
+Board uses shadcn-style HSL tokens with slate neutrals and a small set of semantic accents.
+
+- Light background: white / slate-50 style surfaces.
+- Dark background: slate-like dark tokens, with subtle borders close to card luminance.
+- Primary: near-slate/foreground token, not a brand-gradient.
+- Semantic accents:
+  - emerald for success/ready/allowed
+  - amber for warning/pending
+  - red/destructive for failed/denied/delete
+  - sky/info sparingly
+- Borders are subtle hairlines. Dark borders should not read as bright rails.
+
+Conforming:
+
+- Use theme tokens (`background`, `foreground`, `card`, `muted`, `border`, `primary`, `destructive`) where possible.
+- Use semantic badge colors to encode state.
+- Keep hover states restrained: accent background, subtle border, or small shadow.
+
+Non-conforming:
+
+- Purple/blue gradient dominance, one-note accent palettes, bright saturated backgrounds, or decorative color fields.
+- Destructive actions styled like normal primary actions.
+- State colors that conflict with Board semantics.
+
+## Typography
+
+Board typography is utilitarian and compact.
+
+- Header route titles: about `text-xl font-semibold`.
+- Page description: `text-base text-muted-foreground`, often truncated.
+- Card titles: default `text-2xl` in primitive, often overridden to `text-lg` or `text-sm`.
+- Entity titles: `text-lg font-semibold leading-tight`.
+- Body, controls, and table text: `text-sm`.
+- Dense metadata: `text-xs`, uppercase labels, mono text for protocol/version/config values.
+- Tiny repeated stats can use `text-[9px] uppercase tracking-wide`.
+
+Conforming:
+
+- Reserve large headings for route/header context. Keep card, drawer, and table headings tighter.
+- Use tabular numbers or mono text for durations, versions, protocols, IDs, paths, and code-like values.
+- Clamp or truncate long entity names, targets, routes, descriptions, and file paths.
+
+Non-conforming:
+
+- Hero-scale typography inside cards, drawers, dialogs, toolbars, or tables.
+- Text that overlaps controls or relies on viewport-width font scaling.
+- Uncontrolled wrapping that pushes critical actions offscreen.
+
+## Radius, Borders, Shadow
+
+The system uses moderate radius and clear but quiet boundaries.
+
+- Base radius token: `0.5rem`.
+- Buttons, selects, inputs, tabs, and toolbar controls: `rounded-md` or `rounded-sm`.
+- Cards currently use `rounded-xl` with `border border-border bg-card shadow-sm`.
+- Entity cards may add hover shadow and slight upward motion.
+- Dialogs and drawers use borders plus shadow, not heavy decoration.
+
+Conforming:
+
+- Use borders and small shadows to separate operational surfaces.
+- Use hover shadow on clickable entity cards only when it reinforces actionability.
+- Use dashed borders for empty/loading placeholders.
+
+Non-conforming:
+
+- Large pill cards, excessive shadows, glass effects, bokeh/orbs, or decorative wrappers.
+- Borderless controls in dense forms where affordance becomes unclear.
+
+## Icons
+
+Board uses `lucide-react`.
+
+Conforming:
+
+- Use lucide icons for navigation, toolbar actions, status affordances, and compact commands.
+- Use `h-4 w-4` for toolbar/action icons and about `20px` icons in sidebar links.
+- Add tooltips or accessible labels when the icon-only action is not self-explanatory.
+- Use icon-only buttons for compact tools such as refresh, inspect, theme, docs, feedback, expand row, and grid/list toggle.
+
+Non-conforming:
+
+- Custom SVG icons when a suitable lucide icon exists.
+- Icon-only destructive actions without clear tooltip, confirmation, or local context.
+- Decorative icons that do not clarify state or action.
+
+## Information Hierarchy
+
+Board gives each page a short route title in the fixed header, a compact page description, and then operational content.
+
+Conforming:
+
+- Place page-level actions in the right side of the page header or toolbar.
+- Place entity-specific actions on the entity card/list row/detail header.
+- Show operational summary cards only when they improve scanning or monitoring.
+- Use badges near the entity title or relevant metadata, not as decoration.
+- Use detail tabs for large peer sections and nested tabs only when the content belongs to a stable detail context.
+
+Non-conforming:
+
+- Repeating page titles in multiple places when the fixed header already establishes route context.
+- Moving primary actions into hidden menus without space pressure or risk rationale.
+- Mixing global actions and row actions in one unlabelled cluster.
+
+## Component Selection Rules
+
+### Tabs
+
+Use tabs for stable peer sections inside a detail page or dense workflow context. Board uses tabs for server capability sections and nested capability types.
+
+Conforming:
+
+- Use tabs when content can be lazy-loaded and users need to switch among persistent sections.
+- Keep tab labels short. Pair with URL state when deep-linking matters.
+
+Non-conforming:
+
+- Tabs used as a replacement for a binary toggle, one-off filter, or wizard progress.
+
+### Segment
+
+Use segment controls for small mutually exclusive modes that affect the same local surface.
+
+Conforming:
+
+- Mode selection such as view/transport/channel/state when the options are few and visible comparison helps.
+- Tooltip segment options when labels alone are ambiguous.
+
+Non-conforming:
+
+- Segment controls for long option lists, sparse settings, or destructive decisions.
+
+### Select
+
+Use select for compact option sets where only the selected value matters.
+
+Conforming:
+
+- Sort field, category filter, status filter, page size, server type, language, or profile selection.
+- Keep trigger height consistent with toolbar/form sizing (`h-9` in toolbar, `h-10` in forms).
+
+Non-conforming:
+
+- Select for two obvious binary states where switch/checkbox is clearer.
+- Select for large searchable data sets; use combobox/search instead.
+
+### Radio
+
+Use radio groups for visible exclusive choices when users must compare labels/descriptions before choosing.
+
+Conforming:
+
+- Deployment mode, exposure policy, or plan choice where each option needs explanation.
+
+Non-conforming:
+
+- Radio groups in cramped table rows or toolbars.
+
+### Checkbox
+
+Use checkbox for multi-select or independent inclusion choices.
+
+Conforming:
+
+- Selecting multiple clients, servers, capabilities, or rows.
+- Show indeterminate state for select-all when only some items are selected.
+
+Non-conforming:
+
+- Checkbox for global enablement of a single entity when a switch communicates state better.
+
+### Switch
+
+Use switch for immediate binary enablement that changes live state or governance state.
+
+Conforming:
+
+- Server enabled/disabled, client allowed/suspended, feature toggles.
+- Disable the switch or show pending state when an operation is in progress or cannot be changed.
+
+Non-conforming:
+
+- Switch for one-time destructive actions, irreversible choices, or settings that require multiple related fields.
+
+### Dialog
+
+Use dialog for short, focused forms or decisions.
+
+Conforming:
+
+- Small add/edit forms, account/session state, focused confirmation, or compact setup.
+- Title, description, cancel, submit, loading, and error state are visible.
+
+Non-conforming:
+
+- Long editors, multi-section workflows, or tables inside a small centered dialog.
+
+### Drawer / Sheet
+
+Board uses right-side Vaul drawers for larger editors and inspectors. Prefer this pattern for MCPMate operational editing.
+
+Conforming:
+
+- Server/client/profile editors, import review, inspector output, audit raw event details.
+- Right-side width around `sm:w-[560px]` to `md:w-[720px]`, full-height, scrollable, with clear header/footer.
+
+Non-conforming:
+
+- Center modal for a large editor that forces cramped scrolling.
+- Drawer without a clear close path, dirty-state handling, or submit/cancel affordance.
+
+### Table
+
+Use tables for audit, logs, registry rows, matrix-like capabilities, and dense comparable data.
+
+Conforming:
+
+- Fixed column widths, sticky header for scrollable regions, row expansion for details, pagination for long lists.
+- Truncate long target/path fields and provide detail drawer or expansion.
+
+Non-conforming:
+
+- Cards for log streams or dense event history.
+- Table columns that resize unpredictably when row expansion toggles.
+
+### Card
+
+Use cards for entity summaries, stats, and bounded repeated items.
+
+Conforming:
+
+- EntityCard pattern: avatar/title/description, top-right badge, small stats, bottom tags/actions.
+- Stats cards with title, value, short description.
+- Empty/loading states in a single card or dashed placeholder.
+
+Non-conforming:
+
+- Cards as generic page section wrappers around other cards.
+- Decorative cards that do not represent an entity, metric, or bounded task.
+
+## Forms
+
+Conforming:
+
+- Use React Hook Form + Zod in Board-style surfaces when validation is needed.
+- Use labels, descriptions, error messages, and stable IDs.
+- Group related fields with `space-y-4`, `gap-4`, and compact two-column layouts when space supports it.
+- Use drawers for long editors and dialogs only for short forms.
+- Surface backend/API errors directly instead of substituting hidden fallback behavior.
+- Keep submit/cancel actions in the footer and show loading spinners for pending submit.
+
+Non-conforming:
+
+- Unlabelled inputs, placeholder-only forms, hidden validation failures, or submit buttons far from the edited data.
+- Hardcoded user-facing text in Board-like React surfaces.
+- Silent defaults that create or publish data the user did not explicitly select.
+
+## Toolbars And Main Actions
+
+Conforming:
+
+- Search left/flexible, filters/sort/view mode/actions right.
+- Refresh and inspect are icon buttons with tooltips/titles.
+- Primary add/publish action is the rightmost or most visually prominent toolbar action.
+- Persist search/view/sort in URL when the page is list-heavy and deep-linking is useful.
+
+Non-conforming:
+
+- Multiple primary buttons with equal visual weight.
+- A toolbar that wraps into unreadable controls on narrower screens.
+- Primary action buried in a dropdown when there is enough space.
+
+## Status, Empty State, Danger, Audit
+
+Conforming:
+
+- Status badges use semantic variants and small dots when status should be scanned quickly.
+- Empty state explains whether there are no records or no matches after filters.
+- Dangerous actions use AlertDialog or ConfirmDialog, destructive styling, and clear irreversible copy.
+- Audit-sensitive flows expose reviewable event history, raw details, or a direct route to audit review.
+- Loading uses skeletons or restrained placeholders that preserve layout.
+
+Non-conforming:
+
+- Delete/publish/rollback without confirmation or audit trace.
+- Empty state that implies setup is complete when data is merely filtered out.
+- Error state that only logs to console or hides the backend message.
+
+## Page Structure
+
+Conforming Board-like page:
+
+1. Fixed shell provides route title, docs/feedback/theme/notifications, sidebar navigation.
+2. Page content starts with compact description plus toolbar/actions.
+3. Optional stats cards summarize operational state.
+4. Main content is list/grid/table/detail surface with loading, empty, error, and pagination as needed.
+5. Editors and raw details open in drawer/dialog without losing the list context.
+6. Significant changes produce notifications and update audit/event surfaces.
+
+Non-conforming page:
+
+1. Hero or marketing header dominates the first screen.
+2. Main action is separated from the relevant entity or hidden behind unrelated controls.
+3. Long data has no search/filter/sort/pagination.
+4. State changes have no visible feedback, no audit link, or no refresh/invalidation path.


### PR DESCRIPTION
## Summary
- Add the repo-local `uat-acceptance` skill as the MCPMate entry point for UI/UX review and UAT acceptance work.
- Capture the UI/UX reference inferred from the completed Board implementation, including layout density, color usage, typography, spacing, component choices, information hierarchy, and action placement.
- Add a reusable UAT strategy covering roles, environments, seed/reset expectations, user paths, acceptance dimensions, severity levels, automation boundaries, and the GitHub Project feedback loop.
- Add the first Admin Console UAT playbook for local admin login, account maintenance, portal/client/server editing, publish, public discovery endpoint checks, rollback, and audit review.
- Include `evals.json` prompts for a later with-skill vs baseline effectiveness review.

## Validation
- Checked repo-local skill structure against the existing `.agents/skills/` organization.
- Ran JSON validation for `.agents/skills/uat-acceptance/evals/evals.json`.
- Ran `git diff --check`.
- Completed a manual review of the uncommitted skill files with no actionable findings.

## Not Yet Validated
- Formal skill effectiveness evaluation has not been run yet.
- The follow-up validation should run the skill-creator with-skill vs baseline eval viewer and use the results to refine the skill wording or eval prompts if needed.

## Project
- Project item: `0.2.1f: MCPMate UAT acceptance system`.
- This PR provides the initial repository-local acceptance standard and playbook baseline. The formal skill evaluation remains a follow-up validation step before treating the UAT acceptance system as fully proven.