### PR TITLE
Improve compact operator panel onboarding, language sync, and controls

### DIFF
--- a/board/e2e/compact-operator-panel.spec.ts
+++ b/board/e2e/compact-operator-panel.spec.ts
@@ -620,7 +620,7 @@ test("operator route follows dashboard language storage updates", async ({
 		const key = "mcp_dashboard_settings";
 		const oldValue = window.localStorage.getItem(key);
 		const nextValue = JSON.stringify({
-			defaultView: "grid",
+			defaultView: "list",
 			language: "zh-cn",
 		});
 		window.localStorage.setItem(key, nextValue);
@@ -641,6 +641,14 @@ test("operator route follows dashboard language storage updates", async ({
 	await expect(page.getByText("Profiles")).toHaveCount(0);
 	await expect(page.getByText("Operator Panel")).toHaveCount(0);
 	await expect(page.getByText(/running · .* uptime/)).toHaveCount(0);
+
+	const storedSettings = await page.evaluate(() =>
+		JSON.parse(window.localStorage.getItem("mcp_dashboard_settings") ?? "{}"),
+	);
+	expect(storedSettings).toEqual({
+		defaultView: "list",
+		language: "zh-cn",
+	});
 });
 
 test("operator route places close as the rightmost header control in Tauri shell", async ({

--- a/board/e2e/compact-operator-panel.spec.ts
+++ b/board/e2e/compact-operator-panel.spec.ts
@@ -643,6 +643,31 @@ test("operator route follows dashboard language storage updates", async ({
 	await expect(page.getByText(/running · .* uptime/)).toHaveCount(0);
 });
 
+test("operator route places close as the rightmost header control in Tauri shell", async ({
+	page,
+}) => {
+	await installReadyApiMocks(page);
+	await installTauriPendingFullBoardPathMock(page, null);
+	await installDashboardLanguage(page, "en");
+
+	await page.goto("/operator");
+	await expect(page.getByRole("button", { name: "Pin on top" })).toBeVisible();
+
+	const controlLabels = await page
+		.locator("header [aria-label]")
+		.evaluateAll((elements) =>
+			elements
+				.map((element) => element.getAttribute("aria-label"))
+				.filter((label) =>
+					label === "Pin on top" ||
+					label === "Open Full Board" ||
+					label === "Close",
+				),
+		);
+
+	expect(controlLabels).toEqual(["Pin on top", "Open Full Board", "Close"]);
+});
+
 test("operator route preserves explicit system error status in core meta", async ({
 	page,
 }) => {

--- a/board/e2e/compact-operator-panel.spec.ts
+++ b/board/e2e/compact-operator-panel.spec.ts
@@ -556,6 +556,36 @@ test("operator route keeps incomplete onboarding out of the tray surface in web 
 	await expect(page.getByText("Runtime requirements")).toHaveCount(0);
 });
 
+test("operator route refreshes incomplete onboarding status while gated", async ({
+	page,
+}) => {
+	await installReadyApiMocks(page);
+	let statusRequests = 0;
+	await page.route("**/api/onboarding/status", (route) => {
+		statusRequests += 1;
+		const completed = statusRequests > 1;
+		return route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				success: true,
+				data: {
+					completed,
+					servers_count: completed ? 3 : 0,
+					clients_count: completed ? 2 : 0,
+				},
+			}),
+		});
+	});
+
+	await page.goto("/operator");
+
+	await expect(page.getByRole("heading", { name: "Setup required" })).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Setup required" })).toHaveCount(0);
+	await expect(page.getByTestId("operator-chart-carousel")).toBeVisible();
+	expect(statusRequests).toBeGreaterThan(1);
+});
+
 test("operator route presents query errors instead of empty successful rows", async ({
 	page,
 }) => {

--- a/board/e2e/compact-operator-panel.spec.ts
+++ b/board/e2e/compact-operator-panel.spec.ts
@@ -698,6 +698,28 @@ test("operator route preserves explicit system error status in core meta", async
 	await expect(page.getByText(/unknown · .* uptime/)).toHaveCount(0);
 });
 
+test("operator route preserves unrecognized system status in core meta", async ({
+	page,
+}) => {
+	await installReadyApiMocks(page);
+	await page.route("**/api/system/status", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				status: "stopping",
+				uptime: 3661,
+				version: "test",
+			}),
+		}),
+	);
+
+	await page.goto("/operator");
+
+	await expect(page.getByText(/stopping · .* uptime/)).toBeVisible();
+	await expect(page.getByText(/unknown · .* uptime/)).toHaveCount(0);
+});
+
 test("operator route presents query errors instead of empty successful rows", async ({
 	page,
 }) => {

--- a/board/e2e/compact-operator-panel.spec.ts
+++ b/board/e2e/compact-operator-panel.spec.ts
@@ -7,6 +7,24 @@ declare global {
 	}
 }
 
+type TestDashboardLanguage = "en" | "zh-cn" | "ja";
+
+async function installDashboardLanguage(
+	page: Page,
+	language: TestDashboardLanguage,
+): Promise<void> {
+	await page.addInitScript((selectedLanguage) => {
+		window.localStorage.setItem("i18nextLng", selectedLanguage);
+		window.localStorage.setItem(
+			"mcp_dashboard_settings",
+			JSON.stringify({
+				defaultView: "grid",
+				language: selectedLanguage,
+			}),
+		);
+	}, language);
+}
+
 async function installReadyApiMocks(page: Page): Promise<void> {
 	await page.route("**/api/**", async (route) => {
 		const request = route.request();
@@ -584,6 +602,67 @@ test("operator route refreshes incomplete onboarding status while gated", async 
 	await expect(page.getByRole("heading", { name: "Setup required" })).toHaveCount(0);
 	await expect(page.getByTestId("operator-chart-carousel")).toBeVisible();
 	expect(statusRequests).toBeGreaterThan(1);
+});
+
+test("operator route follows dashboard language storage updates", async ({
+	page,
+}) => {
+	await installReadyApiMocks(page);
+	await installDashboardLanguage(page, "en");
+
+	await page.goto("/operator");
+
+	await expect(page.getByText("Operator Panel")).toBeVisible();
+	await expect(page.getByText("Profiles")).toBeVisible();
+	await expect(page.getByText(/running · .* uptime/)).toBeVisible();
+
+	await page.evaluate(() => {
+		const key = "mcp_dashboard_settings";
+		const oldValue = window.localStorage.getItem(key);
+		const nextValue = JSON.stringify({
+			defaultView: "grid",
+			language: "zh-cn",
+		});
+		window.localStorage.setItem(key, nextValue);
+		window.dispatchEvent(
+			new StorageEvent("storage", {
+				key,
+				oldValue,
+				newValue: nextValue,
+				storageArea: window.localStorage,
+				url: window.location.href,
+			}),
+		);
+	});
+
+	await expect(page.getByText("操作面板")).toBeVisible();
+	await expect(page.getByText("配置集")).toBeVisible();
+	await expect(page.getByText(/运行中 · 已运行/)).toBeVisible();
+	await expect(page.getByText("Profiles")).toHaveCount(0);
+	await expect(page.getByText("Operator Panel")).toHaveCount(0);
+	await expect(page.getByText(/running · .* uptime/)).toHaveCount(0);
+});
+
+test("operator route preserves explicit system error status in core meta", async ({
+	page,
+}) => {
+	await installReadyApiMocks(page);
+	await page.route("**/api/system/status", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				status: "error",
+				uptime: 3661,
+				version: "test",
+			}),
+		}),
+	);
+
+	await page.goto("/operator");
+
+	await expect(page.getByText(/error · .* uptime/)).toBeVisible();
+	await expect(page.getByText(/unknown · .* uptime/)).toHaveCount(0);
 });
 
 test("operator route presents query errors instead of empty successful rows", async ({

--- a/board/src/components/language-synchronizer.ts
+++ b/board/src/components/language-synchronizer.ts
@@ -5,7 +5,12 @@ import {
 	resolveI18nLanguage,
 	SUPPORTED_LANGUAGES,
 } from "../lib/i18n/index";
-import { useAppStore } from "../lib/store";
+import {
+	DASHBOARD_SETTINGS_KEY,
+	type DashboardLanguage,
+	isDashboardLanguage,
+	useAppStore,
+} from "../lib/store";
 
 const FALLBACK_STORE_LANGUAGE = "en";
 
@@ -18,6 +23,23 @@ function mapI18nToStore(code: string): string {
 function mapStoreToI18n(code: string): string {
 	const match = SUPPORTED_LANGUAGES.find((entry) => entry.store === code);
 	return match?.i18n ?? resolveI18nLanguage(code);
+}
+
+function readStoredDashboardLanguage(raw: string | null): DashboardLanguage | null {
+	if (!raw) {
+		return null;
+	}
+
+	try {
+		const parsed = JSON.parse(raw) as { language?: unknown };
+		if (isDashboardLanguage(parsed.language)) {
+			return parsed.language;
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
 }
 
 export function LanguageSynchronizer() {
@@ -42,6 +64,24 @@ export function LanguageSynchronizer() {
 				}
 			})();
 		}
+	}, [dashboardLanguage, setDashboardSetting]);
+
+	useEffect(() => {
+		const handleStorage = (event: StorageEvent) => {
+			if (event.key !== DASHBOARD_SETTINGS_KEY) {
+				return;
+			}
+
+			const nextLanguage = readStoredDashboardLanguage(event.newValue);
+			if (!nextLanguage || nextLanguage === dashboardLanguage) {
+				return;
+			}
+
+			setDashboardSetting("language", nextLanguage);
+		};
+
+		window.addEventListener("storage", handleStorage);
+		return () => window.removeEventListener("storage", handleStorage);
 	}, [dashboardLanguage, setDashboardSetting]);
 
 	useEffect(() => {

--- a/board/src/components/language-synchronizer.ts
+++ b/board/src/components/language-synchronizer.ts
@@ -7,8 +7,6 @@ import {
 } from "../lib/i18n/index";
 import {
 	DASHBOARD_SETTINGS_KEY,
-	type DashboardLanguage,
-	isDashboardLanguage,
 	useAppStore,
 } from "../lib/store";
 
@@ -25,28 +23,14 @@ function mapStoreToI18n(code: string): string {
 	return match?.i18n ?? resolveI18nLanguage(code);
 }
 
-function readStoredDashboardLanguage(raw: string | null): DashboardLanguage | null {
-	if (!raw) {
-		return null;
-	}
-
-	try {
-		const parsed = JSON.parse(raw) as { language?: unknown };
-		if (isDashboardLanguage(parsed.language)) {
-			return parsed.language;
-		}
-	} catch {
-		return null;
-	}
-
-	return null;
-}
-
 export function LanguageSynchronizer() {
 	const dashboardLanguage = useAppStore(
 		(state) => state.dashboardSettings.language,
 	);
 	const setDashboardSetting = useAppStore((state) => state.setDashboardSetting);
+	const syncDashboardSettingsFromStorage = useAppStore(
+		(state) => state.syncDashboardSettingsFromStorage,
+	);
 	const { i18n } = useTranslation();
 	const initialisedRef = useRef(false);
 
@@ -68,21 +52,16 @@ export function LanguageSynchronizer() {
 
 	useEffect(() => {
 		const handleStorage = (event: StorageEvent) => {
-			if (event.key !== DASHBOARD_SETTINGS_KEY) {
+			if (event.key !== DASHBOARD_SETTINGS_KEY || !event.newValue) {
 				return;
 			}
 
-			const nextLanguage = readStoredDashboardLanguage(event.newValue);
-			if (!nextLanguage || nextLanguage === dashboardLanguage) {
-				return;
-			}
-
-			setDashboardSetting("language", nextLanguage);
+			syncDashboardSettingsFromStorage(event.newValue);
 		};
 
 		window.addEventListener("storage", handleStorage);
 		return () => window.removeEventListener("storage", handleStorage);
-	}, [dashboardLanguage, setDashboardSetting]);
+	}, [syncDashboardSettingsFromStorage]);
 
 	useEffect(() => {
 		void (async () => {

--- a/board/src/lib/store.ts
+++ b/board/src/lib/store.ts
@@ -80,6 +80,7 @@ interface AppState {
 		value: DashboardSettings[K],
 	) => void;
 	updateDashboardSettings: (patch: Partial<DashboardSettings>) => void;
+	syncDashboardSettingsFromStorage: (raw: string) => void;
 	removeFromMarketBlacklist: (serverId: string) => void;
 	addToMarketBlacklist: (entry: MarketBlacklistEntry) => void;
 	pendingServerDeepLinkImport: PendingServerDeepLinkImport | null;
@@ -294,6 +295,18 @@ function readDashboardSettings(): DashboardSettings {
 	}
 }
 
+function parseDashboardSettingsSnapshot(raw: string): DashboardSettings | null {
+	try {
+		const parsed = JSON.parse(raw) as Partial<DashboardSettings> | null;
+		if (!parsed || typeof parsed !== "object") {
+			return null;
+		}
+		return normalizeDashboardSettings(defaultDashboardSettings, parsed);
+	} catch {
+		return null;
+	}
+}
+
 function persistDashboardSettings(settings: DashboardSettings) {
 	try {
 		if (typeof window !== "undefined") {
@@ -393,6 +406,13 @@ export const useAppStore = create<AppState>((set) => ({
 			persistDashboardSettings(next);
 			return { dashboardSettings: next };
 		});
+	},
+	syncDashboardSettingsFromStorage: (raw) => {
+		const next = parseDashboardSettingsSnapshot(raw);
+		if (!next) {
+			return;
+		}
+		set({ dashboardSettings: next });
 	},
 	removeFromMarketBlacklist: (serverId) => {
 		set((state) => {

--- a/board/src/lib/store.ts
+++ b/board/src/lib/store.ts
@@ -88,7 +88,11 @@ interface AppState {
 	) => void;
 }
 
-const DASHBOARD_SETTINGS_KEY = "mcp_dashboard_settings";
+export const DASHBOARD_SETTINGS_KEY = "mcp_dashboard_settings";
+
+export function isDashboardLanguage(value: unknown): value is DashboardLanguage {
+	return value === "en" || value === "zh-cn" || value === "ja";
+}
 
 const defaultDashboardSettings: DashboardSettings = {
 	defaultView: "grid",
@@ -137,11 +141,7 @@ function normalizeDashboardSettings(
 		next.defaultView = patch.defaultView;
 	}
 
-	if (
-		patch.language === "en" ||
-		patch.language === "zh-cn" ||
-		patch.language === "ja"
-	) {
+	if (isDashboardLanguage(patch.language)) {
 		next.language = patch.language;
 	}
 

--- a/board/src/pages/operator/i18n/index.ts
+++ b/board/src/pages/operator/i18n/index.ts
@@ -12,6 +12,14 @@ export const operatorTranslations = {
 			connections: "Clients & Servers",
 			activity: "Activity",
 		},
+		systemStatus: {
+			running: "running",
+			degraded: "degraded",
+			stopped: "stopped",
+			starting: "starting",
+			error: "error",
+			unknown: "unknown",
+		},
 		charts: {
 			carouselLabel: "Resource and token usage charts",
 			pagination: "Chart pagination",
@@ -247,10 +255,18 @@ export const operatorTranslations = {
 		pin: "置顶",
 		unpin: "取消置顶",
 		groups: {
-			runtime: "Runtime 与 Profiles",
+			runtime: "运行与配置",
 			workspace: "工作区",
-			connections: "Clients 与 Servers",
-			activity: "Activity",
+			connections: "客户端与服务器",
+			activity: "活动",
+		},
+		systemStatus: {
+			running: "运行中",
+			degraded: "降级运行",
+			stopped: "已停止",
+			starting: "启动中",
+			error: "错误",
+			unknown: "未知",
 		},
 		charts: {
 			carouselLabel: "资源与 Token 使用图表",
@@ -297,7 +313,7 @@ export const operatorTranslations = {
 		},
 		rows: {
 			core: {
-				title: "Core",
+				title: "核心",
 				ready: "MCPMate Core 已就绪",
 				notReady: "Core 需要关注",
 				loading: "正在检查 Core 状态",
@@ -305,7 +321,7 @@ export const operatorTranslations = {
 				meta: "{{status}} · 已运行 {{uptime}}",
 			},
 			profiles: {
-				title: "Profiles",
+				title: "配置集",
 				summary_one: "{{active}} 个 Profile 已启用",
 				summary_other: "{{total}} 个 Profile 中 {{active}} 个已启用",
 				noDefault: "未选择默认 Profile",
@@ -313,7 +329,7 @@ export const operatorTranslations = {
 				error: "无法获取 Profiles",
 			},
 			clients: {
-				title: "Clients",
+				title: "客户端",
 				summary_one: "检测到 {{count}} 个客户端",
 				summary_other: "检测到 {{count}} 个客户端",
 				meta: "{{approved}} 已批准 · {{pending}} 待处理",
@@ -327,7 +343,7 @@ export const operatorTranslations = {
 				error: "无法获取 Clients",
 			},
 			servers: {
-				title: "Servers",
+				title: "服务器",
 				summary_one: "已安装 {{count}} 个 Server",
 				summary_other: "已安装 {{count}} 个 Server",
 				meta: "{{active}} 已激活 · {{attention}} 需关注",
@@ -345,7 +361,7 @@ export const operatorTranslations = {
 				error: "无法获取流量指标",
 			},
 			activity: {
-				title: "Activity",
+				title: "活动",
 				lastEvent: "最近：{{action}}",
 				noEvents: "暂无近期活动",
 				loading: "正在加载 Activity",
@@ -489,6 +505,14 @@ export const operatorTranslations = {
 			workspace: "ワークスペース",
 			connections: "Clients と Servers",
 			activity: "Activity",
+		},
+		systemStatus: {
+			running: "実行中",
+			degraded: "縮退中",
+			stopped: "停止中",
+			starting: "起動中",
+			error: "エラー",
+			unknown: "不明",
 		},
 		charts: {
 			carouselLabel: "リソースと Token 使用チャート",

--- a/board/src/pages/operator/tray-operator-panel-page.tsx
+++ b/board/src/pages/operator/tray-operator-panel-page.tsx
@@ -93,7 +93,7 @@ function formatActivityMeta(
 	});
 }
 
-function systemStatusTranslationKey(status: string): string {
+function systemStatusTranslationKey(status: string): string | null {
 	switch (status) {
 		case "running":
 			return "operator:systemStatus.running";
@@ -105,8 +105,10 @@ function systemStatusTranslationKey(status: string): string {
 			return "operator:systemStatus.starting";
 		case "error":
 			return "operator:systemStatus.error";
-		default:
+		case "unknown":
 			return "operator:systemStatus.unknown";
+		default:
+			return null;
 	}
 }
 
@@ -528,9 +530,12 @@ export function TrayOperatorPanelPage() {
 						defaultValue: "Open Full Board to create or activate a profile.",
 					});
 
-			const localizedSystemStatus = rowT(systemStatusTranslationKey(systemStatus), {
-				defaultValue: systemStatus,
-			});
+			const systemStatusKey = systemStatusTranslationKey(systemStatus);
+			const localizedSystemStatus = systemStatusKey
+				? rowT(systemStatusKey, {
+						defaultValue: systemStatus,
+					})
+				: systemStatus;
 
 			const clientsDetailHint =
 				pendingClients > 0

--- a/board/src/pages/operator/tray-operator-panel-page.tsx
+++ b/board/src/pages/operator/tray-operator-panel-page.tsx
@@ -394,6 +394,8 @@ export function TrayOperatorPanelPage() {
 		queryKey: ["onboardingStatus"],
 		queryFn: () => onboardingApi.getStatus(),
 		staleTime: 60_000,
+		refetchInterval: (query) =>
+			query.state.data?.data?.completed === false ? 2_000 : false,
 		retry: false,
 		refetchOnWindowFocus: false,
 	});
@@ -449,6 +451,24 @@ export function TrayOperatorPanelPage() {
 	});
 
 	const onboardingCompleted = onboardingQuery.data?.data?.completed;
+	const { refetch: refetchOnboardingStatus } = onboardingQuery;
+
+	React.useEffect(() => {
+		const refetchOnActivation = () => {
+			if (document.visibilityState === "hidden") {
+				return;
+			}
+			void refetchOnboardingStatus();
+		};
+
+		window.addEventListener("focus", refetchOnActivation);
+		document.addEventListener("visibilitychange", refetchOnActivation);
+		return () => {
+			window.removeEventListener("focus", refetchOnActivation);
+			document.removeEventListener("visibilitychange", refetchOnActivation);
+		};
+	}, [refetchOnboardingStatus]);
+
 	const servers = serversQuery.data?.servers ?? [];
 	const connectedServers = servers.filter(
 		(server) => String(server.status).toLowerCase() === "connected",

--- a/board/src/pages/operator/tray-operator-panel-page.tsx
+++ b/board/src/pages/operator/tray-operator-panel-page.tsx
@@ -1002,42 +1002,26 @@ export function TrayOperatorPanelPage() {
 				controls={
 					<>
 						{isTauriShell ? (
-							<>
-								<Button
-									type="button"
-									variant="ghost"
-									size="icon"
-									className="h-8 w-8"
-									aria-pressed={pinned}
-									aria-label={t(pinned ? "operator:unpin" : "operator:pin", {
-										defaultValue: pinned ? "Unpin" : "Pin on top",
-									})}
-									style={operatorNoDragRegionStyle}
-									title={t(pinned ? "operator:unpin" : "operator:pin", {
-										defaultValue: pinned ? "Unpin" : "Pin on top",
-									})}
-									disabled={pinPending}
-									onClick={() => {
-										void togglePinned();
-									}}
-								>
-									{pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
-								</Button>
-								<Button
-									type="button"
-									variant="ghost"
-									size="icon"
-									className="h-8 w-8 text-slate-600 dark:text-slate-300"
-									aria-label={t("operator:close", { defaultValue: "Close" })}
-									style={operatorNoDragRegionStyle}
-									title={t("operator:close", { defaultValue: "Close" })}
-									onClick={() => {
-										void runDesktopAction(closeOperatorPanel);
-									}}
-								>
-									<X className="h-4 w-4" />
-								</Button>
-							</>
+							<Button
+								type="button"
+								variant="ghost"
+								size="icon"
+								className="h-8 w-8"
+								aria-pressed={pinned}
+								aria-label={t(pinned ? "operator:unpin" : "operator:pin", {
+									defaultValue: pinned ? "Unpin" : "Pin on top",
+								})}
+								style={operatorNoDragRegionStyle}
+								title={t(pinned ? "operator:unpin" : "operator:pin", {
+									defaultValue: pinned ? "Unpin" : "Pin on top",
+								})}
+								disabled={pinPending}
+								onClick={() => {
+									void togglePinned();
+								}}
+							>
+								{pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
+							</Button>
 						) : null}
 						<OperatorFullBoardControl
 							className="h-8 w-8 text-slate-600 dark:text-slate-300"
@@ -1046,6 +1030,22 @@ export function TrayOperatorPanelPage() {
 							onDesktopOpen={openFullBoardPath}
 							path="/"
 						/>
+						{isTauriShell ? (
+							<Button
+								type="button"
+								variant="ghost"
+								size="icon"
+								className="h-8 w-8 text-slate-600 dark:text-slate-300"
+								aria-label={t("operator:close", { defaultValue: "Close" })}
+								style={operatorNoDragRegionStyle}
+								title={t("operator:close", { defaultValue: "Close" })}
+								onClick={() => {
+									void runDesktopAction(closeOperatorPanel);
+								}}
+							>
+								<X className="h-4 w-4" />
+							</Button>
+						) : null}
 					</>
 				}
 			/>

--- a/board/src/pages/operator/tray-operator-panel-page.tsx
+++ b/board/src/pages/operator/tray-operator-panel-page.tsx
@@ -93,6 +93,23 @@ function formatActivityMeta(
 	});
 }
 
+function systemStatusTranslationKey(status: string): string {
+	switch (status) {
+		case "running":
+			return "operator:systemStatus.running";
+		case "degraded":
+			return "operator:systemStatus.degraded";
+		case "stopped":
+			return "operator:systemStatus.stopped";
+		case "starting":
+			return "operator:systemStatus.starting";
+		case "error":
+			return "operator:systemStatus.error";
+		default:
+			return "operator:systemStatus.unknown";
+	}
+}
+
 const ROW_EXPAND_CHEVRON_CLASS =
 	"h-4 w-4 shrink-0 text-slate-400 transition-transform duration-200 dark:text-slate-500";
 
@@ -511,6 +528,10 @@ export function TrayOperatorPanelPage() {
 						defaultValue: "Open Full Board to create or activate a profile.",
 					});
 
+			const localizedSystemStatus = rowT(systemStatusTranslationKey(systemStatus), {
+				defaultValue: systemStatus,
+			});
+
 			const clientsDetailHint =
 				pendingClients > 0
 					? rowT("operator:detail.clients.pending", {
@@ -547,7 +568,7 @@ export function TrayOperatorPanelPage() {
 									defaultValue: "Core needs attention",
 								}),
 					meta: rowT("operator:rows.core.meta", {
-						status: systemStatus,
+						status: localizedSystemStatus,
 						uptime: formatUptime(systemQuery.data?.uptime ?? 0),
 						defaultValue: "{{status}} · {{uptime}} uptime",
 					}),


### PR DESCRIPTION
## Summary
- Refreshes incomplete onboarding status in the compact operator panel so it can recover after setup completes in the full board.
- Keeps the compact panel in sync with dashboard language changes and removes mixed-language output in shared status text.
- Reorders the Tauri header controls so the close button sits at the far right.
- Adds E2E coverage for onboarding refresh, language storage updates, explicit system error status rendering, and header control order.

## Testing
- E2E coverage added and exercised for the compact operator panel scenarios above.
- Frontend validation completed during implementation with lint, build, and targeted Playwright checks passing.

## Scope
- No config, schema, or migration impact.
- Small UI behavior change only; ready for human review.