### PR TITLE
chore(website): refine nightly download entry

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -8,7 +8,6 @@ import Homepage from "./pages/Homepage";
 import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
 import { initGA, trackPageView } from "./utils/analytics";
-import CornerRibbon from "./components/ui/CornerRibbon";
 import DomainMigrationBanner from "./components/ui/DomainMigrationBanner";
 import { renderDocRoutes } from "./docs/DocRoutes";
 
@@ -79,8 +78,6 @@ function AppInner() {
 						</Routes>
 					</main>
 					<Footer />
-					{/* Site-wide updating ribbon */}
-					<CornerRibbon />
 				</div>
 			</LanguageProvider>
 		</ThemeProvider>

--- a/website/src/components/sections/Download.tsx
+++ b/website/src/components/sections/Download.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Download, ExternalLink, RefreshCw, Sparkles } from "lucide-react";
+import { ArrowRight, Download, ExternalLink, RefreshCw } from "lucide-react";
 import { useCallback, useId, useMemo } from "react";
 import { useLanguage } from "../LanguageProvider";
 import { useNavigate } from "react-router-dom";
@@ -43,57 +43,6 @@ const QuickStartSection = () => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <div className="space-y-6 min-w-0">
-            <div>
-              <h3 className="text-lg font-semibold mb-2">{t("download.getting_started")}</h3>
-              <p className="text-slate-600 dark:text-slate-400 mb-4">{t("download.getting_started.desc")}</p>
-              <Button
-                variant="outline"
-                className="w-full flex items-center justify-center gap-2"
-                onClick={() => navigate(language === "zh" ? "/docs/zh/quickstart" : language === "ja" ? "/docs/ja/quickstart" : "/docs/en/quickstart")}
-              >
-                <span>{t("download.read_guide")}</span>
-                <ArrowRight size={16} />
-              </Button>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold mb-2">{t("contact.github")}</h3>
-              <p className="text-slate-600 dark:text-slate-400 mb-4">{t("contact.github.desc")}</p>
-              <Button
-                variant="outline"
-                className="w-full flex items-center justify-center gap-2"
-                onClick={() => {
-                  const u = "https://github.com/loocor/mcpmate";
-                  trackMCPMateEvents.externalLinkClick(u);
-                  window.open(u, "_blank");
-                }}
-              >
-                <span>github.com/loocor/mcpmate</span>
-                <ArrowRight size={16} />
-              </Button>
-            </div>
-
-            <div className="rounded-lg border border-amber-200 bg-amber-50/80 p-4 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/20">
-              <div className="flex items-center gap-2 text-amber-900 dark:text-amber-200">
-                <Sparkles size={18} aria-hidden />
-                <h3 className="text-lg font-semibold">{t("download.nightly.title")}</h3>
-              </div>
-              <p className="mt-2 text-sm leading-6 text-amber-900/80 dark:text-amber-100/80">{t("download.nightly.desc")}</p>
-              <a
-                href={NIGHTLY_RELEASE_PAGE_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-md border border-amber-300 bg-white px-4 py-2 text-sm font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-slate-950/40 dark:text-amber-100 dark:hover:bg-amber-950/50"
-                onClick={() => trackMCPMateEvents.externalLinkClick(NIGHTLY_RELEASE_PAGE_URL)}
-              >
-                <span>{t("download.nightly.cta")}</span>
-                <ExternalLink size={16} aria-hidden />
-              </a>
-              <p className="mt-3 text-xs leading-5 text-amber-900/70 dark:text-amber-100/60">{t("download.nightly.disclaimer")}</p>
-            </div>
-          </div>
-
           <div className="min-w-0">
             <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
               <h3 className="text-lg font-semibold">{t("download.official_builds")}</h3>
@@ -108,25 +57,14 @@ const QuickStartSection = () => {
                     {t("download.retry")}
                   </button>
                 ) : null}
-                <a
-                  href={RELEASES_PAGE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                  onClick={() => trackMCPMateEvents.externalLinkClick(RELEASES_PAGE_URL)}
-                >
-                  {t("download.all_releases")}
-                  <ExternalLink size={14} aria-hidden />
-                </a>
+                {releaseState.status === "ok" ? (
+                  <span className="flex items-center gap-x-1 text-sm text-slate-600 dark:text-slate-400">
+                    <span className="font-medium text-slate-800 dark:text-slate-200">{t("download.latest_label")}: </span>
+                    <code className="bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded">{releaseState.latest.tag_name}</code>
+                  </span>
+                ) : null}
               </div>
             </div>
-
-            {releaseState.status === "ok" ? (
-              <p className="mb-3 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-sm text-slate-600 dark:text-slate-400">
-                <span className="font-medium text-slate-800 dark:text-slate-200">{t("download.latest_label")}: </span>
-                <code className="text-sm bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded">{releaseState.latest.tag_name}</code>
-              </p>
-            ) : null}
 
             {releaseState.status === "error" ? <p className="text-sm text-amber-700 dark:text-amber-400 mb-3">{t("download.load_error")}</p> : null}
 
@@ -216,7 +154,51 @@ const QuickStartSection = () => {
               </table>
             </div>
 
-            <p className="text-xs text-slate-500 dark:text-slate-500 mt-2">{t("download.platform_availability_note")}</p>
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-500">
+              {t("download.platform_availability_note")}{" "}
+              <a
+                href={NIGHTLY_RELEASE_PAGE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-medium text-amber-700 hover:underline dark:text-amber-400"
+                onClick={() => trackMCPMateEvents.externalLinkClick(NIGHTLY_RELEASE_PAGE_URL)}
+              >
+                {t("download.nightly.cta")}
+                <ExternalLink size={12} aria-hidden />
+              </a>
+            </p>
+          </div>
+
+          <div className="space-y-6 min-w-0">
+            <div>
+              <h3 className="text-lg font-semibold mb-2">{t("download.getting_started")}</h3>
+              <p className="text-slate-600 dark:text-slate-400 mb-4">{t("download.getting_started.desc")}</p>
+              <Button
+                variant="outline"
+                className="w-full flex items-center justify-center gap-2"
+                onClick={() => navigate(language === "zh" ? "/docs/zh/quickstart" : language === "ja" ? "/docs/ja/quickstart" : "/docs/en/quickstart")}
+              >
+                <span>{t("download.read_guide")}</span>
+                <ArrowRight size={16} />
+              </Button>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-semibold mb-2">{t("contact.github")}</h3>
+              <p className="text-slate-600 dark:text-slate-400 mb-4">{t("contact.github.desc")}</p>
+              <Button
+                variant="outline"
+                className="w-full flex items-center justify-center gap-2"
+                onClick={() => {
+                  const u = "https://github.com/loocor/mcpmate";
+                  trackMCPMateEvents.externalLinkClick(u);
+                  window.open(u, "_blank");
+                }}
+              >
+                <span>github.com/loocor/mcpmate</span>
+                <ArrowRight size={16} />
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/website/src/components/sections/Download.tsx
+++ b/website/src/components/sections/Download.tsx
@@ -155,12 +155,12 @@ const QuickStartSection = () => {
             </div>
 
             <p className="mt-2 text-xs text-slate-500 dark:text-slate-500">
-              {t("download.platform_availability_note")}{" "}
+              {t("download.nightly.note")}
               <a
                 href={NIGHTLY_RELEASE_PAGE_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 font-medium text-amber-700 hover:underline dark:text-amber-400"
+                className="ml-1 inline-flex items-center gap-1 font-medium text-amber-700 hover:underline dark:text-amber-400"
                 onClick={() => trackMCPMateEvents.externalLinkClick(NIGHTLY_RELEASE_PAGE_URL)}
               >
                 {t("download.nightly.cta")}

--- a/website/src/i18n/en.ts
+++ b/website/src/i18n/en.ts
@@ -57,8 +57,7 @@ const en = {
 	"download.load_error": "Release metadata could not be loaded. You can still open the releases page.",
 	"download.retry": "Retry",
 	"download.table_caption": "MCPMate desktop installers linked to the latest GitHub release",
-	"download.platform_availability_note":
-		"Daily Debug installers are published separately from stable releases:",
+	"download.nightly.note": "Daily Debug installers are published separately from stable releases:",
 	"download.latest_label": "Latest",
 	"download.platform_macos": "macOS",
 	"download.platform_windows": "Windows",

--- a/website/src/i18n/en.ts
+++ b/website/src/i18n/en.ts
@@ -58,7 +58,7 @@ const en = {
 	"download.retry": "Retry",
 	"download.table_caption": "MCPMate desktop installers linked to the latest GitHub release",
 	"download.platform_availability_note":
-		"macOS, Windows, and Linux installers are currently in Beta. macOS builds are signed and notarized to reduce system security prompts.",
+		"Daily Debug installers are published separately from stable releases:",
 	"download.latest_label": "Latest",
 	"download.platform_macos": "macOS",
 	"download.platform_windows": "Windows",
@@ -69,12 +69,7 @@ const en = {
 	"download.getting_started.desc":
 		"Follow our quick start guide to set up MCPMate and connect your first MCP service.",
 	"download.read_guide": "Read the Guide",
-	"download.nightly.title": "Nightly dev builds",
-	"download.nightly.desc":
-		"Automatically built installers for early testing, published separately from stable releases.",
 	"download.nightly.cta": "Open nightly channel",
-	"download.nightly.disclaimer":
-		"Nightly builds may be unstable and can change without migration support. Use stable releases for supported installs.",
 
 	// Features
 	"features.title": "Powerful Features",

--- a/website/src/i18n/ja.ts
+++ b/website/src/i18n/ja.ts
@@ -58,7 +58,7 @@ const ja = {
 	"download.retry": "再試行",
 	"download.table_caption": "GitHub の最新リリースに紐づく MCPMate デスクトップインストーラ",
 	"download.platform_availability_note":
-		"macOS、Windows、Linux の各インストーラはいずれも現在 Beta です。macOS ビルドは署名と公証に対応し、システムのセキュリティ警告を減らします。",
+		"毎日の Debug インストーラは安定版とは別に公開されます:",
 	"download.latest_label": "最新",
 	"download.platform_macos": "macOS",
 	"download.platform_windows": "Windows",
@@ -69,12 +69,7 @@ const ja = {
 	"download.getting_started.desc":
 		"クイックスタートガイドに従って MCPMate をセットアップし、最初の MCP サービスを接続しましょう。",
 	"download.read_guide": "ガイドを見る",
-	"download.nightly.title": "Nightly 開発ビルド",
-	"download.nightly.desc":
-		"早期テスト向けに自動生成されるインストーラで、安定版リリースとは別に公開されます。",
 	"download.nightly.cta": "Nightly チャンネルを開く",
-	"download.nightly.disclaimer":
-		"Nightly ビルドは不安定な場合があり、移行サポートなしで変更されることがあります。正式なインストールには安定版を使用してください。",
 
 	// 機能
 	"features.title": "強力な機能",

--- a/website/src/i18n/ja.ts
+++ b/website/src/i18n/ja.ts
@@ -57,8 +57,7 @@ const ja = {
 	"download.load_error": "リリース情報を読み込めませんでした。Releases ページから直接入手できます。",
 	"download.retry": "再試行",
 	"download.table_caption": "GitHub の最新リリースに紐づく MCPMate デスクトップインストーラ",
-	"download.platform_availability_note":
-		"毎日の Debug インストーラは安定版とは別に公開されます:",
+	"download.nightly.note": "毎日の Debug インストーラは安定版とは別に公開されます:",
 	"download.latest_label": "最新",
 	"download.platform_macos": "macOS",
 	"download.platform_windows": "Windows",

--- a/website/src/i18n/zh.ts
+++ b/website/src/i18n/zh.ts
@@ -56,8 +56,7 @@ const zh = {
 	"download.load_error": "无法加载版本信息，你仍可直接打开 Releases 页面下载。",
 	"download.retry": "重试",
 	"download.table_caption": "指向 GitHub 最新版本的 MCPMate 桌面安装包",
-	"download.platform_availability_note":
-		"每日 Debug 安装包与稳定版本分开发布：",
+	"download.nightly.note": "每日 Debug 安装包与稳定版本分开发布：",
 	"download.latest_label": "最新版本",
 	"download.platform_macos": "macOS",
 	"download.platform_windows": "Windows",

--- a/website/src/i18n/zh.ts
+++ b/website/src/i18n/zh.ts
@@ -57,7 +57,7 @@ const zh = {
 	"download.retry": "重试",
 	"download.table_caption": "指向 GitHub 最新版本的 MCPMate 桌面安装包",
 	"download.platform_availability_note":
-		"macOS、Windows 与 Linux 安装包目前均为 Beta 状态。macOS 构建已加入签名与公证，以减少系统安全提示。",
+		"每日 Debug 安装包与稳定版本分开发布：",
 	"download.latest_label": "最新版本",
 	"download.platform_macos": "macOS",
 	"download.platform_windows": "Windows",
@@ -68,12 +68,7 @@ const zh = {
 	"download.getting_started.desc":
 		"按照快速开始指南完成 MCPMate 安装，并连接你的第一个 MCP 服务。",
 	"download.read_guide": "查看指南",
-	"download.nightly.title": "Nightly 开发构建",
-	"download.nightly.desc":
-		"面向早期体验的自动构建安装包，与稳定版本分开发布。",
 	"download.nightly.cta": "打开 Nightly 通道",
-	"download.nightly.disclaimer":
-		"Nightly 构建可能不稳定，也可能在没有迁移支持的情况下变化。正式安装请使用稳定版本。",
 
 	// 功能区
 	"features.title": "强大功能",

--- a/website/src/utils/githubRelease.ts
+++ b/website/src/utils/githubRelease.ts
@@ -22,7 +22,7 @@ export const LIST_RELEASES_API_URL = `https://api.github.com/repos/${MCPMATE_GIT
 
 export const RELEASES_PAGE_URL = `https://github.com/${MCPMATE_GITHUB_OWNER}/${MCPMATE_GITHUB_REPO}/releases`;
 
-export const NIGHTLY_RELEASE_PAGE_URL = `${RELEASES_PAGE_URL}/tag/nightly`;
+export const NIGHTLY_RELEASE_PAGE_URL = `${RELEASES_PAGE_URL}?q=nightly`;
 
 export type DesktopBuildRowId =
 	| "macos-aarch64"


### PR DESCRIPTION
## Summary
- Move Official Desktop Builds to the primary column and keep DOM order aligned with the visual order.
- Replace the separate highlighted Nightly card with a compact Nightly channel link under the desktop downloads table.
- Point the Nightly channel to the GitHub release search URL: https://github.com/loocor/mcpmate/releases?q=nightly.
- Remove the fixed site-wide Updating corner ribbon from the app shell.

## Intentional choices
- The Nightly entry is intentionally plain text under the desktop downloads table instead of a highlighted card, so all installer-related actions stay in one semantic area.
- The top-right release metadata intentionally shows the latest tag instead of the All releases link to reduce vertical space.
- The CornerRibbon component and old i18n keys are left in place for now to keep this PR narrowly scoped; the rendered ribbon is removed by stopping the app-level mount.

## Validation
- bun run lint
- bun run build
- git diff --check