### PR TITLE
feat(secrets): add root key provider modes

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3336,6 +3336,7 @@ dependencies = [
  "keyring",
  "ring",
  "serde",
+ "serde_json",
  "serial_test",
  "sha2",
  "sqlx",

--- a/backend/crates/mcpmate-secrets/Cargo.toml
+++ b/backend/crates/mcpmate-secrets/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 base64 = "0.22.1"
 ring = "0.17.14"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8.1", features = [
   "runtime-tokio",

--- a/backend/crates/mcpmate-secrets/README.md
+++ b/backend/crates/mcpmate-secrets/README.md
@@ -67,11 +67,10 @@ The default target is enterprise-local secret storage:
 - Missing secrets, locked providers, invalid references, or decrypt failures
   must fail explicitly. Runtime code must not silently substitute placeholders,
   empty values, defaults, or plaintext fallbacks.
-- Production/default secret custody must be operating-system backed on every
-  supported desktop platform without requiring paid hosted services.
-- A local root-key file is not an acceptable production/default custody
-  boundary. It may only be used for tests, controlled development, or explicit
-  migration tooling.
+- The recommended default secret custody path is operating-system backed on
+  every supported desktop platform without requiring paid hosted services.
+- Non-OS custody modes are explicit user choices. They must be surfaced with a
+  lower security level and must not be selected silently when OS custody fails.
 
 ## Cross-Platform OS Custody
 
@@ -91,7 +90,33 @@ store; it must not become a plaintext secret store.
 If the required OS secret provider is unavailable, locked, or cannot persist
 the root key, MCPMate must fail closed with an actionable error. It must not
 silently fall back to environment keys, local files, empty values, or plaintext
-server configuration.
+server configuration. A user may explicitly select a lower security mode from
+the MCPMate security settings surface.
+
+## Root Key Provider Modes
+
+`mcpmate-secrets` classifies root-key providers separately from the secret
+record encryption engine. The current provider modes are:
+
+- `operating_system`: recommended default. The root wrapping key is held by the
+  platform secure-storage provider, such as Keychain, Credential Manager, or
+  Secret Service.
+- `passphrase`: user-managed local mode. MCPMate stores a generated root key
+  wrapped by a key derived from the user's Master Password. This avoids an OS
+  keychain dependency, but losing the Master Password can make stored secrets
+  unrecoverable.
+- `local_file`: basic local protection. MCPMate stores local root material in
+  the MCPMate data area. The crate enforces `0600` permissions on Unix-like
+  systems; Windows deployments must use a private app data directory with
+  appropriate ACLs. This is better than storing plaintext secret values, but it
+  is not equivalent to OS custody if an attacker can read the app data
+  directory.
+- `development`: deterministic or local-file root material for tests and
+  controlled development runs.
+
+Provider metadata records both a stable provider kind and a security level so
+backend APIs and Board can display the correct UX without interpreting provider
+ids by convention.
 
 ## Runtime Parameter Boundary
 
@@ -138,7 +163,9 @@ The crate keeps a replaceable provider interface so MCPMate can support
 different local or enterprise backends later:
 
 - OS-backed local root key providers.
-- Local encrypted vault storage for explicit development/test use.
+- Master Password protected local root-key providers.
+- Basic local-file root key providers for explicit user opt-in.
+- Local development providers for explicit development/test use.
 - Enterprise KMS, HSM, or managed-vault providers.
 - Future commercial provider integrations under a separate license.
 

--- a/backend/crates/mcpmate-secrets/src/database.rs
+++ b/backend/crates/mcpmate-secrets/src/database.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use sha2::{Digest, Sha256};
 use sqlx::{Pool, Row, Sqlite};
 
@@ -8,6 +8,32 @@ use crate::{
     crypto::{EncryptedSecret, EncryptedSecretParts},
     types::{SecretMetadataView, SecretOriginInput, SecretUsageLocationInput, SecretUsageUpsertInput, SecretUsageView},
 };
+
+const SECURE_STORE_SECRETS_TABLE: &str = "secure_store_secrets";
+const REQUIRED_SECRET_COLUMNS: &[&str] = &[
+    "alias",
+    "kind",
+    "label",
+    "origin_server_id",
+    "origin_server_name",
+    "origin_server_kind",
+    "origin_source",
+    "origin_field_group",
+    "origin_field_key",
+    "origin_field_index",
+    "origin_field_path",
+    "provider_id",
+    "provider_kind",
+    "version",
+    "key_nonce",
+    "encrypted_key",
+    "nonce",
+    "encrypted_value",
+    "key_wrap_alg",
+    "encryption_alg",
+    "created_at",
+    "updated_at",
+];
 
 pub(crate) struct SecretInsert<'a> {
     pub alias: &'a str,
@@ -27,6 +53,94 @@ pub(crate) struct SecretUpdate<'a> {
 }
 
 pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
+    ensure_secure_store_secrets_schema(pool).await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS secure_store_usages (
+            id TEXT PRIMARY KEY,
+            alias TEXT NOT NULL,
+            server_id TEXT NOT NULL,
+            location_kind TEXT NOT NULL,
+            location_name TEXT,
+            location_index INTEGER,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (alias) REFERENCES secure_store_secrets (alias) ON DELETE CASCADE,
+            UNIQUE(alias, server_id, location_kind, location_name, location_index)
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("create secure_store_usages table")?;
+
+    Ok(())
+}
+
+async fn ensure_secure_store_secrets_schema(pool: &Pool<Sqlite>) -> Result<()> {
+    if !table_exists(pool, SECURE_STORE_SECRETS_TABLE).await? {
+        create_secure_store_secrets_table(pool).await?;
+        return Ok(());
+    }
+
+    let columns = table_columns(pool, SECURE_STORE_SECRETS_TABLE).await?;
+    let missing_columns = REQUIRED_SECRET_COLUMNS
+        .iter()
+        .filter(|column| !columns.iter().any(|existing| existing == **column))
+        .copied()
+        .collect::<Vec<_>>();
+    if missing_columns.is_empty() {
+        return Ok(());
+    }
+
+    let legacy_record_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM secure_store_secrets")
+        .fetch_one(pool)
+        .await
+        .context("count legacy secure store secrets")?;
+
+    if legacy_record_count == 0 {
+        sqlx::query("DROP TABLE secure_store_secrets")
+            .execute(pool)
+            .await
+            .context("drop empty legacy secure_store_secrets table")?;
+        create_secure_store_secrets_table(pool).await?;
+        return Ok(());
+    }
+
+    bail!(
+        "outdated secure_store_secrets schema contains {legacy_record_count} legacy secret record(s); missing column(s): {}; reset the secure store data or run an explicit migration tool before using encrypted secrets",
+        missing_columns.join(", ")
+    );
+}
+
+async fn table_exists(
+    pool: &Pool<Sqlite>,
+    table_name: &str,
+) -> Result<bool> {
+    let exists: Option<String> =
+        sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?1")
+            .bind(table_name)
+            .fetch_optional(pool)
+            .await
+            .with_context(|| format!("inspect sqlite table '{table_name}'"))?;
+    Ok(exists.is_some())
+}
+
+async fn table_columns(
+    pool: &Pool<Sqlite>,
+    table_name: &str,
+) -> Result<Vec<String>> {
+    let rows = sqlx::query(&format!("PRAGMA table_info({table_name})"))
+        .fetch_all(pool)
+        .await
+        .with_context(|| format!("inspect sqlite table columns for '{table_name}'"))?;
+    rows.into_iter()
+        .map(|row| row.try_get("name").context("read sqlite table column name"))
+        .collect()
+}
+
+async fn create_secure_store_secrets_table(pool: &Pool<Sqlite>) -> Result<()> {
     let secrets_schema = format!(
         r#"
         CREATE TABLE IF NOT EXISTS secure_store_secrets (
@@ -59,27 +173,6 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         .execute(pool)
         .await
         .context("create secure_store_secrets table")?;
-
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS secure_store_usages (
-            id TEXT PRIMARY KEY,
-            alias TEXT NOT NULL,
-            server_id TEXT NOT NULL,
-            location_kind TEXT NOT NULL,
-            location_name TEXT,
-            location_index INTEGER,
-            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (alias) REFERENCES secure_store_secrets (alias) ON DELETE CASCADE,
-            UNIQUE(alias, server_id, location_kind, location_name, location_index)
-        )
-        "#,
-    )
-    .execute(pool)
-    .await
-    .context("create secure_store_usages table")?;
-
     Ok(())
 }
 
@@ -457,4 +550,88 @@ fn secret_origin_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Option<Secret
         field_path: row.try_get("origin_field_path")?,
     };
     Ok((!origin.is_empty()).then_some(origin))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    #[tokio::test]
+    async fn ensure_schema_rebuilds_empty_legacy_secret_table() {
+        let pool = sqlite_pool().await;
+        create_legacy_secret_table(&pool).await;
+
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        let columns = table_columns(&pool, "secure_store_secrets")
+            .await
+            .expect("table columns");
+        assert!(columns.iter().any(|column| column == "key_nonce"));
+        assert!(columns.iter().any(|column| column == "encrypted_key"));
+        assert!(columns.iter().any(|column| column == "origin_server_id"));
+    }
+
+    #[tokio::test]
+    async fn ensure_schema_rejects_nonempty_legacy_secret_table() {
+        let pool = sqlite_pool().await;
+        create_legacy_secret_table(&pool).await;
+        sqlx::query(
+            r#"
+            INSERT INTO secure_store_secrets (
+                alias,
+                kind,
+                label,
+                provider_id,
+                provider_kind,
+                version,
+                nonce,
+                encrypted_value
+            )
+            VALUES ('context7-token', 'token', NULL, 'local-encrypted-vault', 'local_encrypted_vault', 1, 'nonce', 'value')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("insert legacy secret");
+
+        let err = ensure_schema(&pool)
+            .await
+            .expect_err("non-empty legacy schema should fail closed");
+        let message = err.to_string();
+
+        assert!(message.contains("outdated secure_store_secrets schema"));
+        assert!(message.contains("1 legacy secret record"));
+    }
+
+    async fn sqlite_pool() -> Pool<Sqlite> {
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool")
+    }
+
+    async fn create_legacy_secret_table(pool: &Pool<Sqlite>) {
+        sqlx::query(
+            r#"
+            CREATE TABLE secure_store_secrets (
+                alias TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                label TEXT,
+                provider_id TEXT NOT NULL,
+                provider_kind TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                nonce TEXT NOT NULL,
+                encrypted_value TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+        )
+        .execute(pool)
+        .await
+        .expect("create legacy secrets table");
+    }
 }

--- a/backend/crates/mcpmate-secrets/src/lib.rs
+++ b/backend/crates/mcpmate-secrets/src/lib.rs
@@ -17,6 +17,8 @@ pub use reference::{
     SecretError, SecretReference, SecretValue, extract_secret_references, parse_placeholder, resolve_placeholders,
 };
 pub use root_key::{
-    DEVELOPMENT_ROOT_KEY_ENV, DevelopmentRootKeyProvider, OperatingSystemRootKeyProvider, RootKeyProviderMetadata,
-    SecretRootKey, SecretRootKeyError, SecretRootKeyProvider, default_root_key_provider,
+    DEVELOPMENT_ROOT_KEY_ENV, DevelopmentRootKeyProvider, LOCAL_FILE_PROVIDER_ID, LOCAL_FILE_PROVIDER_KIND,
+    LocalFileRootKeyProvider, OperatingSystemRootKeyProvider, PASSPHRASE_PROVIDER_ID, PASSPHRASE_PROVIDER_KIND,
+    PassphraseRootKeyProvider, RootKeyProviderMetadata, RootKeyProviderMode, RootKeySecurityLevel, SecretRootKey,
+    SecretRootKeyError, SecretRootKeyProvider, default_root_key_provider,
 };

--- a/backend/crates/mcpmate-secrets/src/root_key.rs
+++ b/backend/crates/mcpmate-secrets/src/root_key.rs
@@ -2,12 +2,14 @@ use std::{
     fmt,
     fs::{self, OpenOptions},
     io::{Read, Write},
-    path::PathBuf,
+    num::NonZeroU32,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
-use ring::rand;
+use ring::{aead, pbkdf2, rand};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
@@ -15,15 +17,69 @@ use crate::constants::{DEVELOPMENT_PROVIDER_ID, DEVELOPMENT_PROVIDER_KIND, OS_PR
 
 const OS_KEYRING_SERVICE: &str = "ai.umate.mcpmate.secure-store";
 const OS_KEYRING_USER: &str = "secure-store-root-key";
+pub const PASSPHRASE_PROVIDER_ID: &str = "master-password-local-root-key";
+pub const PASSPHRASE_PROVIDER_KIND: &str = "passphrase_wrapped_root_key";
+pub const LOCAL_FILE_PROVIDER_ID: &str = "local-file-root-key";
+pub const LOCAL_FILE_PROVIDER_KIND: &str = "local_file_root_key";
+const PASSPHRASE_FILE_VERSION: u32 = 1;
+const PASSPHRASE_KDF_NAME: &str = "pbkdf2-hmac-sha256";
+const PASSPHRASE_KDF_ITERATIONS: u32 = 210_000;
+const PASSPHRASE_ROOT_KEY_AAD: &[u8] = b"mcpmate-secrets:v1:passphrase-root-key";
+const PASSPHRASE_SALT_LEN: usize = 16;
+const AES_256_GCM_NONCE_LEN: usize = 12;
 
 pub const DEVELOPMENT_ROOT_KEY_ENV: &str = "MCPMATE_SECRETS_LOCAL_KEY";
 
 pub type SecretRootKey = [u8; 32];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootKeyProviderMode {
+    OperatingSystem,
+    Passphrase,
+    LocalFile,
+    Development,
+    Custom,
+}
+
+impl RootKeyProviderMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OperatingSystem => "operating_system",
+            Self::Passphrase => "passphrase",
+            Self::LocalFile => "local_file",
+            Self::Development => "development",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootKeySecurityLevel {
+    Recommended,
+    UserManaged,
+    BasicLocal,
+    Development,
+    Custom,
+}
+
+impl RootKeySecurityLevel {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Recommended => "recommended",
+            Self::UserManaged => "user_managed",
+            Self::BasicLocal => "basic_local",
+            Self::Development => "development",
+            Self::Custom => "custom",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RootKeyProviderMetadata {
     provider_id: &'static str,
     provider_kind: &'static str,
+    mode: RootKeyProviderMode,
+    security_level: RootKeySecurityLevel,
 }
 
 impl RootKeyProviderMetadata {
@@ -31,9 +87,25 @@ impl RootKeyProviderMetadata {
         provider_id: &'static str,
         provider_kind: &'static str,
     ) -> Self {
+        Self::with_mode(
+            provider_id,
+            provider_kind,
+            RootKeyProviderMode::Custom,
+            RootKeySecurityLevel::Custom,
+        )
+    }
+
+    pub const fn with_mode(
+        provider_id: &'static str,
+        provider_kind: &'static str,
+        mode: RootKeyProviderMode,
+        security_level: RootKeySecurityLevel,
+    ) -> Self {
         Self {
             provider_id,
             provider_kind,
+            mode,
+            security_level,
         }
     }
 
@@ -44,6 +116,14 @@ impl RootKeyProviderMetadata {
     pub fn provider_kind(&self) -> &'static str {
         self.provider_kind
     }
+
+    pub fn mode(&self) -> RootKeyProviderMode {
+        self.mode
+    }
+
+    pub fn security_level(&self) -> RootKeySecurityLevel {
+        self.security_level
+    }
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -52,6 +132,8 @@ pub enum SecretRootKeyError {
     ProviderUnavailable(String),
     #[error("invalid root key material: {0}")]
     InvalidMaterial(String),
+    #[error("local root key storage failed: {0}")]
+    LocalStorage(String),
     #[error("development root key storage failed: {0}")]
     DevelopmentStorage(String),
 }
@@ -95,11 +177,90 @@ impl Default for OperatingSystemRootKeyProvider {
 
 impl SecretRootKeyProvider for OperatingSystemRootKeyProvider {
     fn metadata(&self) -> RootKeyProviderMetadata {
-        RootKeyProviderMetadata::new(os_provider_id(), OS_PROVIDER_KIND)
+        RootKeyProviderMetadata::with_mode(
+            os_provider_id(),
+            OS_PROVIDER_KIND,
+            RootKeyProviderMode::OperatingSystem,
+            RootKeySecurityLevel::Recommended,
+        )
     }
 
     fn load_or_create_root_key(&self) -> Result<SecretRootKey, SecretRootKeyError> {
         load_or_create_os_root_key(&self.service, &self.user)
+    }
+}
+
+#[derive(Clone)]
+pub struct PassphraseRootKeyProvider {
+    wrapped_key_path: PathBuf,
+    passphrase: String,
+}
+
+impl fmt::Debug for PassphraseRootKeyProvider {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        formatter
+            .debug_struct("PassphraseRootKeyProvider")
+            .field("wrapped_key_path", &self.wrapped_key_path)
+            .field("passphrase", &"<redacted>")
+            .finish()
+    }
+}
+
+impl PassphraseRootKeyProvider {
+    pub fn new(
+        wrapped_key_path: impl Into<PathBuf>,
+        passphrase: impl Into<String>,
+    ) -> Self {
+        Self {
+            wrapped_key_path: wrapped_key_path.into(),
+            passphrase: passphrase.into(),
+        }
+    }
+}
+
+impl SecretRootKeyProvider for PassphraseRootKeyProvider {
+    fn metadata(&self) -> RootKeyProviderMetadata {
+        RootKeyProviderMetadata::with_mode(
+            PASSPHRASE_PROVIDER_ID,
+            PASSPHRASE_PROVIDER_KIND,
+            RootKeyProviderMode::Passphrase,
+            RootKeySecurityLevel::UserManaged,
+        )
+    }
+
+    fn load_or_create_root_key(&self) -> Result<SecretRootKey, SecretRootKeyError> {
+        load_or_create_passphrase_root_key(&self.wrapped_key_path, &self.passphrase)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalFileRootKeyProvider {
+    local_key_path: PathBuf,
+}
+
+impl LocalFileRootKeyProvider {
+    pub fn new(local_key_path: impl Into<PathBuf>) -> Self {
+        Self {
+            local_key_path: local_key_path.into(),
+        }
+    }
+}
+
+impl SecretRootKeyProvider for LocalFileRootKeyProvider {
+    fn metadata(&self) -> RootKeyProviderMetadata {
+        RootKeyProviderMetadata::with_mode(
+            LOCAL_FILE_PROVIDER_ID,
+            LOCAL_FILE_PROVIDER_KIND,
+            RootKeyProviderMode::LocalFile,
+            RootKeySecurityLevel::BasicLocal,
+        )
+    }
+
+    fn load_or_create_root_key(&self) -> Result<SecretRootKey, SecretRootKeyError> {
+        load_or_create_local_file_root_key(&self.local_key_path)
     }
 }
 
@@ -118,7 +279,12 @@ impl DevelopmentRootKeyProvider {
 
 impl SecretRootKeyProvider for DevelopmentRootKeyProvider {
     fn metadata(&self) -> RootKeyProviderMetadata {
-        RootKeyProviderMetadata::new(DEVELOPMENT_PROVIDER_ID, DEVELOPMENT_PROVIDER_KIND)
+        RootKeyProviderMetadata::with_mode(
+            DEVELOPMENT_PROVIDER_ID,
+            DEVELOPMENT_PROVIDER_KIND,
+            RootKeyProviderMode::Development,
+            RootKeySecurityLevel::Development,
+        )
     }
 
     fn load_or_create_root_key(&self) -> Result<SecretRootKey, SecretRootKeyError> {
@@ -128,35 +294,10 @@ impl SecretRootKeyProvider for DevelopmentRootKeyProvider {
             }
         }
 
-        if self.local_key_path.exists() {
-            let mut file = OpenOptions::new()
-                .read(true)
-                .open(&self.local_key_path)
-                .map_err(|err| SecretRootKeyError::DevelopmentStorage(err.to_string()))?;
-            let mut encoded = String::new();
-            file.read_to_string(&mut encoded)
-                .map_err(|err| SecretRootKeyError::DevelopmentStorage(err.to_string()))?;
-            return decode_root_key(&encoded);
-        }
-
-        if let Some(parent) = self.local_key_path.parent() {
-            fs::create_dir_all(parent).map_err(|err| SecretRootKeyError::DevelopmentStorage(err.to_string()))?;
-        }
-        let root = generate_root_key()?;
-        let mut file = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&self.local_key_path)
-            .map_err(|err| SecretRootKeyError::DevelopmentStorage(err.to_string()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            file.set_permissions(fs::Permissions::from_mode(0o600))
-                .map_err(|err| SecretRootKeyError::DevelopmentStorage(err.to_string()))?;
-        }
-        file.write_all(STANDARD.encode(root).as_bytes())
-            .map_err(|err| SecretRootKeyError::DevelopmentStorage(err.to_string()))?;
-        Ok(derive_key(&root))
+        load_or_create_local_file_root_key(&self.local_key_path).map_err(|err| match err {
+            SecretRootKeyError::LocalStorage(message) => SecretRootKeyError::DevelopmentStorage(message),
+            other => other,
+        })
     }
 }
 
@@ -172,11 +313,210 @@ fn decode_root_key(encoded: &str) -> Result<SecretRootKey, SecretRootKeyError> {
     let decoded = STANDARD
         .decode(encoded.trim())
         .map_err(|err| SecretRootKeyError::InvalidMaterial(err.to_string()))?;
+    if decoded.len() != 32 {
+        return Err(SecretRootKeyError::InvalidMaterial(format!(
+            "root key material must be 32 bytes, got {}",
+            decoded.len()
+        )));
+    }
     Ok(derive_key(&decoded))
 }
 
 fn derive_key(material: &[u8]) -> SecretRootKey {
     Sha256::digest(material).into()
+}
+
+fn load_or_create_local_file_root_key(local_key_path: &Path) -> Result<SecretRootKey, SecretRootKeyError> {
+    if local_key_path.exists() {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .open(local_key_path)
+            .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+        let mut encoded = String::new();
+        file.read_to_string(&mut encoded)
+            .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+        return decode_root_key(&encoded);
+    }
+
+    if let Some(parent) = local_key_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+    }
+    let root = generate_root_key()?;
+    write_secret_file(local_key_path, STANDARD.encode(root).as_bytes())?;
+    Ok(derive_key(&root))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PassphraseRootKeyFile {
+    version: u32,
+    kdf: String,
+    iterations: u32,
+    salt: String,
+    nonce: String,
+    encrypted_root_key: String,
+}
+
+fn load_or_create_passphrase_root_key(
+    wrapped_key_path: &Path,
+    passphrase: &str,
+) -> Result<SecretRootKey, SecretRootKeyError> {
+    if passphrase.is_empty() {
+        return Err(SecretRootKeyError::InvalidMaterial(
+            "passphrase cannot be empty".to_string(),
+        ));
+    }
+
+    if wrapped_key_path.exists() {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .open(wrapped_key_path)
+            .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+        let mut serialized = String::new();
+        file.read_to_string(&mut serialized)
+            .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+        return unwrap_passphrase_root_key(&serialized, passphrase);
+    }
+
+    if let Some(parent) = wrapped_key_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+    }
+
+    let root = generate_root_key()?;
+    let salt = generate_random_bytes(PASSPHRASE_SALT_LEN)?;
+    let nonce = generate_random_bytes(AES_256_GCM_NONCE_LEN)?;
+    let wrapping_key = derive_passphrase_wrapping_key(passphrase, &salt, PASSPHRASE_KDF_ITERATIONS)?;
+    let encrypted_root_key = encrypt_root_material(&root, &wrapping_key, &nonce)?;
+    let serialized = serde_json::to_vec_pretty(&PassphraseRootKeyFile {
+        version: PASSPHRASE_FILE_VERSION,
+        kdf: PASSPHRASE_KDF_NAME.to_string(),
+        iterations: PASSPHRASE_KDF_ITERATIONS,
+        salt: STANDARD.encode(salt),
+        nonce: STANDARD.encode(nonce),
+        encrypted_root_key: STANDARD.encode(encrypted_root_key),
+    })
+    .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+    write_secret_file(wrapped_key_path, &serialized)?;
+    Ok(derive_key(&root))
+}
+
+fn unwrap_passphrase_root_key(
+    serialized: &str,
+    passphrase: &str,
+) -> Result<SecretRootKey, SecretRootKeyError> {
+    let file: PassphraseRootKeyFile =
+        serde_json::from_str(serialized).map_err(|err| SecretRootKeyError::InvalidMaterial(err.to_string()))?;
+    if file.version != PASSPHRASE_FILE_VERSION {
+        return Err(SecretRootKeyError::InvalidMaterial(format!(
+            "unsupported passphrase root key file version {}",
+            file.version
+        )));
+    }
+    if file.kdf != PASSPHRASE_KDF_NAME {
+        return Err(SecretRootKeyError::InvalidMaterial(format!(
+            "unsupported passphrase root key kdf '{}'",
+            file.kdf
+        )));
+    }
+
+    let salt = STANDARD
+        .decode(file.salt)
+        .map_err(|err| SecretRootKeyError::InvalidMaterial(err.to_string()))?;
+    let nonce = STANDARD
+        .decode(file.nonce)
+        .map_err(|err| SecretRootKeyError::InvalidMaterial(err.to_string()))?;
+    let encrypted_root_key = STANDARD
+        .decode(file.encrypted_root_key)
+        .map_err(|err| SecretRootKeyError::InvalidMaterial(err.to_string()))?;
+    let wrapping_key = derive_passphrase_wrapping_key(passphrase, &salt, file.iterations)?;
+    let root = decrypt_root_material(&encrypted_root_key, &wrapping_key, &nonce)?;
+    Ok(derive_key(&root))
+}
+
+fn derive_passphrase_wrapping_key(
+    passphrase: &str,
+    salt: &[u8],
+    iterations: u32,
+) -> Result<SecretRootKey, SecretRootKeyError> {
+    let iterations = NonZeroU32::new(iterations)
+        .ok_or_else(|| SecretRootKeyError::InvalidMaterial("passphrase kdf iterations cannot be zero".to_string()))?;
+    let mut key = [0_u8; 32];
+    pbkdf2::derive(
+        pbkdf2::PBKDF2_HMAC_SHA256,
+        iterations,
+        salt,
+        passphrase.as_bytes(),
+        &mut key,
+    );
+    Ok(key)
+}
+
+fn encrypt_root_material(
+    root: &SecretRootKey,
+    wrapping_key: &SecretRootKey,
+    nonce: &[u8],
+) -> Result<Vec<u8>, SecretRootKeyError> {
+    let key = aead_key(wrapping_key)?;
+    let nonce = aead_nonce(nonce)?;
+    let mut in_out = root.to_vec();
+    key.seal_in_place_append_tag(nonce, aead::Aad::from(PASSPHRASE_ROOT_KEY_AAD), &mut in_out)
+        .map_err(|_| SecretRootKeyError::InvalidMaterial("encrypt passphrase root key".to_string()))?;
+    Ok(in_out)
+}
+
+fn decrypt_root_material(
+    encrypted: &[u8],
+    wrapping_key: &SecretRootKey,
+    nonce: &[u8],
+) -> Result<SecretRootKey, SecretRootKeyError> {
+    let key = aead_key(wrapping_key)?;
+    let nonce = aead_nonce(nonce)?;
+    let mut in_out = encrypted.to_vec();
+    let plaintext = key
+        .open_in_place(nonce, aead::Aad::from(PASSPHRASE_ROOT_KEY_AAD), &mut in_out)
+        .map_err(|_| SecretRootKeyError::InvalidMaterial("passphrase did not unwrap root key".to_string()))?;
+    plaintext
+        .try_into()
+        .map_err(|_| SecretRootKeyError::InvalidMaterial("invalid root key length".to_string()))
+}
+
+fn aead_key(raw_key: &SecretRootKey) -> Result<aead::LessSafeKey, SecretRootKeyError> {
+    let key = aead::UnboundKey::new(&aead::AES_256_GCM, raw_key)
+        .map_err(|_| SecretRootKeyError::InvalidMaterial("invalid wrapping key".to_string()))?;
+    Ok(aead::LessSafeKey::new(key))
+}
+
+fn aead_nonce(nonce: &[u8]) -> Result<aead::Nonce, SecretRootKeyError> {
+    let nonce: [u8; AES_256_GCM_NONCE_LEN] = nonce
+        .try_into()
+        .map_err(|_| SecretRootKeyError::InvalidMaterial("invalid root key nonce length".to_string()))?;
+    Ok(aead::Nonce::assume_unique_for_key(nonce))
+}
+
+fn generate_random_bytes(len: usize) -> Result<Vec<u8>, SecretRootKeyError> {
+    let rng = rand::SystemRandom::new();
+    let mut bytes = vec![0_u8; len];
+    rand::SecureRandom::fill(&rng, &mut bytes)
+        .map_err(|_| SecretRootKeyError::InvalidMaterial("secure random generation failed".to_string()))?;
+    Ok(bytes)
+}
+
+fn write_secret_file(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<(), SecretRootKeyError> {
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))?;
+    }
+    file.write_all(bytes)
+        .map_err(|err| SecretRootKeyError::LocalStorage(err.to_string()))
 }
 
 #[cfg(target_os = "macos")]
@@ -277,6 +617,34 @@ mod tests {
 
         assert_eq!(metadata.provider_kind(), OS_PROVIDER_KIND);
         assert_ne!(metadata.provider_id(), DEVELOPMENT_PROVIDER_ID);
+        assert_eq!(metadata.mode(), RootKeyProviderMode::OperatingSystem);
+        assert_eq!(metadata.security_level(), RootKeySecurityLevel::Recommended);
+    }
+
+    #[test]
+    fn passphrase_provider_uses_user_managed_metadata() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        let provider = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple");
+        let metadata = provider.metadata();
+
+        assert_eq!(metadata.provider_id(), PASSPHRASE_PROVIDER_ID);
+        assert_eq!(metadata.provider_kind(), PASSPHRASE_PROVIDER_KIND);
+        assert_eq!(metadata.mode(), RootKeyProviderMode::Passphrase);
+        assert_eq!(metadata.security_level(), RootKeySecurityLevel::UserManaged);
+    }
+
+    #[test]
+    fn local_file_provider_uses_basic_local_metadata() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("local-root.key");
+        let provider = LocalFileRootKeyProvider::new(&key_path);
+        let metadata = provider.metadata();
+
+        assert_eq!(metadata.provider_id(), LOCAL_FILE_PROVIDER_ID);
+        assert_eq!(metadata.provider_kind(), LOCAL_FILE_PROVIDER_KIND);
+        assert_eq!(metadata.mode(), RootKeyProviderMode::LocalFile);
+        assert_eq!(metadata.security_level(), RootKeySecurityLevel::BasicLocal);
     }
 
     #[test]
@@ -310,6 +678,181 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn local_file_provider_rejects_short_root_material() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("local-root.key");
+        fs::create_dir_all(key_path.parent().expect("parent dir")).expect("create parent");
+        fs::write(&key_path, STANDARD.encode([42_u8])).expect("write short material");
+
+        let err = LocalFileRootKeyProvider::new(&key_path)
+            .load_or_create_root_key()
+            .expect_err("short local root material should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn local_file_provider_rejects_long_root_material() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("local-root.key");
+        fs::create_dir_all(key_path.parent().expect("parent dir")).expect("create parent");
+        fs::write(&key_path, STANDARD.encode([7_u8; 33])).expect("write long material");
+
+        let err = LocalFileRootKeyProvider::new(&key_path)
+            .load_or_create_root_key()
+            .expect_err("long local root material should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn local_file_provider_rejects_non_base64_root_material() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("local-root.key");
+        fs::create_dir_all(key_path.parent().expect("parent dir")).expect("create parent");
+        fs::write(&key_path, "not base64").expect("write invalid material");
+
+        let err = LocalFileRootKeyProvider::new(&key_path)
+            .load_or_create_root_key()
+            .expect_err("invalid local root material should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_reopens_wrapped_root_key_with_same_passphrase() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        let first_provider = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple");
+        let second_provider = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple");
+
+        let first = first_provider
+            .load_or_create_root_key()
+            .expect("create passphrase root key");
+        let second = second_provider
+            .load_or_create_root_key()
+            .expect("load passphrase root key");
+
+        assert_eq!(first, second);
+        assert!(key_path.exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_rejects_wrong_passphrase() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple")
+            .load_or_create_root_key()
+            .expect("create passphrase root key");
+
+        let err = PassphraseRootKeyProvider::new(&key_path, "wrong password")
+            .load_or_create_root_key()
+            .expect_err("wrong passphrase should not unwrap root key");
+
+        assert!(matches!(err, SecretRootKeyError::InvalidMaterial(_)));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_rejects_empty_passphrase() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+
+        let err = PassphraseRootKeyProvider::new(&key_path, "")
+            .load_or_create_root_key()
+            .expect_err("empty passphrase should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_rejects_unsupported_version() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        let mut file = create_passphrase_root_key_file(&key_path);
+        file.version = PASSPHRASE_FILE_VERSION + 1;
+        write_passphrase_root_key_file(&key_path, &file);
+
+        let err = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple")
+            .load_or_create_root_key()
+            .expect_err("unsupported version should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_rejects_unsupported_kdf() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        let mut file = create_passphrase_root_key_file(&key_path);
+        file.kdf = "scrypt".to_string();
+        write_passphrase_root_key_file(&key_path, &file);
+
+        let err = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple")
+            .load_or_create_root_key()
+            .expect_err("unsupported kdf should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_rejects_zero_iterations() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        let mut file = create_passphrase_root_key_file(&key_path);
+        file.iterations = 0;
+        write_passphrase_root_key_file(&key_path, &file);
+
+        let err = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple")
+            .load_or_create_root_key()
+            .expect_err("zero iterations should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_rejects_invalid_nonce_length() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        let mut file = create_passphrase_root_key_file(&key_path);
+        file.nonce = STANDARD.encode([1_u8; AES_256_GCM_NONCE_LEN - 1]);
+        write_passphrase_root_key_file(&key_path, &file);
+
+        let err = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple")
+            .load_or_create_root_key()
+            .expect_err("invalid nonce should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn passphrase_provider_rejects_corrupted_ciphertext() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let key_path = temp_dir.path().join("secrets").join("passphrase-root-key.json");
+        let mut file = create_passphrase_root_key_file(&key_path);
+        let mut ciphertext = STANDARD.decode(&file.encrypted_root_key).expect("decode ciphertext");
+        ciphertext[0] ^= 0x01;
+        file.encrypted_root_key = STANDARD.encode(ciphertext);
+        write_passphrase_root_key_file(&key_path, &file);
+
+        let err = PassphraseRootKeyProvider::new(&key_path, "correct horse battery staple")
+            .load_or_create_root_key()
+            .expect_err("corrupted ciphertext should fail");
+
+        assert_invalid_material(err);
+    }
+
+    #[test]
+    #[serial_test::serial]
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
     fn os_root_key_provider_loads_or_creates_root_key_when_enabled() {
         if std::env::var("MCPMATE_RUN_OS_KEYRING_TESTS").as_deref() != Ok("1") {
@@ -337,5 +880,25 @@ mod tests {
         assert_eq!(first, second);
 
         let _ = entry.delete_credential();
+    }
+
+    fn assert_invalid_material(err: SecretRootKeyError) {
+        assert!(matches!(err, SecretRootKeyError::InvalidMaterial(_)));
+    }
+
+    fn create_passphrase_root_key_file(key_path: &Path) -> PassphraseRootKeyFile {
+        PassphraseRootKeyProvider::new(key_path, "correct horse battery staple")
+            .load_or_create_root_key()
+            .expect("create passphrase root key");
+        let serialized = fs::read_to_string(key_path).expect("read passphrase root key file");
+        serde_json::from_str(&serialized).expect("parse passphrase root key file")
+    }
+
+    fn write_passphrase_root_key_file(
+        key_path: &Path,
+        file: &PassphraseRootKeyFile,
+    ) {
+        let serialized = serde_json::to_vec_pretty(file).expect("serialize passphrase root key file");
+        fs::write(key_path, serialized).expect("write passphrase root key file");
     }
 }

--- a/backend/src/api/handlers/inspector/endpoints.rs
+++ b/backend/src/api/handlers/inspector/endpoints.rs
@@ -92,6 +92,7 @@ pub async fn tool_call(
                 ApiError::NotFound(m) => ("not_found", m.as_str()),
                 ApiError::BadRequest(m) => ("bad_request", m.as_str()),
                 ApiError::InternalError(m) => ("internal_error", m.as_str()),
+                ApiError::ServiceUnavailable(m) => ("service_unavailable", m.as_str()),
                 ApiError::Conflict(m) => ("conflict", m.as_str()),
                 ApiError::Forbidden(m) => ("forbidden", m.as_str()),
                 ApiError::Timeout(m) => ("timeout", m.as_str()),

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -32,6 +32,8 @@ pub enum ApiError {
     BadRequest(String),
     /// Internal server error
     InternalError(String),
+    /// Service unavailable error
+    ServiceUnavailable(String),
     /// Conflict error
     Conflict(String),
     /// Forbidden error
@@ -49,6 +51,7 @@ impl fmt::Display for ApiError {
             ApiError::NotFound(msg) => write!(f, "Not found: {msg}"),
             ApiError::BadRequest(msg) => write!(f, "Bad request: {msg}"),
             ApiError::InternalError(msg) => write!(f, "Internal error: {msg}"),
+            ApiError::ServiceUnavailable(msg) => write!(f, "Service unavailable: {msg}"),
             ApiError::Conflict(msg) => write!(f, "Conflict: {msg}"),
             ApiError::Forbidden(msg) => write!(f, "Forbidden: {msg}"),
             ApiError::Timeout(msg) => write!(f, "Timeout: {msg}"),
@@ -62,6 +65,7 @@ impl IntoResponse for ApiError {
             ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             ApiError::InternalError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg),
             ApiError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
             ApiError::Timeout(msg) => (StatusCode::REQUEST_TIMEOUT, msg),
@@ -82,5 +86,17 @@ impl IntoResponse for ApiError {
 impl From<anyhow::Error> for ApiError {
     fn from(err: anyhow::Error) -> Self {
         ApiError::InternalError(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_unavailable_errors_return_503() {
+        let response = ApiError::ServiceUnavailable("secure store unavailable".to_string()).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/backend/src/api/handlers/secrets.rs
+++ b/backend/src/api/handlers/secrets.rs
@@ -113,7 +113,7 @@ pub async fn list_secret_usages(
 
 fn get_secret_store(state: &Arc<AppState>) -> Result<Arc<crate::core::secrets::store::LocalSecretStore>, ApiError> {
     state.secret_store.clone().ok_or_else(|| {
-        ApiError::InternalError(
+        ApiError::ServiceUnavailable(
             "Secret store is unavailable. Unlock or configure the operating-system secure storage provider."
                 .to_string(),
         )


### PR DESCRIPTION
## Motivation

The secure-store foundation needs explicit root-key provider modes and readiness semantics before the 0.3.0 security work can be made user-operable. The current first secure-store PR focuses on OS-backed custody and encrypted storage; this stacked slice adds the provider-mode layer needed for recommended OS custody, master-password protected local custody, basic local protection, and explicit unavailable or denied states.

## Scope of changes

- Add root-key provider modes and security-level metadata inside mcpmate-secrets.
- Add passphrase-wrapped local root-key support and basic local-file provider behavior behind the crate boundary.
- Extend provider status/readiness types so backend and management shells can distinguish configured, unavailable, locked, denied, and cache-error style states.
- Preserve fail-closed behavior for unavailable secure storage instead of silently falling back to weaker custody.
- Add the minimal backend enum handling needed for the recovered readiness surface.

## Linked project item

GitHub Project: 0.3.0: provider modes and readiness API (PVTI_lAHOAYlBbs4BYAQyzguueqM).

## Dependency and review order

This is a stacked PR on top of PR #94 / branch feat/server-credentials-secure-store. It should be reviewed after or alongside PR #94, and should not be merged before the base secure-store branch lands.

## Config, schema, migration, and compatibility impact

No database migration is included in this recovered slice. The provider mode additions extend the secure-store crate contract and preserve existing explicit development/test root-key behavior. Product-facing runtime selection and full Board readiness UX remain follow-up work on the same Project item.

## Validation evidence

- RUSTC_WRAPPER= cargo test --manifest-path backend/crates/mcpmate-secrets/Cargo.toml -- --test-threads=1
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml --test secrets_runtime_config -- --test-threads=1
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml --test secrets_store_api -- --test-threads=1
- RUSTC_WRAPPER= cargo clippy --manifest-path backend/crates/mcpmate-secrets/Cargo.toml --all-targets --all-features -- -D warnings
- RUSTC_WRAPPER= cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings
- git diff --check

## Known risks, gaps, and follow-up work

Full cargo fmt --check is still blocked by pre-existing unrelated formatting drift in runtime/path files; touched Rust files were checked separately and fixed before commit.

Remaining follow-up scope is unchanged: backend readiness/status API completion, management-shell integration, runtime provider selection, locked/denied/unavailable UX states, explicit reset or migration tooling for non-empty legacy secure-store tables, and OAuth token refresh.