### PR TITLE
Update canonical SEO metadata for the website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -7,11 +7,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Import MCP servers once, share them across AI clients, and grow from simple setup to profiles, per-client tools, setup modes, and runtime checks." />
     <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="MCPMate" />
     <meta property="og:title" content="MCPMate: Progressive MCP management partner" />
     <meta property="og:description" content="Import MCP servers once, share them across AI clients, and grow from simple setup to profiles, per-client tools, setup modes, and runtime checks." />
+    <meta property="og:image" content="https://mcp.umate.ai/screenshot/dashboard-light.png" />
+    <meta property="og:image:alt" content="MCPMate dashboard showing resource metrics and token savings side by side." />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="MCPMate: Progressive MCP management partner" />
     <meta name="twitter:description" content="Import MCP servers once, share them across AI clients, and grow from simple setup to profiles, per-client tools, setup modes, and runtime checks." />
+    <meta name="twitter:image" content="https://mcp.umate.ai/screenshot/dashboard-light.png" />
+    <meta name="twitter:image:alt" content="MCPMate dashboard showing resource metrics and token savings side by side." />
     <title>MCPMate: Progressive MCP management partner</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /api/
 
-Sitemap: https://mcpmate.dev/sitemap.xml
+Sitemap: https://mcp.umate.ai/sitemap.xml

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -1,211 +1,218 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  <url><loc>https://mcpmate.dev</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://mcpmate.dev/privacy</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://mcpmate.dev/terms</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://mcpmate.dev/docs/en/quickstart</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/quickstart"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/quickstart"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/quickstart"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/quickstart"/>
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url><loc>https://mcp.umate.ai/</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.8</priority>
+    <image:image>
+      <image:loc>https://mcp.umate.ai/screenshot/dashboard-light.png</image:loc>
+      <image:title>MCPMate dashboard</image:title>
+      <image:caption>MCPMate dashboard showing resource metrics and token savings side by side.</image:caption>
+    </image:image>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/features-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/features-overview"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/features-overview"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/features-overview"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/features-overview"/>
+  <url><loc>https://mcp.umate.ai/privacy</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mcp.umate.ai/terms</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mcp.umate.ai/docs/en/quickstart</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/quickstart"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/quickstart"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/quickstart"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/quickstart"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/centralized-config</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/centralized-config"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/centralized-config"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/centralized-config"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/centralized-config"/>
+  <url><loc>https://mcp.umate.ai/docs/en/features-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/features-overview"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/features-overview"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/features-overview"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/features-overview"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/resource-optimization</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/resource-optimization"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/resource-optimization"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/resource-optimization"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/resource-optimization"/>
+  <url><loc>https://mcp.umate.ai/docs/en/centralized-config</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/centralized-config"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/centralized-config"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/centralized-config"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/centralized-config"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/inspector</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/inspector"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/inspector"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/inspector"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/inspector"/>
+  <url><loc>https://mcp.umate.ai/docs/en/resource-optimization</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/resource-optimization"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/resource-optimization"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/resource-optimization"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/resource-optimization"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/context-switching</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/context-switching"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/context-switching"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/context-switching"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/context-switching"/>
+  <url><loc>https://mcp.umate.ai/docs/en/inspector</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/inspector"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/inspector"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/inspector"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/inspector"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/protocol-bridging</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/protocol-bridging"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/protocol-bridging"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/protocol-bridging"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/protocol-bridging"/>
+  <url><loc>https://mcp.umate.ai/docs/en/context-switching</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/context-switching"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/context-switching"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/context-switching"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/context-switching"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/marketplace</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/marketplace"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/marketplace"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/marketplace"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/marketplace"/>
+  <url><loc>https://mcp.umate.ai/docs/en/protocol-bridging</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/protocol-bridging"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/protocol-bridging"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/protocol-bridging"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/protocol-bridging"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/granular-controls</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/granular-controls"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/granular-controls"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/granular-controls"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/granular-controls"/>
+  <url><loc>https://mcp.umate.ai/docs/en/marketplace</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/marketplace"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/marketplace"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/marketplace"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/marketplace"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/auto-discovery</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/auto-discovery"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/auto-discovery"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/auto-discovery"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/auto-discovery"/>
+  <url><loc>https://mcp.umate.ai/docs/en/granular-controls</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/granular-controls"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/granular-controls"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/granular-controls"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/granular-controls"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/uni-import</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/uni-import"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/uni-import"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/uni-import"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/uni-import"/>
+  <url><loc>https://mcp.umate.ai/docs/en/auto-discovery</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/auto-discovery"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/auto-discovery"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/auto-discovery"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/auto-discovery"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/guides-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/guides-overview"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/guides-overview"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/guides-overview"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/guides-overview"/>
+  <url><loc>https://mcp.umate.ai/docs/en/uni-import</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/uni-import"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/uni-import"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/uni-import"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/uni-import"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/dashboard</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/dashboard"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/dashboard"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/dashboard"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/dashboard"/>
+  <url><loc>https://mcp.umate.ai/docs/en/guides-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/guides-overview"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/guides-overview"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/guides-overview"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/guides-overview"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/profile</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/profile"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/profile"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/profile"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/profile"/>
+  <url><loc>https://mcp.umate.ai/docs/en/dashboard</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/dashboard"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/dashboard"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/dashboard"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/dashboard"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/profile-presets</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/profile-presets"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/profile-presets"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/profile-presets"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/profile-presets"/>
+  <url><loc>https://mcp.umate.ai/docs/en/profile</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/profile"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/profile"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/profile"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/profile"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/profile-detail-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/profile-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/profile-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/profile-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/profile-detail-overview"/>
+  <url><loc>https://mcp.umate.ai/docs/en/profile-presets</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/profile-presets"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/profile-presets"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/profile-presets"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/profile-presets"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/profile-capabilities</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/profile-capabilities"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/profile-capabilities"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/profile-capabilities"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/profile-capabilities"/>
+  <url><loc>https://mcp.umate.ai/docs/en/profile-detail-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/profile-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/profile-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/profile-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/profile-detail-overview"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/clients</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/clients"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/clients"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/clients"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/clients"/>
+  <url><loc>https://mcp.umate.ai/docs/en/profile-capabilities</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/profile-capabilities"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/profile-capabilities"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/profile-capabilities"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/profile-capabilities"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/client-detail-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/client-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/client-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/client-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/client-detail-overview"/>
+  <url><loc>https://mcp.umate.ai/docs/en/clients</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/clients"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/clients"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/clients"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/clients"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/client-configuration</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/client-configuration"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/client-configuration"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/client-configuration"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/client-configuration"/>
+  <url><loc>https://mcp.umate.ai/docs/en/client-detail-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/client-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/client-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/client-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/client-detail-overview"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/client-backups</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/client-backups"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/client-backups"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/client-backups"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/client-backups"/>
+  <url><loc>https://mcp.umate.ai/docs/en/client-configuration</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/client-configuration"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/client-configuration"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/client-configuration"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/client-configuration"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/servers</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/servers"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/servers"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/servers"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/servers"/>
+  <url><loc>https://mcp.umate.ai/docs/en/client-backups</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/client-backups"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/client-backups"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/client-backups"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/client-backups"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/server-import-preview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/server-import-preview"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/server-import-preview"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/server-import-preview"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/server-import-preview"/>
+  <url><loc>https://mcp.umate.ai/docs/en/servers</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/servers"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/servers"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/servers"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/servers"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/server-detail-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/server-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/server-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/server-detail-overview"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/server-detail-overview"/>
+  <url><loc>https://mcp.umate.ai/docs/en/server-import-preview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/server-import-preview"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/server-import-preview"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/server-import-preview"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/server-import-preview"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/server-capabilities</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/server-capabilities"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/server-capabilities"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/server-capabilities"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/server-capabilities"/>
+  <url><loc>https://mcp.umate.ai/docs/en/server-detail-overview</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/server-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/server-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/server-detail-overview"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/server-detail-overview"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/server-inspector</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/server-inspector"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/server-inspector"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/server-inspector"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/server-inspector"/>
+  <url><loc>https://mcp.umate.ai/docs/en/server-capabilities</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/server-capabilities"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/server-capabilities"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/server-capabilities"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/server-capabilities"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/server-instances</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/server-instances"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/server-instances"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/server-instances"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/server-instances"/>
+  <url><loc>https://mcp.umate.ai/docs/en/server-inspector</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/server-inspector"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/server-inspector"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/server-inspector"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/server-inspector"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/market</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/market"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/market"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/market"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/market"/>
+  <url><loc>https://mcp.umate.ai/docs/en/server-instances</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/server-instances"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/server-instances"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/server-instances"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/server-instances"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/runtime</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/runtime"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/runtime"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/runtime"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/runtime"/>
+  <url><loc>https://mcp.umate.ai/docs/en/market</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/market"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/market"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/market"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/market"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/settings</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/settings"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/settings"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/settings"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/settings"/>
+  <url><loc>https://mcp.umate.ai/docs/en/runtime</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/runtime"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/runtime"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/runtime"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/runtime"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/logs</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/logs"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/logs"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/logs"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/logs"/>
+  <url><loc>https://mcp.umate.ai/docs/en/settings</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/settings"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/settings"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/settings"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/settings"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/api-docs</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/api-docs"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/api-docs"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/api-docs"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/api-docs"/>
+  <url><loc>https://mcp.umate.ai/docs/en/logs</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/logs"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/logs"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/logs"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/logs"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/changelog</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/changelog"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/changelog"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/changelog"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/changelog"/>
+  <url><loc>https://mcp.umate.ai/docs/en/api-docs</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/api-docs"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/api-docs"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/api-docs"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/api-docs"/>
   </url>
-  <url><loc>https://mcpmate.dev/docs/en/roadmap</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://mcpmate.dev/docs/en/roadmap"/>
-    <xhtml:link rel="alternate" hreflang="zh" href="https://mcpmate.dev/docs/zh/roadmap"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://mcpmate.dev/docs/ja/roadmap"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcpmate.dev/docs/en/roadmap"/>
+  <url><loc>https://mcp.umate.ai/docs/en/changelog</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/changelog"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/changelog"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/changelog"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/changelog"/>
+  </url>
+  <url><loc>https://mcp.umate.ai/docs/en/roadmap</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://mcp.umate.ai/docs/en/roadmap"/>
+    <xhtml:link rel="alternate" hreflang="zh" href="https://mcp.umate.ai/docs/zh/roadmap"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://mcp.umate.ai/docs/ja/roadmap"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://mcp.umate.ai/docs/en/roadmap"/>
   </url>
 </urlset>

--- a/website/src/docs/layout/DocLayout.tsx
+++ b/website/src/docs/layout/DocLayout.tsx
@@ -5,6 +5,7 @@ import ToC from "./ToC";
 import SchemaOrg from "../../components/SchemaOrg";
 import { setDocumentMeta } from "../../utils/seo";
 import { buildBreadcrumbList } from "../../utils/schema";
+import { SITE_URL } from "../../utils/site";
 
 export type DocMeta = {
 	title: string;
@@ -15,8 +16,6 @@ type Props = {
 	meta: DocMeta;
 	children: React.ReactNode;
 };
-
-const SITE_URL = "https://mcpmate.dev";
 
 function deriveBreadcrumbs(pathname: string, title: string) {
 	const segments = pathname.split("/").filter(Boolean);

--- a/website/src/pages/Privacy.tsx
+++ b/website/src/pages/Privacy.tsx
@@ -1,13 +1,20 @@
 import { useEffect } from "react";
 import { useLanguage } from "../components/LanguageProvider";
 import Section from "../components/ui/Section";
+import { setDocumentMeta } from "../utils/seo";
 
 const Privacy = () => {
 	const { language } = useLanguage();
 
 	useEffect(() => {
-		document.title =
-			language === "zh" ? "隐私政策 — MCPMate" : "Privacy Policy — MCPMate";
+		setDocumentMeta({
+			title: language === "zh" ? "隐私政策 — MCPMate" : "Privacy Policy — MCPMate",
+			description:
+				language === "zh"
+					? "了解 MCPMate 网站、桌面应用和代理如何处理分析、联系表单、下载事件和本地优先产品数据。"
+					: "Learn how MCPMate handles analytics, contact forms, download events, and local-first product data across the website, desktop app, and proxy.",
+			pathname: "/privacy",
+		});
 	}, [language]);
 
 	// Ensure reading starts at the top whenever opening Privacy or changing language

--- a/website/src/pages/Terms.tsx
+++ b/website/src/pages/Terms.tsx
@@ -1,13 +1,21 @@
 import { useEffect } from "react";
 import { useLanguage } from "../components/LanguageProvider";
 import Section from "../components/ui/Section";
+import { setDocumentMeta } from "../utils/seo";
 
 const Terms = () => {
 	const { language } = useLanguage();
 
 	useEffect(() => {
-		document.title =
-			language === "zh" ? "服务条款 — MCPMate" : "Terms of Service — MCPMate";
+		setDocumentMeta({
+			title:
+				language === "zh" ? "服务条款 — MCPMate" : "Terms of Service — MCPMate",
+			description:
+				language === "zh"
+					? "查看 MCPMate 网站、桌面应用和代理早期访问版本的使用条款、许可范围和责任边界。"
+					: "Review the terms, license scope, and responsibility boundaries for MCPMate website, desktop app, and proxy early-access use.",
+			pathname: "/terms",
+		});
 	}, [language]);
 
 	// Ensure reading starts at the top whenever opening Terms or changing language

--- a/website/src/utils/schema.ts
+++ b/website/src/utils/schema.ts
@@ -3,6 +3,13 @@
  * Produces machine-readable structured data for AI answer engines.
  */
 
+import {
+	SITE_LOGO_URL,
+	SITE_PREVIEW_IMAGE_URL,
+	SITE_URL,
+	buildSiteUrl,
+} from "./site";
+
 export interface FAQItem {
   question: string;
   answer: string;
@@ -33,10 +40,13 @@ export function buildSoftwareApplication(overrides?: {
       url: "https://github.com/loocor",
     },
     license: "https://www.gnu.org/licenses/agpl-3.0.html",
-    url: overrides?.url ?? "https://mcpmate.dev",
+    url: overrides?.url ?? SITE_URL,
+    logo: SITE_LOGO_URL,
+    image: SITE_PREVIEW_IMAGE_URL,
+    screenshot: SITE_PREVIEW_IMAGE_URL,
     softwareHelp: {
       "@type": "CreativeWork",
-      url: "https://mcpmate.dev/docs/en/quickstart",
+      url: buildSiteUrl("/docs/en/quickstart"),
     },
     featureList: [
       "MCP server management",
@@ -54,7 +64,9 @@ export function buildOrganization() {
     "@context": "https://schema.org",
     "@type": "Organization",
     name: "MCPMate",
-    url: "https://mcpmate.dev",
+    url: SITE_URL,
+    logo: SITE_LOGO_URL,
+    image: SITE_PREVIEW_IMAGE_URL,
     sameAs: ["https://github.com/loocor/mcpmate"],
   };
 }

--- a/website/src/utils/seo.ts
+++ b/website/src/utils/seo.ts
@@ -1,3 +1,10 @@
+import {
+	SITE_NAME,
+	SITE_PREVIEW_IMAGE_ALT,
+	SITE_PREVIEW_IMAGE_URL,
+	buildSiteUrl,
+} from "./site";
+
 type MetaConfig = {
 	title: string;
 	description?: string;
@@ -48,13 +55,45 @@ export function setDocumentMeta({ title, description, pathname }: MetaConfig) {
 		property: "og:title",
 		content: title,
 	});
+	upsertMeta('meta[property="og:site_name"]', {
+		property: "og:site_name",
+		content: SITE_NAME,
+	});
+	upsertMeta('meta[property="og:type"]', {
+		property: "og:type",
+		content: "website",
+	});
+	upsertMeta('meta[property="og:image"]', {
+		property: "og:image",
+		content: SITE_PREVIEW_IMAGE_URL,
+	});
+	upsertMeta('meta[property="og:image:alt"]', {
+		property: "og:image:alt",
+		content: SITE_PREVIEW_IMAGE_ALT,
+	});
+	upsertMeta('meta[name="twitter:card"]', {
+		name: "twitter:card",
+		content: "summary_large_image",
+	});
 	upsertMeta('meta[name="twitter:title"]', {
 		name: "twitter:title",
 		content: title,
 	});
+	upsertMeta('meta[name="twitter:image"]', {
+		name: "twitter:image",
+		content: SITE_PREVIEW_IMAGE_URL,
+	});
+	upsertMeta('meta[name="twitter:image:alt"]', {
+		name: "twitter:image:alt",
+		content: SITE_PREVIEW_IMAGE_ALT,
+	});
 
 	if (typeof window !== "undefined") {
-		const canonicalUrl = new URL(pathname ?? window.location.pathname, window.location.origin).toString();
+		const canonicalUrl = buildSiteUrl(pathname ?? window.location.pathname);
 		upsertCanonical(canonicalUrl);
+		upsertMeta('meta[property="og:url"]', {
+			property: "og:url",
+			content: canonicalUrl,
+		});
 	}
 }

--- a/website/src/utils/site.ts
+++ b/website/src/utils/site.ts
@@ -1,0 +1,10 @@
+export const SITE_URL = "https://mcp.umate.ai";
+export const SITE_NAME = "MCPMate";
+export const SITE_LOGO_URL = `${SITE_URL}/logo.svg`;
+export const SITE_PREVIEW_IMAGE_URL = `${SITE_URL}/screenshot/dashboard-light.png`;
+export const SITE_PREVIEW_IMAGE_ALT =
+	"MCPMate dashboard showing resource metrics and token savings side by side.";
+
+export function buildSiteUrl(pathname = "/") {
+	return new URL(pathname, SITE_URL).toString();
+}


### PR DESCRIPTION
## Summary
- Update the public website to use `https://mcp.umate.ai` as the canonical domain in robots, sitemap, structured data, and page metadata.
- Add stable site metadata helpers and use the current light dashboard screenshot for OpenGraph, Twitter, and sitemap image previews.
- Keep the legacy `mcpmate.io` migration banner intact while removing stale `mcpmate.dev` discovery signals.

## Testing
- `bun --cwd=website run build` passed.
- Targeted ESLint passed for the touched TypeScript and TSX files.
- `xmllint --noout website/public/sitemap.xml` passed.
- `git diff --check --cached` passed.

## Notes
- Scope stayed within the website package; admin was not touched.
- No fallback behavior or compatibility shim was added.