### PR TITLE
Switch browser extension discovery to the public worker

### DIFF
--- a/extension/browser/README.md
+++ b/extension/browser/README.md
@@ -4,7 +4,7 @@ The MCPMate browser extension shows curated MCP portals, servers, and clients in
 
 - **Product**: MCPMate
 - **Website**: [https://mcp.umate.ai](https://mcp.umate.ai)
-- **Admin API origin**: `https://auth.mcp.umate.ai`
+- **Public discovery API origin**: `https://public.mcp.umate.ai`
 - **Current discovery mode**: `account`
 
 The import handoff payload JSON matches desktop handling in `deep_link.rs`:
@@ -16,7 +16,7 @@ The import handoff payload JSON matches desktop handling in `deep_link.rs`:
 ## Features
 
 - Popup discovery tabs for **Portals**, **Servers**, and **Clients**.
-- Discovery data comes from the published MCPMate Admin discovery APIs.
+- Discovery data comes from the published Public Worker discovery APIs backed by MCPMate Admin catalog data.
 - Servers and clients request the `extension` surface with paginated discovery
   queries and load more entries as the popup list is scrolled.
 - Use the popup refresh button to reload the active discovery panel; touch
@@ -25,7 +25,7 @@ The import handoff payload JSON matches desktop handling in `deep_link.rs`:
 - Optional language and theme preferences live inside the toolbar popup settings panel.
 - Popup styling mirrors the shadcn Dashboard visual language with lightweight static HTML/CSS/JS, avoiding a React bundle inside the extension.
 - Optional icon metadata is supported when Admin catalog entries provide it.
-- Uses `config.js` as the extension deployment config. Update `adminApiOrigin` there if the Admin API origin changes.
+- Uses `config.js` as the extension deployment config. Update `discoveryApiOrigin` there if the public discovery API origin changes.
 - Run `bun extension/browser/scripts/write-build-info.mjs` before packaging to refresh `build-info.js` with the current build date.
 - The snippet-to-desktop import path remains enabled through `content.js` and `mcpmate://import/server`.
 - What remains disabled is telemetry-style import submission to Admin APIs. The extension does not upload import events or usage analytics to Admin in the current phase.
@@ -56,9 +56,9 @@ Status: Available on Chromium-based browser extension stores, including Chrome W
 ## Notes and limits
 
 - Reload the extension from your browser's extensions page after local changes.
-- `mock` mode remains available for local UI checks only. Production config uses `account` and does not silently fall back to mock data when the Admin API is unavailable.
+- `mock` mode remains available for local UI checks only. Production config uses `account` and does not silently fall back to mock data when the public discovery API is unavailable.
 - The paginated discovery UI uses the existing popup, the `storage` permission
-  for local settings/cache, and the published Admin API origin. It does not add
+  for local settings/cache, and the published public discovery API origin. It does not add
   background network activity, remote code execution, analytics submission, or
   new host/background permissions.
 - Mouse and trackpad gestures are not intercepted for pull-to-refresh, so text

--- a/extension/browser/config.js
+++ b/extension/browser/config.js
@@ -1,4 +1,4 @@
 globalThis.MCPMATE_EXTENSION_CONFIG = Object.freeze({
-	adminApiOrigin: "https://auth.mcp.umate.ai",
+	discoveryApiOrigin: "https://public.mcp.umate.ai",
 	discoveryMode: "account",
 });

--- a/extension/browser/discovery-state.test.mjs
+++ b/extension/browser/discovery-state.test.mjs
@@ -12,7 +12,19 @@ import {
 } from "./discovery-state.mjs";
 
 describe("browser extension discovery pagination", () => {
+	test("configures account discovery against the public worker", async () => {
+		delete globalThis.MCPMATE_EXTENSION_CONFIG;
+
+		await import(`./config.js?test=${Date.now()}`);
+
+		expect(globalThis.MCPMATE_EXTENSION_CONFIG).toEqual({
+			discoveryApiOrigin: "https://public.mcp.umate.ai",
+			discoveryMode: "account",
+		});
+	});
+
 	test("builds account discovery page URLs for the extension surface", () => {
+		const endpoint = "https://public.mcp.umate.ai/discovery/servers";
 		const query = discoveryQueryForPage({ kind: "servers", limit: 6, offset: 12 });
 
 		expect(query).toEqual({
@@ -20,9 +32,9 @@ describe("browser extension discovery pagination", () => {
 			offset: 12,
 			surface: "extension",
 		});
-		expect(
-			buildDiscoveryUrl("https://auth.mcp.umate.ai/discovery/servers", query),
-		).toBe("https://auth.mcp.umate.ai/discovery/servers?limit=6&offset=12&surface=extension");
+		expect(buildDiscoveryUrl(endpoint, query)).toBe(
+			"https://public.mcp.umate.ai/discovery/servers?limit=6&offset=12&surface=extension",
+		);
 	});
 
 	test("does not paginate portal requests", () => {

--- a/extension/browser/popup.js
+++ b/extension/browser/popup.js
@@ -12,13 +12,13 @@ import {
 	shouldStartPullRefresh,
 } from "./discovery-state.mjs";
 
-const ADMIN_ORIGIN = globalThis.MCPMATE_EXTENSION_CONFIG.adminApiOrigin;
+const DISCOVERY_ORIGIN = globalThis.MCPMATE_EXTENSION_CONFIG.discoveryApiOrigin;
 const BUILD_DATE = globalThis.MCPMATE_EXTENSION_BUILD.buildDate;
 const DISCOVERY_MODE = globalThis.MCPMATE_EXTENSION_CONFIG.discoveryMode || "account";
 const DISCOVERY_ENDPOINTS = {
-	portals: `${ADMIN_ORIGIN}/discovery/portals`,
-	servers: `${ADMIN_ORIGIN}/discovery/servers`,
-	clients: `${ADMIN_ORIGIN}/discovery/clients`,
+	portals: `${DISCOVERY_ORIGIN}/discovery/portals`,
+	servers: `${DISCOVERY_ORIGIN}/discovery/servers`,
+	clients: `${DISCOVERY_ORIGIN}/discovery/clients`,
 };
 const MOCK_DISCOVERY_ENDPOINTS = {
 	portals: chrome.runtime.getURL("mock/portals.json"),
@@ -304,7 +304,7 @@ async function writeSettings(settings) {
 }
 
 function discoveryCacheKey(kind, requestUrl) {
-	return `${DISCOVERY_CACHE_KEY_PREFIX}.${DISCOVERY_MODE}.${ADMIN_ORIGIN}.${kind}.${encodeURIComponent(requestUrl)}`;
+	return `${DISCOVERY_CACHE_KEY_PREFIX}.${DISCOVERY_MODE}.${DISCOVERY_ORIGIN}.${kind}.${encodeURIComponent(requestUrl)}`;
 }
 
 async function readDiscoveryCache(kind, requestUrl) {


### PR DESCRIPTION
## Summary
- Point the browser extension at `https://public.mcp.umate.ai` for discovery data.
- Rename the config key to `discoveryApiOrigin` and update popup endpoint/cache key usage.
- Refresh the extension README to describe the Public Worker boundary clearly.
- Add test coverage for the new public discovery configuration and URL construction.

## Testing
- `bun test extension/browser`
- `git diff --check`
- Local API smoke test confirmed `portals`, `servers`, and `clients` return live data from the Public Worker.