### PR TITLE
fix(registry): preserve package install options

### DIFF
--- a/backend/src/api/handlers/registry.rs
+++ b/backend/src/api/handlers/registry.rs
@@ -105,9 +105,14 @@ pub struct CachedRegistryIcon {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CachedRegistryTransport {
-    pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variables: Option<Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -116,11 +121,23 @@ pub struct CachedRegistryPackagePayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registry_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry_base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_hint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transport: Option<CachedRegistryPackageTransport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_variables: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package_arguments: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_arguments: Option<Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -329,27 +346,22 @@ fn parse_remotes(raw: Option<&str>) -> Option<Vec<CachedRegistryTransport>> {
     let parsed = raw.and_then(|source| serde_json::from_str::<Vec<CachedRegistryRemote>>(source).ok())?;
     let remotes: Vec<CachedRegistryTransport> = parsed
         .into_iter()
-        .filter_map(|remote| {
-            let remote_type = remote
-                .r#type
-                .and_then(|value| {
-                    let trimmed = value.trim();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed.to_string())
-                    }
-                })
-                .unwrap_or_else(|| "streamable_http".to_string());
+        .map(|remote| {
+            let remote_type = remote.r#type.and_then(|value| {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            });
 
-            if remote.url.as_deref().is_none_or(str::is_empty) {
-                return None;
-            }
-
-            Some(CachedRegistryTransport {
+            CachedRegistryTransport {
                 r#type: remote_type,
                 url: remote.url,
-            })
+                headers: remote.headers,
+                variables: remote.variables,
+            }
         })
         .collect();
 
@@ -360,13 +372,49 @@ fn parse_packages(raw: Option<&str>) -> Option<Vec<CachedRegistryPackagePayload>
     let parsed = raw.and_then(|source| serde_json::from_str::<Vec<CachedRegistryPackage>>(source).ok())?;
     let packages: Vec<CachedRegistryPackagePayload> = parsed
         .into_iter()
-        .map(|package| CachedRegistryPackagePayload {
-            registry_type: Some("npm".to_string()),
-            identifier: package.name,
-            version: package.version,
-            transport: Some(CachedRegistryPackageTransport {
-                r#type: "stdio".to_string(),
-            }),
+        .map(|package| {
+            let identifier = package.identifier.and_then(|value| {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            });
+            let registry_type = package.registry_type.and_then(|value| {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            });
+            let transport = package
+                .transport
+                .and_then(|transport| transport.r#type)
+                .and_then(|value| {
+                    let trimmed = value.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(CachedRegistryPackageTransport {
+                            r#type: trimmed.to_string(),
+                        })
+                    }
+                });
+
+            CachedRegistryPackagePayload {
+                registry_type,
+                registry_base_url: package.registry_base_url,
+                identifier,
+                version: package.version,
+                runtime_hint: package.runtime_hint,
+                file_sha256: package.file_sha256,
+                transport,
+                environment_variables: package.environment_variables,
+                package_arguments: package.package_arguments,
+                runtime_arguments: package.runtime_arguments,
+            }
         })
         .collect();
 
@@ -743,9 +791,12 @@ mod tests {
             title: Some("Filesystem".to_string()),
             description: Some("File operations".to_string()),
             packages_json: Some(
-                r#"[{"name":"@modelcontextprotocol/server-filesystem","version":"1.2.3"}]"#.to_string(),
+                r#"[{"registryType":"npm","identifier":"@modelcontextprotocol/server-filesystem","version":"1.2.3","runtimeHint":"node","fileSha256":"abc123","transport":{"type":"stdio"},"environmentVariables":[{"name":"FILESYSTEM_ROOT","isRequired":true}]}]"#.to_string(),
             ),
-            remotes_json: Some(r#"[{"url":"https://example.com/mcp","type":"streamable_http"}]"#.to_string()),
+            remotes_json: Some(
+                r#"[{"url":"https://example.com/{region}/mcp","type":"streamable-http","headers":[{"name":"Authorization","isRequired":true,"isSecret":true}],"variables":{"region":{"isRequired":true,"default":"us-east-1"}}}]"#
+                    .to_string(),
+            ),
             icons_json: None,
             meta_json: Some(r#"{"custom":true}"#.to_string()),
             website_url: Some("https://example.com/filesystem".to_string()),
@@ -758,14 +809,74 @@ mod tests {
 
         let wrapper = cache_entry_to_server_wrapper(entry);
         assert_eq!(wrapper.server.name, "filesystem");
-        assert!(wrapper.server.remotes.is_some());
-        assert!(wrapper.server.packages.is_some());
+        let remotes = wrapper.server.remotes.expect("remote payloads");
+        assert_eq!(
+            remotes[0]
+                .headers
+                .as_ref()
+                .and_then(Value::as_array)
+                .and_then(|headers| headers.first())
+                .and_then(|header| header.get("name"))
+                .and_then(Value::as_str),
+            Some("Authorization")
+        );
+        assert_eq!(
+            remotes[0]
+                .variables
+                .as_ref()
+                .and_then(|variables| variables.get("region"))
+                .and_then(|region| region.get("default"))
+                .and_then(Value::as_str),
+            Some("us-east-1")
+        );
+        let packages = wrapper.server.packages.expect("package payloads");
+        assert_eq!(
+            packages[0].identifier.as_deref(),
+            Some("@modelcontextprotocol/server-filesystem")
+        );
+        assert_eq!(packages[0].registry_type.as_deref(), Some("npm"));
+        assert_eq!(packages[0].runtime_hint.as_deref(), Some("node"));
+        assert_eq!(packages[0].file_sha256.as_deref(), Some("abc123"));
+        assert_eq!(
+            packages[0]
+                .transport
+                .as_ref()
+                .map(|transport| transport.r#type.as_str()),
+            Some("stdio")
+        );
+        assert!(packages[0].environment_variables.is_some());
 
         let meta = wrapper.meta.expect("wrapper metadata");
         let official = meta
             .get("io.modelcontextprotocol.registry/official")
             .expect("official metadata");
         assert_eq!(official.get("serverId").and_then(Value::as_str), Some("filesystem"));
+    }
+
+    #[test]
+    fn test_parse_packages_preserves_entries_without_identifier() {
+        let packages = parse_packages(Some(
+            r#"[
+                {"registryType":"npm","transport":{"type":"stdio"}},
+                {"registryType":"npm","identifier":"@upstash/context7-mcp","transport":{"type":"stdio"}}
+            ]"#,
+        ))
+        .expect("package payloads");
+
+        assert_eq!(packages.len(), 2);
+        assert!(packages[0].identifier.is_none());
+        assert_eq!(packages[1].identifier.as_deref(), Some("@upstash/context7-mcp"));
+    }
+
+    #[test]
+    fn test_parse_packages_preserves_missing_registry_type_and_transport() {
+        let packages =
+            parse_packages(Some(r#"[{"identifier":"@scope/package","version":"1.0.0"}]"#)).expect("package payloads");
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].identifier.as_deref(), Some("@scope/package"));
+        assert!(packages[0].registry_type.is_none());
+        assert!(packages[0].transport.is_none());
     }
 
     #[test]
@@ -811,7 +922,10 @@ mod tests {
                 schema_url: Some("https://modelcontextprotocol.io/schema/server.schema.json".to_string()),
                 title: Some("Cached Server".to_string()),
                 description: Some("Cached registry entry".to_string()),
-                packages_json: Some(r#"[{"name":"@scope/cached-server","version":"0.1.0"}]"#.to_string()),
+                packages_json: Some(
+                    r#"[{"registryType":"npm","identifier":"@scope/cached-server","version":"0.1.0","transport":{"type":"stdio"}}]"#
+                        .to_string(),
+                ),
                 remotes_json: Some(r#"[{"url":"https://cached.example/mcp","type":"streamable_http"}]"#.to_string()),
                 icons_json: None,
                 meta_json: None,

--- a/backend/src/config/registry/sync.rs
+++ b/backend/src/config/registry/sync.rs
@@ -43,12 +43,36 @@ pub struct RegistryServer {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegistryPackage {
     #[serde(default)]
-    pub name: Option<String>,
+    pub registry_type: Option<String>,
+    #[serde(default)]
+    pub registry_base_url: Option<String>,
+    #[serde(default, alias = "name")]
+    pub identifier: Option<String>,
     #[serde(default)]
     pub version: Option<String>,
+    #[serde(default)]
+    pub runtime_hint: Option<String>,
+    #[serde(default)]
+    pub file_sha256: Option<String>,
+    #[serde(default)]
+    pub transport: Option<RegistryPackageTransport>,
+    #[serde(default)]
+    pub environment_variables: Option<serde_json::Value>,
+    #[serde(default)]
+    pub package_arguments: Option<serde_json::Value>,
+    #[serde(default)]
+    pub runtime_arguments: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistryPackageTransport {
+    #[serde(default)]
+    pub r#type: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -57,6 +81,10 @@ pub struct RegistryRemote {
     pub url: Option<String>,
     #[serde(default)]
     pub r#type: Option<String>,
+    #[serde(default)]
+    pub headers: Option<serde_json::Value>,
+    #[serde(default)]
+    pub variables: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -346,7 +374,7 @@ mod tests {
                     "url": "https://github.com/example/test-server",
                     "source": "github"
                 },
-                "packages": [{"name": "test-pkg", "version": "1.0.0"}],
+                "packages": [{"name": "test-pkg", "version": "1.0.0", "runtimeHint": "node", "fileSha256": "abc123"}],
                 "remotes": [{"url": "https://example.com", "type": "http"}],
                 "icons": [{"url": "https://example.com/icon.png"}],
                 "status": "active"
@@ -363,6 +391,9 @@ mod tests {
         assert_eq!(server.server.version, "1.0.0");
         assert_eq!(server.server.title, Some("Test Server".to_string()));
         assert_eq!(server.server.packages.len(), 1);
+        assert_eq!(server.server.packages[0].identifier.as_deref(), Some("test-pkg"));
+        assert_eq!(server.server.packages[0].runtime_hint.as_deref(), Some("node"));
+        assert_eq!(server.server.packages[0].file_sha256.as_deref(), Some("abc123"));
         assert_eq!(server.server.remotes.len(), 1);
         assert_eq!(server.server.icons.len(), 1);
         assert!(server.meta.is_some());
@@ -392,8 +423,15 @@ mod tests {
                     id: None,
                 }),
                 packages: vec![RegistryPackage {
-                    name: Some("test-pkg".to_string()),
+                    registry_type: Some("npm".to_string()),
+                    identifier: Some("test-pkg".to_string()),
                     version: Some("1.0.0".to_string()),
+                    runtime_hint: Some("node".to_string()),
+                    file_sha256: Some("abc123".to_string()),
+                    transport: Some(RegistryPackageTransport {
+                        r#type: Some("stdio".to_string()),
+                    }),
+                    ..RegistryPackage::default()
                 }],
                 remotes: vec![],
                 icons: vec![],

--- a/backend/src/config/server/import.rs
+++ b/backend/src/config/server/import.rs
@@ -744,9 +744,21 @@ fn validate_server_config(
 
 /// Package information extracted from registry cache
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct RegistryPackage {
-    name: Option<String>,
+    registry_type: Option<String>,
+    #[serde(alias = "name")]
+    identifier: Option<String>,
     version: Option<String>,
+    transport: Option<RegistryPackageTransport>,
+    environment_variables: Option<Vec<RegistryNamedInput>>,
+    package_arguments: Option<Vec<RegistryNamedInput>>,
+    runtime_arguments: Option<Vec<RegistryNamedInput>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RegistryPackageTransport {
+    r#type: Option<String>,
 }
 
 /// Remote information extracted from registry cache
@@ -754,6 +766,20 @@ struct RegistryPackage {
 struct RegistryRemote {
     url: Option<String>,
     r#type: Option<String>,
+    headers: Option<serde_json::Value>,
+    variables: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RegistryNamedInput {
+    name: Option<String>,
+    value: Option<String>,
+    default: Option<String>,
+    #[serde(rename = "type")]
+    argument_type: Option<String>,
+    #[serde(default)]
+    is_required: bool,
 }
 
 /// Result of converting a registry package to import config
@@ -763,6 +789,132 @@ struct PackageImportConfig {
     command: Option<String>,
     args: Option<Vec<String>>,
     url: Option<String>,
+    env: Option<HashMap<String, String>>,
+    headers: Option<HashMap<String, String>>,
+}
+
+fn compact_string(value: Option<&str>) -> Option<&str> {
+    let value = value?.trim();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn normalize_registry_remote_kind(value: Option<&str>) -> Result<&'static str> {
+    match compact_string(value).map(str::to_ascii_lowercase).as_deref() {
+        Some("sse") => Ok("sse"),
+        Some("streamable-http" | "streamable_http" | "streamablehttp" | "http") => Ok("streamable_http"),
+        Some(other) => Err(anyhow::anyhow!("Unsupported remote transport type '{}'", other)),
+        None => Err(anyhow::anyhow!("Remote transport type is required")),
+    }
+}
+
+fn ensure_registry_package_stdio_transport(value: Option<&str>) -> Result<()> {
+    match compact_string(value).map(str::to_ascii_lowercase).as_deref() {
+        Some("stdio") => Ok(()),
+        Some(other) => Err(anyhow::anyhow!(
+            "Unsupported package transport type '{}' for stdio server",
+            other
+        )),
+        None => Err(anyhow::anyhow!("Package transport type is required for stdio server")),
+    }
+}
+
+fn registry_input_value(input: &RegistryNamedInput) -> Option<String> {
+    compact_string(input.value.as_deref())
+        .or_else(|| compact_string(input.default.as_deref()))
+        .map(str::to_string)
+}
+
+fn registry_named_inputs_to_map(
+    inputs: Option<&[RegistryNamedInput]>,
+    input_kind: &str,
+) -> Result<Option<HashMap<String, String>>> {
+    let Some(inputs) = inputs else {
+        return Ok(None);
+    };
+    let mut values = HashMap::new();
+
+    for input in inputs {
+        let name =
+            compact_string(input.name.as_deref()).ok_or_else(|| anyhow::anyhow!("{} name is required", input_kind))?;
+        if let Some(value) = registry_input_value(input) {
+            values.insert(name.to_string(), value);
+            continue;
+        }
+        if input.is_required {
+            return Err(anyhow::anyhow!("Required {} '{}' is missing a value", input_kind, name));
+        }
+    }
+
+    if values.is_empty() { Ok(None) } else { Ok(Some(values)) }
+}
+
+fn resolve_registry_arguments(
+    arguments: Option<&[RegistryNamedInput]>,
+    argument_kind: &str,
+) -> Result<Vec<String>> {
+    let mut resolved = Vec::new();
+
+    for argument in arguments.unwrap_or_default() {
+        let argument_type = compact_string(argument.argument_type.as_deref())
+            .map(str::to_ascii_lowercase)
+            .unwrap_or_else(|| "positional".to_string());
+        let value = registry_input_value(argument);
+
+        if argument.is_required && value.is_none() {
+            return Err(anyhow::anyhow!("Required {} is missing a value", argument_kind));
+        }
+
+        if argument_type == "named" {
+            let name = compact_string(argument.name.as_deref())
+                .ok_or_else(|| anyhow::anyhow!("Named {} requires a name", argument_kind))?;
+            resolved.push(name.to_string());
+            if let Some(value) = value {
+                resolved.push(value);
+            }
+            continue;
+        }
+
+        if let Some(value) = value {
+            resolved.push(value);
+        }
+    }
+
+    Ok(resolved)
+}
+
+fn remote_headers_to_import_headers(raw: Option<&serde_json::Value>) -> Result<Option<HashMap<String, String>>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let inputs: Vec<RegistryNamedInput> =
+        serde_json::from_value(raw.clone()).context("Failed to parse remote headers")?;
+    let mut headers = HashMap::new();
+
+    for input in inputs {
+        let name =
+            compact_string(input.name.as_deref()).ok_or_else(|| anyhow::anyhow!("Remote header name is required"))?;
+        if let Some(value) = registry_input_value(&input) {
+            headers.insert(name.to_string(), value);
+            continue;
+        }
+        if input.is_required {
+            return Err(anyhow::anyhow!("Required remote header '{}' is missing a value", name));
+        }
+    }
+
+    if headers.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(headers))
+    }
+}
+
+fn remote_has_variables(raw: Option<&serde_json::Value>) -> bool {
+    match raw {
+        Some(serde_json::Value::Object(object)) => !object.is_empty(),
+        Some(serde_json::Value::Null) | None => false,
+        Some(_) => true,
+    }
 }
 
 /// Convert npm package to import configuration
@@ -770,28 +922,128 @@ struct PackageImportConfig {
 fn npm_package_to_import_config(
     identifier: &str,
     version: Option<&str>,
+    env: Option<HashMap<String, String>>,
+    runtime_arguments: Vec<String>,
+    package_arguments: Vec<String>,
 ) -> PackageImportConfig {
     let full_identifier = match version {
         Some(v) => format!("{}@{}", identifier, v),
         None => identifier.to_string(),
     };
+    let mut args = vec!["-y".to_string()];
+    args.extend(runtime_arguments);
+    args.push(full_identifier);
+    args.extend(package_arguments);
+
     PackageImportConfig {
         kind: "stdio".to_string(),
         command: Some("npx".to_string()),
-        args: Some(vec!["-y".to_string(), full_identifier]),
+        args: Some(args),
         url: None,
+        env,
+        headers: None,
+    }
+}
+
+/// Convert PyPI package to import configuration
+/// PyPI packages use: uvx <identifier>@<version>
+fn pypi_package_to_import_config(
+    identifier: &str,
+    version: Option<&str>,
+    env: Option<HashMap<String, String>>,
+    runtime_arguments: Vec<String>,
+    package_arguments: Vec<String>,
+) -> PackageImportConfig {
+    let full_identifier = match version {
+        Some(v) => format!("{}@{}", identifier, v),
+        None => identifier.to_string(),
+    };
+    let mut args = runtime_arguments;
+    args.push(full_identifier);
+    args.extend(package_arguments);
+
+    PackageImportConfig {
+        kind: "stdio".to_string(),
+        command: Some("uvx".to_string()),
+        args: Some(args),
+        url: None,
+        env,
+        headers: None,
     }
 }
 
 /// Convert remote URL to import configuration
-/// remotes use streamable_http transport
-fn remote_to_import_config(url: &str) -> PackageImportConfig {
+/// remotes use the transport declared by the registry entry
+fn remote_to_import_config(
+    url: &str,
+    kind: &str,
+    headers: Option<HashMap<String, String>>,
+) -> PackageImportConfig {
     PackageImportConfig {
-        kind: "streamable_http".to_string(),
+        kind: kind.to_string(),
         command: None,
         args: None,
         url: Some(url.to_string()),
+        env: None,
+        headers,
     }
+}
+
+fn registry_package_to_import_config(
+    package: &RegistryPackage,
+    preferred_version: Option<&str>,
+) -> Result<PackageImportConfig> {
+    let registry_type = compact_string(package.registry_type.as_deref())
+        .ok_or_else(|| anyhow::anyhow!("Package registry type is required for stdio server"))?
+        .to_ascii_lowercase();
+    ensure_registry_package_stdio_transport(
+        package
+            .transport
+            .as_ref()
+            .and_then(|transport| transport.r#type.as_deref()),
+    )?;
+    let identifier = package
+        .identifier
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("Package identifier is required for stdio server"))?;
+    let version = preferred_version.or(package.version.as_deref());
+    let env = registry_named_inputs_to_map(package.environment_variables.as_deref(), "package environment variable")?;
+    let runtime_arguments = resolve_registry_arguments(package.runtime_arguments.as_deref(), "runtime argument")?;
+    let package_arguments = resolve_registry_arguments(package.package_arguments.as_deref(), "package argument")?;
+
+    match registry_type.as_str() {
+        "npm" => Ok(npm_package_to_import_config(
+            identifier,
+            version,
+            env,
+            runtime_arguments,
+            package_arguments,
+        )),
+        "pypi" => Ok(pypi_package_to_import_config(
+            identifier,
+            version,
+            env,
+            runtime_arguments,
+            package_arguments,
+        )),
+        other => Err(anyhow::anyhow!(
+            "Unsupported package registry type '{}' for stdio server",
+            other
+        )),
+    }
+}
+
+fn registry_remote_to_import_config(remote: &RegistryRemote) -> Result<PackageImportConfig> {
+    let url = compact_string(remote.url.as_deref()).ok_or_else(|| anyhow::anyhow!("Remote URL is required"))?;
+    let kind = normalize_registry_remote_kind(remote.r#type.as_deref())?;
+    if remote_has_variables(remote.variables.as_ref()) {
+        return Err(anyhow::anyhow!(
+            "Remote URL variables are not supported by registry install endpoint"
+        ));
+    }
+    let headers = remote_headers_to_import_headers(remote.headers.as_ref())?;
+    Ok(remote_to_import_config(url, kind, headers))
 }
 
 /// Parse packages_json from registry cache entry
@@ -818,24 +1070,33 @@ fn registry_entry_to_import_config(
 ) -> Result<Option<PackageImportConfig>> {
     // First, check for remotes (HTTP-based servers)
     let remotes = parse_remotes(entry.remotes_json.as_deref())?;
-    if let Some(remote) = remotes.first() {
-        if let Some(url) = &remote.url {
-            return Ok(Some(remote_to_import_config(url)));
+    let mut first_remote_error = None;
+    for remote in &remotes {
+        match registry_remote_to_import_config(remote) {
+            Ok(config) => return Ok(Some(config)),
+            Err(err) => {
+                first_remote_error.get_or_insert(err);
+            }
         }
     }
 
     // Then, check for packages (stdio-based servers)
     let packages = parse_packages(entry.packages_json.as_deref())?;
-    if let Some(package) = packages.first() {
-        let name = package
-            .name
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Package name is required for stdio server"))?;
+    let mut first_package_error = None;
+    for package in &packages {
+        match registry_package_to_import_config(package, preferred_version) {
+            Ok(config) => return Ok(Some(config)),
+            Err(err) => {
+                first_package_error.get_or_insert(err);
+            }
+        }
+    }
 
-        // Use preferred version if provided, otherwise use package version
-        let version = preferred_version.or(package.version.as_deref());
-
-        return Ok(Some(npm_package_to_import_config(name, version)));
+    if let Some(err) = first_package_error {
+        return Err(err);
+    }
+    if let Some(err) = first_remote_error {
+        return Err(err);
     }
 
     // No packages or remotes found
@@ -986,8 +1247,8 @@ pub async fn import_from_registry(
         command: import_config.command,
         args: import_config.args,
         url: import_config.url,
-        env: None,
-        headers: None,
+        env: import_config.env,
+        headers: import_config.headers,
         registry_server_id: Some(name.to_string()),
         meta: Some(build_meta_from_entry(&entry)),
     };
@@ -1020,6 +1281,29 @@ mod tests {
             headers: HashMap::new(),
             url: url.map(str::to_string),
             issue: issue.map(str::to_string),
+        }
+    }
+
+    fn registry_cache_entry(
+        packages_json: Option<&str>,
+        remotes_json: Option<&str>,
+    ) -> RegistryCacheEntry {
+        RegistryCacheEntry {
+            server_name: "test-server".to_string(),
+            version: "1.0.0".to_string(),
+            schema_url: None,
+            title: None,
+            description: None,
+            packages_json: packages_json.map(str::to_string),
+            remotes_json: remotes_json.map(str::to_string),
+            icons_json: None,
+            meta_json: None,
+            website_url: None,
+            repository_json: None,
+            status: "active".to_string(),
+            published_at: None,
+            updated_at: None,
+            synced_at: chrono::Utc::now(),
         }
     }
 
@@ -1061,7 +1345,13 @@ mod tests {
 
     #[test]
     fn test_npm_package_to_import_config_with_version() {
-        let config = npm_package_to_import_config("@modelcontextprotocol/server-filesystem", Some("1.0.0"));
+        let config = npm_package_to_import_config(
+            "@modelcontextprotocol/server-filesystem",
+            Some("1.0.0"),
+            None,
+            Vec::new(),
+            Vec::new(),
+        );
         assert_eq!(config.kind, "stdio");
         assert_eq!(config.command, Some("npx".to_string()));
         assert_eq!(
@@ -1076,7 +1366,13 @@ mod tests {
 
     #[test]
     fn test_npm_package_to_import_config_without_version() {
-        let config = npm_package_to_import_config("@modelcontextprotocol/server-filesystem", None);
+        let config = npm_package_to_import_config(
+            "@modelcontextprotocol/server-filesystem",
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+        );
         assert_eq!(config.kind, "stdio");
         assert_eq!(config.command, Some("npx".to_string()));
         assert_eq!(
@@ -1089,8 +1385,30 @@ mod tests {
     }
 
     #[test]
+    fn test_pypi_package_to_import_config_with_version() {
+        let config = pypi_package_to_import_config(
+            "mcp-server-fetch",
+            Some("1.6.0"),
+            None,
+            vec!["--python".to_string(), "3.12".to_string()],
+            vec!["--debug".to_string()],
+        );
+        assert_eq!(config.kind, "stdio");
+        assert_eq!(config.command, Some("uvx".to_string()));
+        assert_eq!(
+            config.args,
+            Some(vec![
+                "--python".to_string(),
+                "3.12".to_string(),
+                "mcp-server-fetch@1.6.0".to_string(),
+                "--debug".to_string()
+            ])
+        );
+    }
+
+    #[test]
     fn test_remote_to_import_config() {
-        let config = remote_to_import_config("https://api.example.com/mcp");
+        let config = remote_to_import_config("https://api.example.com/mcp", "streamable_http", None);
         assert_eq!(config.kind, "streamable_http");
         assert!(config.command.is_none());
         assert!(config.args.is_none());
@@ -1099,11 +1417,20 @@ mod tests {
 
     #[test]
     fn test_parse_packages_valid_json() {
-        let json = r#"[{"name": "@scope/package", "version": "1.0.0"}]"#;
+        let json = r#"[{"registryType": "npm", "identifier": "@scope/package", "version": "1.0.0", "transport": {"type": "stdio"}}]"#;
         let packages = parse_packages(Some(json)).unwrap();
         assert_eq!(packages.len(), 1);
-        assert_eq!(packages[0].name, Some("@scope/package".to_string()));
+        assert_eq!(packages[0].identifier, Some("@scope/package".to_string()));
+        assert_eq!(packages[0].registry_type, Some("npm".to_string()));
         assert_eq!(packages[0].version, Some("1.0.0".to_string()));
+    }
+
+    #[test]
+    fn test_parse_packages_accepts_legacy_name_alias() {
+        let json = r#"[{"name": "@scope/package", "version": "1.0.0"}]"#;
+        let packages = parse_packages(Some(json)).unwrap();
+
+        assert_eq!(packages[0].identifier, Some("@scope/package".to_string()));
     }
 
     #[test]
@@ -1128,23 +1455,10 @@ mod tests {
 
     #[test]
     fn test_registry_entry_to_import_config_with_remote() {
-        let entry = RegistryCacheEntry {
-            server_name: "test-server".to_string(),
-            version: "1.0.0".to_string(),
-            schema_url: None,
-            title: None,
-            description: None,
-            packages_json: Some(r#"[{"name": "test-pkg"}]"#.to_string()),
-            remotes_json: Some(r#"[{"url": "https://api.example.com/mcp"}]"#.to_string()),
-            icons_json: None,
-            meta_json: None,
-            website_url: None,
-            repository_json: None,
-            status: "active".to_string(),
-            published_at: None,
-            updated_at: None,
-            synced_at: chrono::Utc::now(),
-        };
+        let entry = registry_cache_entry(
+            Some(r#"[{"name": "test-pkg"}]"#),
+            Some(r#"[{"type":"streamable-http","url":"https://api.example.com/mcp"}]"#),
+        );
 
         let config = registry_entry_to_import_config(&entry, None).unwrap().unwrap();
         // Remotes take priority
@@ -1153,27 +1467,151 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_entry_to_import_config_with_sse_remote() {
+        let entry = registry_cache_entry(None, Some(r#"[{"type":"sse","url":"https://api.example.com/sse"}]"#));
+
+        let config = registry_entry_to_import_config(&entry, None).unwrap().unwrap();
+
+        assert_eq!(config.kind, "sse");
+        assert_eq!(config.url, Some("https://api.example.com/sse".to_string()));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_preserves_remote_headers() {
+        let entry = registry_cache_entry(
+            None,
+            Some(
+                r#"[{"type":"streamable-http","url":"https://api.example.com/mcp","headers":[{"name":"X-Region","default":"us-east-1"},{"name":"X-Trace","value":"enabled"}]}]"#,
+            ),
+        );
+
+        let config = registry_entry_to_import_config(&entry, None).unwrap().unwrap();
+        let headers = config.headers.expect("remote headers");
+
+        assert_eq!(headers.get("X-Region").map(String::as_str), Some("us-east-1"));
+        assert_eq!(headers.get("X-Trace").map(String::as_str), Some("enabled"));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_rejects_remote_variables() {
+        let entry = registry_cache_entry(
+            None,
+            Some(
+                r#"[{"type":"streamable-http","url":"https://api.example.com/{region}/mcp","variables":{"region":{"isRequired":true,"default":"us-east-1"}}}]"#,
+            ),
+        );
+
+        let err = registry_entry_to_import_config(&entry, None).expect_err("remote variables are unsupported");
+
+        assert!(err.to_string().contains("Remote URL variables are not supported"));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_uses_package_when_remote_has_variables() {
+        let entry = registry_cache_entry(
+            Some(
+                r#"[{"registryType": "pypi", "identifier": "mcp-server-fetch", "version": "1.6.0", "transport": {"type": "stdio"}}]"#,
+            ),
+            Some(
+                r#"[{"type":"streamable-http","url":"https://api.example.com/{region}/mcp","variables":{"region":{"isRequired":true}}}]"#,
+            ),
+        );
+
+        let config = registry_entry_to_import_config(&entry, None).unwrap().unwrap();
+
+        assert_eq!(config.command, Some("uvx".to_string()));
+        assert_eq!(config.args, Some(vec!["mcp-server-fetch@1.6.0".to_string()]));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_rejects_required_remote_header_without_value() {
+        let entry = registry_cache_entry(
+            None,
+            Some(
+                r#"[{"type":"streamable-http","url":"https://api.example.com/mcp","headers":[{"name":"X-API-Key","isRequired":true}]}]"#,
+            ),
+        );
+
+        let err = registry_entry_to_import_config(&entry, None).expect_err("required header value is missing");
+
+        assert!(err.to_string().contains("Required remote header"));
+    }
+
+    #[test]
     fn test_registry_entry_to_import_config_with_npm_package() {
-        let entry = RegistryCacheEntry {
-            server_name: "test-server".to_string(),
-            version: "1.0.0".to_string(),
-            schema_url: None,
-            title: None,
-            description: None,
-            packages_json: Some(r#"[{"name": "@scope/package", "version": "1.0.0"}]"#.to_string()),
-            remotes_json: None,
-            icons_json: None,
-            meta_json: None,
-            website_url: None,
-            repository_json: None,
-            status: "active".to_string(),
-            published_at: None,
-            updated_at: None,
-            synced_at: chrono::Utc::now(),
-        };
+        let entry = registry_cache_entry(
+            Some(
+                r#"[{"registryType": "npm", "identifier": "@scope/package", "version": "1.0.0", "transport": {"type": "stdio"},"environmentVariables":[{"name":"API_KEY","default":"test-key"}],"runtimeArguments":[{"name":"--registry","type":"named","value":"https://registry.npmjs.org"}],"packageArguments":[{"name":"--debug","type":"named"}]}]"#,
+            ),
+            None,
+        );
 
         let config = registry_entry_to_import_config(&entry, None).unwrap().unwrap();
         assert_eq!(config.kind, "stdio");
+        assert_eq!(config.command, Some("npx".to_string()));
+        assert_eq!(
+            config.args,
+            Some(vec![
+                "-y".to_string(),
+                "--registry".to_string(),
+                "https://registry.npmjs.org".to_string(),
+                "@scope/package@1.0.0".to_string(),
+                "--debug".to_string()
+            ])
+        );
+        assert_eq!(
+            config
+                .env
+                .as_ref()
+                .and_then(|env| env.get("API_KEY"))
+                .map(String::as_str),
+            Some("test-key")
+        );
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_rejects_required_package_argument_without_value() {
+        let entry = registry_cache_entry(
+            Some(
+                r#"[{"registryType": "npm", "identifier": "@scope/package", "version": "1.0.0", "transport": {"type": "stdio"},"packageArguments":[{"name":"--api-key","type":"named","isRequired":true}]}]"#,
+            ),
+            None,
+        );
+
+        let err = registry_entry_to_import_config(&entry, None).expect_err("required package argument is missing");
+
+        assert!(err.to_string().contains("Required package argument is missing a value"));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_with_pypi_package() {
+        let entry = registry_cache_entry(
+            Some(
+                r#"[{"registryType": "pypi", "identifier": "mcp-server-fetch", "version": "1.6.0", "transport": {"type": "stdio"}}]"#,
+            ),
+            None,
+        );
+
+        let config = registry_entry_to_import_config(&entry, None).unwrap().unwrap();
+        assert_eq!(config.kind, "stdio");
+        assert_eq!(config.command, Some("uvx".to_string()));
+        assert_eq!(config.args, Some(vec!["mcp-server-fetch@1.6.0".to_string()]));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_skips_unsupported_package_alternative() {
+        let entry = registry_cache_entry(
+            Some(
+                r#"[
+                    {"registryType": "mcpb", "identifier": "https://example.com/server.mcpb", "transport": {"type": "stdio"}},
+                    {"registryType": "npm", "identifier": "@scope/package", "version": "1.0.0", "transport": {"type": "stdio"}}
+                ]"#,
+            ),
+            None,
+        );
+
+        let config = registry_entry_to_import_config(&entry, None).unwrap().unwrap();
+
         assert_eq!(config.command, Some("npx".to_string()));
         assert_eq!(
             config.args,
@@ -1183,23 +1621,12 @@ mod tests {
 
     #[test]
     fn test_registry_entry_to_import_config_with_preferred_version() {
-        let entry = RegistryCacheEntry {
-            server_name: "test-server".to_string(),
-            version: "1.0.0".to_string(),
-            schema_url: None,
-            title: None,
-            description: None,
-            packages_json: Some(r#"[{"name": "@scope/package", "version": "1.0.0"}]"#.to_string()),
-            remotes_json: None,
-            icons_json: None,
-            meta_json: None,
-            website_url: None,
-            repository_json: None,
-            status: "active".to_string(),
-            published_at: None,
-            updated_at: None,
-            synced_at: chrono::Utc::now(),
-        };
+        let entry = registry_cache_entry(
+            Some(
+                r#"[{"registryType": "npm", "identifier": "@scope/package", "version": "1.0.0", "transport": {"type": "stdio"}}]"#,
+            ),
+            None,
+        );
 
         let config = registry_entry_to_import_config(&entry, Some("2.0.0")).unwrap().unwrap();
         assert_eq!(
@@ -1209,24 +1636,48 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_entry_to_import_config_rejects_unsupported_package_registry_type() {
+        let entry = registry_cache_entry(
+            Some(
+                r#"[{"registryType": "mcpb", "identifier": "https://example.com/server.mcpb", "transport": {"type": "stdio"}}]"#,
+            ),
+            None,
+        );
+
+        let err = registry_entry_to_import_config(&entry, None).expect_err("unsupported registry type");
+
+        assert!(err.to_string().contains("Unsupported package registry type"));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_rejects_missing_package_transport() {
+        let entry = registry_cache_entry(
+            Some(r#"[{"registryType": "npm", "identifier": "@scope/package", "version": "1.0.0"}]"#),
+            None,
+        );
+
+        let err = registry_entry_to_import_config(&entry, None).expect_err("package transport is required");
+
+        assert!(err.to_string().contains("Package transport type is required"));
+    }
+
+    #[test]
+    fn test_registry_entry_to_import_config_rejects_non_stdio_package_transport() {
+        let entry = registry_cache_entry(
+            Some(
+                r#"[{"registryType": "npm", "identifier": "@scope/package", "version": "1.0.0", "transport": {"type": "streamable-http"}}]"#,
+            ),
+            None,
+        );
+
+        let err = registry_entry_to_import_config(&entry, None).expect_err("package transport must be stdio");
+
+        assert!(err.to_string().contains("Unsupported package transport type"));
+    }
+
+    #[test]
     fn test_registry_entry_to_import_config_no_packages_or_remotes() {
-        let entry = RegistryCacheEntry {
-            server_name: "test-server".to_string(),
-            version: "1.0.0".to_string(),
-            schema_url: None,
-            title: None,
-            description: None,
-            packages_json: None,
-            remotes_json: None,
-            icons_json: None,
-            meta_json: None,
-            website_url: None,
-            repository_json: None,
-            status: "active".to_string(),
-            published_at: None,
-            updated_at: None,
-            synced_at: chrono::Utc::now(),
-        };
+        let entry = registry_cache_entry(None, None);
 
         let config = registry_entry_to_import_config(&entry, None).unwrap();
         assert!(config.is_none());

--- a/board/src/lib/server-import-payload.test.ts
+++ b/board/src/lib/server-import-payload.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { buildMcpServersImportBodyFromDrafts } from "./server-import-payload";
+
+describe("server import payload", () => {
+	test("preserves remote headers in the shared import request payload", () => {
+		const body = buildMcpServersImportBodyFromDrafts([
+			{
+				name: "remote-api",
+				kind: "streamable_http",
+				url: "https://api.example.com/mcp",
+				headers: {
+					Authorization: "",
+				},
+			},
+		]);
+
+		expect(body).toEqual({
+			mcpServers: {
+				"remote-api": {
+					type: "streamable_http",
+					url: "https://api.example.com/mcp",
+					headers: {
+						Authorization: "",
+					},
+				},
+			},
+		});
+	});
+});

--- a/board/src/lib/server-import-payload.ts
+++ b/board/src/lib/server-import-payload.ts
@@ -53,6 +53,9 @@ export function buildMcpServersImportBodyFromDrafts(
 		if (item.env && Object.keys(item.env).length) {
 			entry.env = item.env;
 		}
+		if (item.kind !== "stdio" && item.headers && Object.keys(item.headers).length) {
+			entry.headers = item.headers;
+		}
 		if (item.registryServerId) {
 			entry.registry_server_id = item.registryServerId;
 		}

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -99,23 +99,32 @@ export interface ServerDetail extends ServerSummary {
   instances: InstanceSummary[];
 }
 
-export interface RegistryTransportHeader {
-  name: string;
+export interface RegistryInput {
   description?: string;
   isRequired?: boolean;
   isSecret?: boolean;
+  value?: string;
+  default?: string;
+  placeholder?: string;
+  choices?: string[];
+}
+
+export interface RegistryTransportHeader extends RegistryInput {
+  name: string;
 }
 
 export interface RegistryTransport {
-  type: string;
+  type?: string;
   url?: string;
   headers?: RegistryTransportHeader[] | null;
+  variables?: Record<string, RegistryInput> | null;
 }
 
 export interface RegistryPackageArgument {
-  name: string;
+  name?: string;
   description?: string;
   type?: string;
+  value?: string;
   isRequired?: boolean;
   default?: string;
   valueHint?: string;
@@ -126,6 +135,8 @@ export interface RegistryPackage {
   registryBaseUrl?: string;
   identifier?: string;
   version?: string;
+  runtimeHint?: string;
+  fileSha256?: string;
   transport?: { type: string };
   environmentVariables?: RegistryTransportHeader[] | null;
   packageArguments?: RegistryPackageArgument[] | null;

--- a/board/src/pages/market/i18n/index.ts
+++ b/board/src/pages/market/i18n/index.ts
@@ -9,6 +9,7 @@ export const marketTranslations = {
 			installed: "Installed",
 			manage: "Manage",
 			reinstall: "Reinstall",
+			unsupported: "Unsupported",
 		},
 		search: {
 			placeholder: "Search by server name",
@@ -97,6 +98,7 @@ export const marketTranslations = {
 			installed: "已安装",
 			manage: "管理",
 			reinstall: "重新安装",
+			unsupported: "暂不支持",
 		},
 		search: {
 			placeholder: "按服务器名称搜索",
@@ -184,6 +186,7 @@ export const marketTranslations = {
 			installed: "インストール済み",
 			manage: "管理",
 			reinstall: "再インストール",
+			unsupported: "未対応",
 		},
 		search: {
 			placeholder: "サーバー名で検索",

--- a/board/src/pages/market/market-card.tsx
+++ b/board/src/pages/market/market-card.tsx
@@ -19,6 +19,7 @@ import type { MarketCardProps } from "./types";
 import {
 	formatServerName,
 	getRemoteTypeLabel,
+	hasUnsupportedRegistryPackageOption,
 	hasPreviewableOption,
 } from "./utils";
 
@@ -56,6 +57,11 @@ export function MarketCard({
 	const displayName = formatServerName(server.name);
 
 	const supportsPreview = useMemo(() => hasPreviewableOption(server), [server]);
+	const hasUnsupportedPackageOption = useMemo(
+		() => hasUnsupportedRegistryPackageOption(server),
+		[server],
+	);
+	const installDisabled = isInstalled || !supportsPreview;
 
 	const handleCardClick = () => {
 		if (!supportsPreview) {
@@ -185,8 +191,8 @@ export function MarketCard({
 							"h-7 px-2 text-xs",
 							isInstalled && "bg-green-50 text-green-700 hover:bg-green-50 hover:text-green-700 border-transparent dark:bg-green-950/30 dark:text-green-400 dark:hover:bg-green-950/30 cursor-default opacity-100"
 						)}
-						onClick={isInstalled ? (e) => { e.stopPropagation(); e.preventDefault(); } : handleInstall}
-						disabled={isInstalled}
+						onClick={installDisabled ? (e) => { e.stopPropagation(); e.preventDefault(); } : handleInstall}
+						disabled={installDisabled}
 					>
 						{isInstalled ? (
 							<ShieldCheck className="h-3 w-3 mr-1" />
@@ -195,7 +201,9 @@ export function MarketCard({
 						)}
 						{isInstalled 
 							? t("buttons.installed", { defaultValue: "Installed" })
-							: t("buttons.install", { defaultValue: "Install" })}
+							: !supportsPreview && hasUnsupportedPackageOption
+								? t("buttons.unsupported", { defaultValue: "Unsupported" })
+								: t("buttons.install", { defaultValue: "Install" })}
 					</Button>
 					<button
 						type="button"

--- a/board/src/pages/market/market-detail-page.tsx
+++ b/board/src/pages/market/market-detail-page.tsx
@@ -28,7 +28,7 @@ import {
 	matchesInstalledRegistryServer,
 } from "../../lib/registry";
 import type { RegistryServerEntry } from "../../lib/types";
-import { formatLocalDateTime } from "../../lib/utils";
+import { cn, formatLocalDateTime } from "../../lib/utils";
 import type { RemoteOption } from "./types";
 import {
 	buildDraftFromRemoteOption,
@@ -182,22 +182,6 @@ async function fetchRepositoryReadmeMarkdown(repositoryUrl: string, subfolder?: 
 	}
 
 	return decodeBase64Utf8(payload.content);
-}
-
-function getReadmeErrorMessage(
-	error: unknown,
-	t: ReturnType<typeof useTranslation>["t"],
-): string {
-	const errorMessage = String(error);
-	if (errorMessage.includes("unsupported-repository")) {
-		return t("market:detail.readmeUnsupported", {
-			defaultValue: "README preview currently supports GitHub repositories only.",
-		});
-	}
-
-	return t("market:detail.readmeFetchFailed", {
-		defaultValue: "Failed to load README content.",
-	});
 }
 
 const MARKET_DETAIL_SPLIT_STORAGE_KEY = "marketDetail.registryReadmeSplitPct";
@@ -386,12 +370,13 @@ export function MarketDetailPage() {
 			icon: Code,
 		});
 	}
-	const splitGridStyle = isLgLayout
+	const readmeMarkdown = readmeQuery.data?.trim() ? readmeQuery.data : "";
+	const showReadmePanel = Boolean(readmeMarkdown);
+	const splitGridStyle = isLgLayout && showReadmePanel
 		? {
 				gridTemplateColumns: `minmax(0,${leftSplitPct}fr) 8px minmax(0,${100 - leftSplitPct}fr)`,
 			}
 		: undefined;
-	const readmeErrorText = getReadmeErrorMessage(readmeQuery.error, t);
 
 	return (
 		<>
@@ -503,10 +488,18 @@ export function MarketDetailPage() {
 
 				<div
 					ref={splitContainerRef}
-					className="grid grid-cols-1 items-stretch gap-6 lg:grid-cols-none lg:items-stretch lg:gap-0"
+					className={cn(
+						"grid grid-cols-1 items-stretch gap-6",
+						showReadmePanel && "lg:grid-cols-none lg:items-stretch lg:gap-0",
+					)}
 					style={splitGridStyle}
 				>
-					<Card className="min-w-0 rounded-xl lg:h-full lg:min-h-0 lg:rounded-none lg:rounded-l-xl">
+					<Card
+						className={cn(
+							"min-w-0 rounded-xl lg:h-full lg:min-h-0",
+							showReadmePanel && "lg:rounded-none lg:rounded-l-xl",
+						)}
+					>
 						<CardHeader>
 							<CardTitle>{t("market:detail.repositoryRegistrySection", { defaultValue: "Repository & Registry" })}</CardTitle>
 						</CardHeader>
@@ -573,66 +566,52 @@ export function MarketDetailPage() {
 						</CardContent>
 					</Card>
 
-					<div
-						className="hidden h-full min-h-0 w-2 shrink-0 cursor-col-resize touch-none self-stretch bg-transparent lg:block"
-						role="separator"
-						aria-orientation="vertical"
-						aria-valuemin={22}
-						aria-valuemax={78}
-						aria-valuenow={Math.round(leftSplitPct)}
-						aria-label={t("market:detail.splitResize", { defaultValue: "Resize registry and README panels" })}
-						onPointerDown={onSplitPointerDown}
-					/>
+					{showReadmePanel ? (
+						<>
+							<div
+								className="hidden h-full min-h-0 w-2 shrink-0 cursor-col-resize touch-none self-stretch bg-transparent lg:block"
+								role="separator"
+								aria-orientation="vertical"
+								aria-valuemin={22}
+								aria-valuemax={78}
+								aria-valuenow={Math.round(leftSplitPct)}
+								aria-label={t("market:detail.splitResize", { defaultValue: "Resize registry and README panels" })}
+								onPointerDown={onSplitPointerDown}
+							/>
 
-					<Card className="min-w-0 rounded-xl lg:h-full lg:min-h-0 lg:rounded-none lg:rounded-r-xl">
-						<CardHeader>
-							<CardTitle>{t("market:detail.readme", { defaultValue: "README" })}</CardTitle>
-						</CardHeader>
-						<CardContent className="p-4">
-							{!repositoryUrl ? (
-								<p className="text-sm text-muted-foreground">
-									{t("market:detail.readmeUnavailable", { defaultValue: "README is unavailable because repository URL is missing." })}
-								</p>
-							) : readmeQuery.isLoading ? (
-								<p className="text-sm text-muted-foreground">
-									{t("market:detail.readmeLoading", { defaultValue: "Loading README..." })}
-								</p>
-							) : readmeQuery.isError ? (
-								<p className="text-sm text-muted-foreground">
-									{readmeErrorText}
-								</p>
-							) : readmeQuery.data ? (
-								<ReactMarkdown
-									remarkPlugins={[remarkGfm]}
-									components={{
-										a: ({ href, children }) => {
-											const url = href ?? "";
-											return (
-												<a href={url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline dark:text-blue-400">
-													{children}
-												</a>
-											);
-										},
-										p: ({ children }) => <p className="mb-3 text-sm leading-6 text-slate-700 dark:text-slate-300">{children}</p>,
-										h1: ({ children }) => <h1 className="mb-3 text-xl font-semibold">{children}</h1>,
-										h2: ({ children }) => <h2 className="mb-3 text-lg font-semibold">{children}</h2>,
-										h3: ({ children }) => <h3 className="mb-2 text-base font-semibold">{children}</h3>,
-										ul: ({ children }) => <ul className="mb-3 list-disc space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-300">{children}</ul>,
-										ol: ({ children }) => <ol className="mb-3 list-decimal space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-300">{children}</ol>,
-										code: ({ children }) => <code className="rounded bg-slate-100 px-1 py-0.5 text-xs dark:bg-slate-800">{children}</code>,
-										pre: ({ children }) => <pre className="mb-3 overflow-x-auto rounded-lg bg-slate-100 p-3 text-xs dark:bg-slate-900">{children}</pre>,
-										blockquote: ({ children }) => <blockquote className="mb-3 border-l-2 border-slate-300 pl-3 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-400">{children}</blockquote>,
-									}}
-								>
-									{readmeQuery.data}
-								</ReactMarkdown>
-							) : (
-								<p className="text-sm text-muted-foreground">
-									{t("market:detail.readmeEmpty", { defaultValue: "README content is empty." })}
-								</p>
-							)}
-						</CardContent>
-					</Card>
+							<Card className="flex max-h-[70vh] min-w-0 flex-col overflow-hidden rounded-xl lg:h-[calc(100vh-18rem)] lg:max-h-none lg:min-h-0 lg:rounded-none lg:rounded-r-xl">
+								<CardHeader className="shrink-0">
+									<CardTitle>{t("market:detail.readme", { defaultValue: "README" })}</CardTitle>
+								</CardHeader>
+								<CardContent className="min-h-0 flex-1 overflow-y-auto p-4">
+									<ReactMarkdown
+										remarkPlugins={[remarkGfm]}
+										components={{
+											a: ({ href, children }) => {
+												const url = href ?? "";
+												return (
+													<a href={url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline dark:text-blue-400">
+														{children}
+													</a>
+												);
+											},
+											p: ({ children }) => <p className="mb-3 text-sm leading-6 text-slate-700 dark:text-slate-300">{children}</p>,
+											h1: ({ children }) => <h1 className="mb-3 text-xl font-semibold">{children}</h1>,
+											h2: ({ children }) => <h2 className="mb-3 text-lg font-semibold">{children}</h2>,
+											h3: ({ children }) => <h3 className="mb-2 text-base font-semibold">{children}</h3>,
+											ul: ({ children }) => <ul className="mb-3 list-disc space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-300">{children}</ul>,
+											ol: ({ children }) => <ol className="mb-3 list-decimal space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-300">{children}</ol>,
+											code: ({ children }) => <code className="rounded bg-slate-100 px-1 py-0.5 text-xs dark:bg-slate-800">{children}</code>,
+											pre: ({ children }) => <pre className="mb-3 overflow-x-auto rounded-lg bg-slate-100 p-3 text-xs dark:bg-slate-900">{children}</pre>,
+											blockquote: ({ children }) => <blockquote className="mb-3 border-l-2 border-slate-300 pl-3 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-400">{children}</blockquote>,
+										}}
+									>
+										{readmeMarkdown}
+									</ReactMarkdown>
+								</CardContent>
+							</Card>
+						</>
+					) : null}
 				</div>
 
 				<div className="border-t border-slate-200 dark:border-slate-800" />

--- a/board/src/pages/market/market-detail-page.tsx
+++ b/board/src/pages/market/market-detail-page.tsx
@@ -34,6 +34,10 @@ import {
 	buildDraftFromRemoteOption,
 	formatServerName,
 	getRemoteTypeLabel,
+	hasUnsupportedRegistryPackageOption,
+	hasRegistryVariables,
+	hasUnresolvedRequiredRegistryArguments,
+	isSupportedRegistryPackageType,
 	normalizeRemoteKind,
 	slugifyForConfig,
 } from "./utils";
@@ -44,6 +48,7 @@ function buildRemoteOptions(server: RegistryServerEntry): RemoteOption[] {
 	(server.remotes ?? []).forEach((remote, idx) => {
 		const kind = normalizeRemoteKind(remote.type);
 		if (!kind || !remote?.url) return;
+		if (hasRegistryVariables(remote.variables)) return;
 		options.push({
 			id: `${server.name}-remote-${idx}`,
 			label: `${getRemoteTypeLabel(kind)} • ${remote.url}`,
@@ -59,8 +64,16 @@ function buildRemoteOptions(server: RegistryServerEntry): RemoteOption[] {
 
 	(server.packages ?? []).forEach((pkg, idx) => {
 		const kind = normalizeRemoteKind(pkg.transport?.type);
-		if (!kind) return;
-		const identifier = pkg.identifier ?? pkg.registryType ?? `package-${idx + 1}`;
+		if (kind !== "stdio") return;
+		if (!isSupportedRegistryPackageType(pkg.registryType)) return;
+		if (
+			hasUnresolvedRequiredRegistryArguments(pkg.runtimeArguments) ||
+			hasUnresolvedRequiredRegistryArguments(pkg.packageArguments)
+		) {
+			return;
+		}
+		const identifier = pkg.identifier?.trim();
+		if (!identifier) return;
 		options.push({
 			id: `${server.name}-package-${idx}`,
 			label: `${getRemoteTypeLabel(kind)} • ${identifier}`,
@@ -239,6 +252,10 @@ export function MarketDetailPage() {
 	});
 
 	const remoteOptions = useMemo(() => (server ? buildRemoteOptions(server) : []), [server]);
+	const hasUnsupportedPackageOption = useMemo(
+		() => hasUnsupportedRegistryPackageOption(server),
+		[server],
+	);
 	const selectedRemote = useMemo(
 		() => remoteOptions.find((option) => option.id === selectedTransportId) ?? remoteOptions[0] ?? null,
 		[selectedTransportId, remoteOptions],
@@ -420,6 +437,7 @@ export function MarketDetailPage() {
 								</>
 							) : (
 								<Button
+									disabled={remoteOptions.length === 0}
 									onClick={() => {
 										if (remoteOptions.length > 0) {
 											setSelectedTransportId(remoteOptions[0].id);
@@ -428,7 +446,9 @@ export function MarketDetailPage() {
 									}}
 								>
 									<Download className="mr-2 h-4 w-4" />
-									{t("market:buttons.install", { defaultValue: "Install" })}
+									{remoteOptions.length === 0 && hasUnsupportedPackageOption
+										? t("market:buttons.unsupported", { defaultValue: "Unsupported" })
+										: t("market:buttons.install", { defaultValue: "Install" })}
 								</Button>
 							)}
 						</div>

--- a/board/src/pages/market/types.ts
+++ b/board/src/pages/market/types.ts
@@ -21,11 +21,15 @@ export interface RemoteOption {
 		name: string;
 		isRequired?: boolean;
 		description?: string;
+		value?: string;
+		default?: string;
 	}> | null;
 	envVars: Array<{
 		name: string;
 		isRequired?: boolean;
 		description?: string;
+		value?: string;
+		default?: string;
 	}> | null;
 	packageIdentifier: string | null;
 	packageMeta: unknown;

--- a/board/src/pages/market/utils.test.ts
+++ b/board/src/pages/market/utils.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+import type { RegistryServerEntry } from "../../lib/types";
+import type { RemoteOption } from "./types";
+import {
+	buildDraftFromRemoteOption,
+	hasUnsupportedRegistryPackageOption,
+	hasPreviewableOption,
+	isSupportedRegistryPackageType,
+} from "./utils";
+
+function packageOption(overrides: Partial<RemoteOption> = {}): RemoteOption {
+	return {
+		id: "context7-package",
+		label: "Stdio - @upstash/context7-mcp",
+		kind: "stdio",
+		source: "package",
+		url: null,
+		headers: null,
+		envVars: [{ name: "CONTEXT7_API_KEY", isRequired: true }],
+		packageIdentifier: "@upstash/context7-mcp",
+		packageMeta: {
+			registryType: "npm",
+			version: "1.0.31",
+		},
+		...overrides,
+	};
+}
+
+describe("market registry install resolution", () => {
+	test("resolves npm packages with explicit registry identifier and version", () => {
+		const draft = buildDraftFromRemoteOption(packageOption(), "context7");
+
+		expect(draft).toMatchObject({
+			name: "context7",
+			kind: "stdio",
+			command: "npx",
+			args: ["-y", "@upstash/context7-mcp@1.0.31"],
+			env: {
+				CONTEXT7_API_KEY: "",
+			},
+		});
+	});
+
+	test("resolves pypi packages through uvx", () => {
+		const draft = buildDraftFromRemoteOption(
+			packageOption({
+				packageIdentifier: "mcp-server-fetch",
+				packageMeta: {
+					registryType: "pypi",
+					version: "1.6.0",
+					runtimeArguments: [{ name: "--python", type: "named", value: "3.12" }],
+					packageArguments: [{ name: "--debug", type: "named" }],
+				},
+			}),
+			"fetch",
+		);
+
+		expect(draft).toMatchObject({
+			name: "fetch",
+			kind: "stdio",
+			command: "uvx",
+			args: ["--python", "3.12", "mcp-server-fetch@1.6.0", "--debug"],
+		});
+	});
+
+	test("rejects unsupported package registry types instead of falling back to npx", () => {
+		expect(() =>
+			buildDraftFromRemoteOption(
+				packageOption({
+					packageMeta: {
+						registryType: "mcpb",
+						version: "1.0.0",
+					},
+				}),
+				"mcpb-server",
+			),
+		).toThrow("Unsupported package registry type");
+	});
+
+	test("does not mark unsupported package registry types as previewable", () => {
+		expect(isSupportedRegistryPackageType("npm")).toBe(true);
+		expect(isSupportedRegistryPackageType("pypi")).toBe(true);
+		expect(isSupportedRegistryPackageType("mcpb")).toBe(false);
+	});
+
+	test("recognizes official package types that are not supported yet", () => {
+		const server: RegistryServerEntry = {
+			name: "mcpb-server",
+			version: "1.0.0",
+			packages: [
+				{
+					registryType: "mcpb",
+					identifier: "https://example.com/server.mcpb",
+					transport: {
+						type: "stdio",
+					},
+				},
+			],
+		};
+
+		expect(hasPreviewableOption(server)).toBe(false);
+		expect(hasUnsupportedRegistryPackageOption(server)).toBe(true);
+	});
+
+	test("does not mark package entries with non-stdio transport as previewable", () => {
+		const server: RegistryServerEntry = {
+			name: "package-server",
+			version: "1.0.0",
+			packages: [
+				{
+					registryType: "npm",
+					identifier: "@example/package-server",
+					transport: {
+						type: "streamable-http",
+					},
+				},
+			],
+		};
+
+		expect(hasPreviewableOption(server)).toBe(false);
+	});
+
+	test("does not mark packages with unresolved required arguments as previewable", () => {
+		const server: RegistryServerEntry = {
+			name: "package-server",
+			version: "1.0.0",
+			packages: [
+				{
+					registryType: "npm",
+					identifier: "@example/package-server",
+					transport: {
+						type: "stdio",
+					},
+					packageArguments: [
+						{
+							name: "--api-key",
+							type: "named",
+							isRequired: true,
+						},
+					],
+				},
+			],
+		};
+
+		expect(hasPreviewableOption(server)).toBe(false);
+	});
+
+	test("rejects package drafts with non-stdio transport", () => {
+		expect(() =>
+			buildDraftFromRemoteOption(
+				packageOption({
+					kind: "streamable_http",
+				}),
+				"package-server",
+			),
+		).toThrow("Package transport must be stdio");
+	});
+
+	test("rejects package drafts with unresolved required arguments", () => {
+		expect(() =>
+			buildDraftFromRemoteOption(
+				packageOption({
+					packageMeta: {
+						registryType: "npm",
+						version: "1.0.0",
+						packageArguments: [
+							{
+								name: "--api-key",
+								type: "named",
+								isRequired: true,
+							},
+						],
+					},
+				}),
+				"package-server",
+			),
+		).toThrow("Required package argument is missing a value");
+	});
+
+	test("uses remote headers instead of env values for remote drafts", () => {
+		const draft = buildDraftFromRemoteOption(
+			{
+				id: "remote",
+				label: "SSE - https://api.example.com/sse",
+				kind: "sse",
+				source: "remote",
+				url: "https://api.example.com/sse",
+				headers: [
+					{
+						name: "X-Region",
+						default: "us-east-1",
+					},
+				],
+				envVars: null,
+				packageIdentifier: null,
+				packageMeta: null,
+			},
+			"remote-api",
+		);
+
+		expect(draft).toMatchObject({
+			name: "remote-api",
+			kind: "sse",
+			url: "https://api.example.com/sse",
+			env: {},
+			headers: {
+				"X-Region": "us-east-1",
+			},
+		});
+	});
+
+	test("marks sse and streamable http remotes as previewable when no variables are required", () => {
+		const server: RegistryServerEntry = {
+			name: "remote-server",
+			version: "1.0.0",
+			remotes: [
+				{
+					type: "sse",
+					url: "https://api.example.com/sse",
+				},
+			],
+		};
+
+		expect(hasPreviewableOption(server)).toBe(true);
+	});
+
+	test("does not mark remotes with unresolved url variables as previewable", () => {
+		const server: RegistryServerEntry = {
+			name: "remote-server",
+			version: "1.0.0",
+			remotes: [
+				{
+					type: "streamable-http",
+					url: "https://api.example.com/{region}/mcp",
+					variables: {
+						region: {
+							isRequired: true,
+							default: "us-east-1",
+						},
+					},
+				},
+			],
+		};
+
+		expect(hasPreviewableOption(server)).toBe(false);
+	});
+});

--- a/board/src/pages/market/utils.ts
+++ b/board/src/pages/market/utils.ts
@@ -1,6 +1,7 @@
+import { useEffect, useState } from "react";
 import type { ServerInstallDraft } from "../../hooks/use-server-install-pipeline";
 import { getCanonicalRegistryServerId } from "../../lib/registry";
-import type { RegistryServerEntry } from "../../lib/types";
+import type { RegistryPackageArgument, RegistryServerEntry } from "../../lib/types";
 import type { RemoteOption } from "./types";
 
 export function useDebouncedValue<T>(value: T, delay = 300) {
@@ -18,10 +19,16 @@ export function hasPreviewableOption(
 	if (!server) return false;
 	const hasRemote = (server.remotes ?? []).some(
 		(remote) =>
-			Boolean(normalizeRemoteKind(remote.type)) && Boolean(remote.url),
+			Boolean(normalizeRemoteKind(remote.type)) &&
+			Boolean(remote.url) &&
+			!hasRegistryVariables(remote.variables),
 	);
 	const hasPackage = (server.packages ?? []).some((pkg) =>
-		Boolean(normalizeRemoteKind(pkg.transport?.type)),
+		normalizeRemoteKind(pkg.transport?.type) === "stdio" &&
+		Boolean(pkg.identifier?.trim()) &&
+		isSupportedRegistryPackageType(pkg.registryType) &&
+		!hasUnresolvedRequiredRegistryArguments(pkg.runtimeArguments) &&
+		!hasUnresolvedRequiredRegistryArguments(pkg.packageArguments),
 	);
 	return hasRemote || hasPackage;
 }
@@ -61,6 +68,13 @@ export function normalizeRemoteKind(value?: string | null): string | null {
 	return null;
 }
 
+export function hasRegistryVariables(
+	variables?: Record<string, unknown> | null,
+): boolean {
+	if (!variables || typeof variables !== "object") return false;
+	return Object.keys(variables).length > 0;
+}
+
 export function getRemoteTypeLabel(type: string): string {
 	switch (type.toLowerCase()) {
 		case "sse":
@@ -83,6 +97,114 @@ export function slugifyForConfig(value: string): string {
 	return slug || "registry-server";
 }
 
+function compactString(value?: string | null): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed ? trimmed : null;
+}
+
+export function isSupportedRegistryPackageType(value?: string | null): boolean {
+	const registryType = compactString(value)?.toLowerCase();
+	return registryType === "npm" || registryType === "pypi";
+}
+
+export function isKnownUnsupportedRegistryPackageType(
+	value?: string | null,
+): boolean {
+	const registryType = compactString(value)?.toLowerCase();
+	return (
+		registryType === "nuget" ||
+		registryType === "oci" ||
+		registryType === "mcpb"
+	);
+}
+
+export function hasUnsupportedRegistryPackageOption(
+	server: RegistryServerEntry | null,
+): boolean {
+	if (!server) return false;
+	return (server.packages ?? []).some((pkg) => {
+		const kind = normalizeRemoteKind(pkg.transport?.type);
+		return (
+			kind === "stdio" &&
+			Boolean(pkg.identifier?.trim()) &&
+			isKnownUnsupportedRegistryPackageType(pkg.registryType)
+		);
+	});
+}
+
+function registryArgumentValue(argument: RegistryPackageArgument): string | null {
+	return compactString(argument.value) ?? compactString(argument.default);
+}
+
+export function hasUnresolvedRequiredRegistryArguments(
+	argumentsList?: RegistryPackageArgument[] | null,
+): boolean {
+	return (argumentsList ?? []).some(
+		(argument) => Boolean(argument.isRequired) && !registryArgumentValue(argument),
+	);
+}
+
+function resolveRegistryArguments(
+	argumentsList?: RegistryPackageArgument[] | null,
+): string[] {
+	const resolved: string[] = [];
+	for (const argument of argumentsList ?? []) {
+		const argumentType = compactString(argument.type)?.toLowerCase() ?? "positional";
+		const value = registryArgumentValue(argument);
+		if (argument.isRequired && !value) {
+			throw new Error("Required package argument is missing a value");
+		}
+		if (argumentType === "named") {
+			const name = compactString(argument.name);
+			if (!name) {
+				throw new Error("Named package argument requires a name");
+			}
+			resolved.push(name);
+			if (value) {
+				resolved.push(value);
+			}
+			continue;
+		}
+		if (value) {
+			resolved.push(value);
+		}
+	}
+	return resolved;
+}
+
+function packageSpecifier(identifier: string, version?: string | null): string {
+	const normalizedVersion = compactString(version);
+	return normalizedVersion ? `${identifier}@${normalizedVersion}` : identifier;
+}
+
+function commandForRegistryPackage(registryType: string): string {
+	switch (registryType) {
+		case "npm":
+			return "npx";
+		case "pypi":
+			return "uvx";
+		default:
+			throw new Error(`Unsupported package registry type '${registryType}'`);
+	}
+}
+
+function argsForRegistryPackage(
+	registryType: string,
+	identifier: string,
+	version: string | null | undefined,
+	runtimeArguments?: RegistryPackageArgument[] | null,
+	packageArguments?: RegistryPackageArgument[] | null,
+): string[] {
+	const args = resolveRegistryArguments(runtimeArguments);
+	if (registryType === "npm") {
+		args.unshift("-y");
+	}
+	args.push(packageSpecifier(identifier, version));
+	args.push(...resolveRegistryArguments(packageArguments));
+	return args;
+}
+
 export function buildDraftFromRemoteOption(
 	option: RemoteOption,
 	fallbackName: string,
@@ -92,44 +214,49 @@ export function buildDraftFromRemoteOption(
 			? (option.envVars ?? [])
 			: (option.headers ?? []);
 
-	const env: Record<string, string> = {};
+	const inputValues: Record<string, string> = {};
 	descriptors.forEach((descriptor) => {
-		env[descriptor.name] = "";
+		inputValues[descriptor.name] =
+			compactString(descriptor.value) ??
+			compactString(descriptor.default) ??
+			"";
 	});
 
 	if (option.source === "package") {
-		// For packages, we need to build command and args
+		if (option.kind !== "stdio") {
+			throw new Error("Package transport must be stdio");
+		}
 		const identifier = option.packageIdentifier || "";
-		const registryType =
-			(
-				option.packageMeta as { registryType?: string }
-			)?.registryType?.toLowerCase() || "";
-
-		let command = "";
-		let args: string[] = [];
-
-		if (
-			registryType === "pip" ||
-			registryType === "pypi" ||
-			registryType === "python"
-		) {
-			command = "uvx";
-			args = [identifier];
-		} else if (registryType === "bun" || registryType === "bunx") {
-			command = "bunx";
-			args = ["-y", identifier];
-		} else {
-			command = "npx";
-			args = ["-y", identifier];
+		if (!identifier) {
+			throw new Error("Package identifier is required");
+		}
+		const packageMeta = option.packageMeta as {
+			registryType?: string | null;
+			version?: string | null;
+			packageArguments?: RegistryPackageArgument[] | null;
+			runtimeArguments?: RegistryPackageArgument[] | null;
+		};
+		const registryType = compactString(packageMeta.registryType)?.toLowerCase();
+		if (!registryType) {
+			throw new Error("Package registry type is required");
+		}
+		if (!isSupportedRegistryPackageType(registryType)) {
+			throw new Error(`Unsupported package registry type '${registryType}'`);
 		}
 
 		return {
 			name: fallbackName,
 			kind: option.kind as ServerInstallDraft["kind"],
 			url: undefined,
-			command,
-			args,
-			env,
+			command: commandForRegistryPackage(registryType),
+			args: argsForRegistryPackage(
+				registryType,
+				identifier,
+				packageMeta.version,
+				packageMeta.runtimeArguments,
+				packageMeta.packageArguments,
+			),
+			env: inputValues,
 		};
 	}
 
@@ -139,9 +266,7 @@ export function buildDraftFromRemoteOption(
 		url: option.url || "",
 		command: "",
 		args: [],
-		env,
+		env: {},
+		headers: inputValues,
 	};
 }
-
-// Import React hooks for the debounced value function
-import { useEffect, useState } from "react";


### PR DESCRIPTION
## Motivation

Official MCP Registry package entries are source-specific install options. MCPMate was collapsing those package facts into the older name/version shape, and Market could fall back to non-package fields when building stdio preview commands. That could produce invalid commands such as npx -y npm for Context7 and surface as initialize response connection closures during preview.

## Scope of changes

- Preserve official Registry package facts through sync/cache/API, including registryType, registryBaseUrl, identifier, version, runtimeHint, fileSha256, transport, environmentVariables, packageArguments, and runtimeArguments.
- Preserve remote headers and variables in cached Registry API payloads instead of filtering facts at the API projection layer.
- Treat npm and pypi stdio packages as supported first-class Market package options.
- Build Market import drafts from explicit package identifiers only: npm uses npx -y and pypi uses uvx as logical commands. Runtime path resolution remains in the existing stdio execution layer.
- Keep remote aliases compatible for streamable-http, streamable_http, streamablehttp, and http, and keep SSE as legacy-compatible transport.
- Recognize nuget, oci, and mcpb package entries but leave them unsupported in this PR; Market disables the install action for those package-only entries.
- Reject or skip package options with unresolved required package/runtime arguments because this PR does not add a user-fillable package-argument input path.
- Preserve remote headers in the shared Board import payload so Market remote imports use the same backend import pipeline as other standard drafts.
- Keep the backend direct Registry install path aligned as a legacy compatibility path, while the intended Market path is Board Registry entry -> ServerInstallDraft -> unified backend import.

## Linked project item

GitHub Project: hotfix: preserve registry package identifiers (PVTI_lAHOAYlBbs4BYAQyzguwNpg).

Follow-up architecture note was recorded in the same Project item: evaluate moving Official Registry API access, client-side cache, and source-adapter logic fully into Board, leaving backend to consume only standard import payloads.

## Config, schema, migration, and compatibility impact

No database migration is required. Cached Registry JSON payloads remain backward compatible with legacy name entries and now preserve additional official fields for current package schema consumers.

The Market install behavior changes from fallback-based package command construction to explicit installability checks. Unsupported package types and unresolved required package arguments no longer produce draft commands.

## Validation evidence

- bun test src/pages/market/utils.test.ts src/lib/server-import-payload.test.ts: 13 pass.
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml registry -- --nocapture: 39 pass.
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml import::tests::test_registry -- --nocapture: 15 pass.
- RUSTC_WRAPPER= cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings: passed.
- bun run build in board/: passed with existing Browserslist and chunk-size warnings.
- bun run lint in board/: passed with 0 errors and existing warnings.
- git diff --check: passed.

## Known risks, gaps, and follow-up work

Real Market UAT should still refresh the official Registry cache and verify Context7 npm stdio preview, one pypi stdio package if available, one streamable HTTP remote, and one SSE legacy remote.

This PR intentionally does not move Official Registry fetching/cache fully into Board, does not add user-fillable package argument prompts, and does not change secure-store provider modes, Inspector lifecycle behavior, browser extension import, or OAuth token refresh.