### PR TITLE
fix(oauth): refresh expired server tokens

### DIFF
--- a/backend/src/api/handlers/server/preview.rs
+++ b/backend/src/api/handlers/server/preview.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
+
 use super::shared::*;
 use crate::api::models::server::{
     ServerCapabilityMeta, ServerPreviewData, ServerPreviewItemData, ServerPreviewItemReq, ServerPreviewReq,
     ServerPreviewResp, ServerPromptsData, ServerResourceTemplatesData, ServerResourcesData, ServerToolsData,
 };
 
-/// Preview capabilities for arbitrary server configs (no DB/REDB/pool side-effects)
+/// Preview capabilities for arbitrary server configs.
+///
+/// Saved-server previews may refresh stored OAuth tokens while resolving effective headers.
 pub async fn preview_servers(
     State(state): State<Arc<AppState>>,
     Json(req): Json<ServerPreviewReq>,
@@ -36,16 +40,12 @@ async fn preview_one(
         }
     };
 
-    // Call preview (no side effects)
     // Build optional HTTP client with default headers if provided
-    let effective_headers = if let (Some(pool), Some(server_id)) = (db_pool, item.server_id.as_deref()) {
-        crate::config::server::oauth::get_effective_server_headers(pool, server_id, item.headers.clone())
-            .await
-            .ok()
-            .flatten()
-    } else {
-        item.headers.clone()
-    };
+    let effective_headers =
+        match resolve_preview_headers(item.headers.clone(), item.server_id.as_deref(), db_pool).await {
+            Ok(headers) => headers,
+            Err(e) => return empty_with_error(item.name, e.to_string()),
+        };
 
     let mut client: Option<reqwest::Client> = None;
     if kind.is_http_transport() {
@@ -97,6 +97,20 @@ async fn preview_one(
         Ok(s) => build_item(item.name, s, include_details),
         Err(e) => empty_with_error(item.name, e.to_string()),
     }
+}
+
+async fn resolve_preview_headers(
+    item_headers: Option<HashMap<String, String>>,
+    server_id: Option<&str>,
+    db_pool: Option<&sqlx::SqlitePool>,
+) -> anyhow::Result<Option<HashMap<String, String>>> {
+    if let (Some(pool), Some(server_id)) = (db_pool, server_id) {
+        return crate::core::oauth::OAuthManager::new(pool.clone())
+            .get_effective_server_headers(server_id, item_headers)
+            .await;
+    }
+
+    Ok(item_headers)
 }
 
 fn build_item(
@@ -236,5 +250,156 @@ fn empty_with_error(
             state: "error".to_string(),
             meta,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        models::{ServerOAuthConfig, ServerOAuthToken},
+        server::{init::initialize_server_tables, upsert_server_oauth_config, upsert_server_oauth_token},
+    };
+    use chrono::{Duration, Utc};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_string_contains, method, path},
+    };
+
+    async fn setup_pool() -> sqlx::SqlitePool {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .expect("enable foreign keys");
+        initialize_server_tables(&pool).await.expect("init server tables");
+        pool
+    }
+
+    async fn insert_http_server(
+        pool: &sqlx::SqlitePool,
+        server_id: &str,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO server_config (id, name, server_type, url, enabled)
+            VALUES (?, ?, 'streamable_http', 'https://example.com/mcp', 1)
+            "#,
+        )
+        .bind(server_id)
+        .bind(format!("server-{server_id}"))
+        .execute(pool)
+        .await
+        .expect("insert http server");
+    }
+
+    async fn store_expired_oauth_token(
+        pool: &sqlx::SqlitePool,
+        server_id: &str,
+        token_endpoint: String,
+    ) {
+        upsert_server_oauth_config(
+            pool,
+            &ServerOAuthConfig {
+                id: None,
+                server_id: server_id.to_string(),
+                authorization_endpoint: "https://issuer.example.com/authorize".to_string(),
+                token_endpoint,
+                client_id: "client-1".to_string(),
+                client_secret: None,
+                scopes: Some("read write".to_string()),
+                redirect_uri: "http://localhost:5173/oauth/callback".to_string(),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("save oauth config");
+        upsert_server_oauth_token(
+            pool,
+            &ServerOAuthToken {
+                id: None,
+                server_id: server_id.to_string(),
+                access_token: "access-old".to_string(),
+                refresh_token: Some("refresh-123".to_string()),
+                token_type: "bearer".to_string(),
+                expires_at: Some((Utc::now() - Duration::minutes(1)).to_rfc3339()),
+                scope: Some("read write".to_string()),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("store expired token");
+    }
+
+    #[tokio::test]
+    async fn resolve_preview_headers_refreshes_expired_oauth_token() {
+        let pool = setup_pool().await;
+        insert_http_server(&pool, "serv_preview_refresh").await;
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .and(body_string_contains("refresh_token=refresh-123"))
+            .and(body_string_contains("resource=https%3A%2F%2Fexample.com%2Fmcp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "access-new",
+                "token_type": "bearer",
+                "expires_in": 3600
+            })))
+            .mount(&mock_server)
+            .await;
+
+        store_expired_oauth_token(&pool, "serv_preview_refresh", format!("{}/token", mock_server.uri())).await;
+
+        let headers = resolve_preview_headers(None, Some("serv_preview_refresh"), Some(&pool))
+            .await
+            .expect("resolve headers")
+            .expect("headers");
+
+        assert_eq!(
+            headers.get("authorization").map(String::as_str),
+            Some("Bearer access-new")
+        );
+    }
+
+    #[tokio::test]
+    async fn preview_reports_oauth_header_resolution_errors() {
+        let pool = setup_pool().await;
+        insert_http_server(&pool, "serv_preview_error").await;
+
+        store_expired_oauth_token(
+            &pool,
+            "serv_preview_error",
+            "http://not-loopback.example.com/token".to_string(),
+        )
+        .await;
+
+        let item = ServerPreviewItemReq {
+            name: "Preview Error".to_string(),
+            server_id: Some("serv_preview_error".to_string()),
+            kind: "streamable_http".to_string(),
+            command: None,
+            url: Some("https://example.com/mcp".to_string()),
+            args: None,
+            env: None,
+            headers: None,
+        };
+
+        let preview = preview_one(item, Some(std::time::Duration::from_millis(100)), false, Some(&pool)).await;
+
+        assert!(!preview.ok);
+        assert!(
+            preview
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("OAuth token endpoint must use HTTPS"))
+        );
     }
 }

--- a/backend/src/core/foundation/loader.rs
+++ b/backend/src/core/foundation/loader.rs
@@ -31,6 +31,7 @@ async fn build_config_from_servers(
     servers: &[Server],
 ) -> Result<Config> {
     let mut config = empty_config();
+    let oauth_manager = crate::core::oauth::OAuthManager::new(db.pool.clone());
 
     for server in servers {
         let args = if let Some(id) = &server.id {
@@ -60,10 +61,14 @@ async fn build_config_from_servers(
         };
 
         let headers = if let Some(id) = &server.id {
-            match crate::config::server::get_server_headers(&db.pool, id).await {
+            let manual_headers = match crate::config::server::get_server_headers(&db.pool, id).await {
                 Ok(map) if !map.is_empty() => Some(map),
                 _ => None,
-            }
+            };
+            oauth_manager
+                .get_effective_server_headers(id, manual_headers)
+                .await
+                .context("Failed to get effective server headers")?
         } else {
             None
         };
@@ -227,9 +232,18 @@ pub async fn load_server_config(db: &Database) -> Result<Config> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::initialization::run_initialization;
+    use crate::config::{
+        initialization::run_initialization,
+        models::{ServerOAuthConfig, ServerOAuthToken},
+        server::{upsert_server_oauth_config, upsert_server_oauth_token},
+    };
+    use chrono::{Duration, Utc};
     use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
     use tempfile::TempDir;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_string_contains, method, path},
+    };
 
     async fn create_test_database() -> (TempDir, Database) {
         let temp_dir = TempDir::new().expect("temp dir");
@@ -269,6 +283,26 @@ mod tests {
         .expect("insert server");
     }
 
+    async fn insert_http_server(
+        pool: &SqlitePool,
+        server_id: &str,
+        name: &str,
+        enabled: bool,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO server_config (id, name, server_type, url, enabled)
+            VALUES (?, ?, 'streamable_http', 'https://example.com/mcp', ?)
+            "#,
+        )
+        .bind(server_id)
+        .bind(name)
+        .bind(enabled)
+        .execute(pool)
+        .await
+        .expect("insert http server");
+    }
+
     #[tokio::test]
     async fn load_pool_base_config_uses_globally_enabled_servers_without_profile_merge() {
         let (_temp_dir, db) = create_test_database().await;
@@ -282,5 +316,71 @@ mod tests {
 
         assert!(pool_config.mcp_servers.contains_key("server-global"));
         assert!(!active_profile_config.mcp_servers.contains_key("server-global"));
+    }
+
+    #[tokio::test]
+    async fn load_pool_base_config_refreshes_expired_oauth_headers() {
+        let (_temp_dir, db) = create_test_database().await;
+        insert_http_server(&db.pool, "server-oauth", "OAuth Server", true).await;
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .and(body_string_contains("refresh_token=refresh-123"))
+            .and(body_string_contains("resource=https%3A%2F%2Fexample.com%2Fmcp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "access-new",
+                "token_type": "bearer",
+                "expires_in": 3600
+            })))
+            .mount(&mock_server)
+            .await;
+
+        upsert_server_oauth_config(
+            &db.pool,
+            &ServerOAuthConfig {
+                id: None,
+                server_id: "server-oauth".to_string(),
+                authorization_endpoint: format!("{}/authorize", mock_server.uri()),
+                token_endpoint: format!("{}/token", mock_server.uri()),
+                client_id: "client-1".to_string(),
+                client_secret: None,
+                scopes: Some("read write".to_string()),
+                redirect_uri: "http://localhost:5173/oauth/callback".to_string(),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("save oauth config");
+        upsert_server_oauth_token(
+            &db.pool,
+            &ServerOAuthToken {
+                id: None,
+                server_id: "server-oauth".to_string(),
+                access_token: "access-old".to_string(),
+                refresh_token: Some("refresh-123".to_string()),
+                token_type: "bearer".to_string(),
+                expires_at: Some((Utc::now() - Duration::minutes(1)).to_rfc3339()),
+                scope: Some("read write".to_string()),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("store expired token");
+
+        let config = load_pool_base_config(&db).await.expect("load pool config");
+        let headers = config
+            .mcp_servers
+            .get("server-oauth")
+            .and_then(|server| server.headers.as_ref())
+            .expect("headers");
+
+        assert_eq!(
+            headers.get("authorization").map(String::as_str),
+            Some("Bearer access-new")
+        );
     }
 }

--- a/backend/src/core/oauth/manager.rs
+++ b/backend/src/core/oauth/manager.rs
@@ -53,6 +53,8 @@ struct DynamicClientRegistrationResponse {
     scope: Option<String>,
 }
 
+const OAUTH_TOKEN_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 #[derive(Clone)]
 pub struct OAuthManager {
     pool: SqlitePool,
@@ -386,7 +388,10 @@ impl OAuthManager {
             id: token.id,
             server_id: server_id.to_string(),
             access_token: token_response.access_token,
-            refresh_token: token_response.refresh_token.or(token.refresh_token),
+            refresh_token: token_response
+                .refresh_token
+                .filter(|value| !value.trim().is_empty())
+                .or(token.refresh_token),
             token_type: token_response.token_type.unwrap_or(token.token_type),
             expires_at: token_response
                 .expires_in
@@ -586,6 +591,7 @@ impl OAuthManager {
             .http_client
             .post(token_endpoint)
             .header(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .timeout(OAUTH_TOKEN_REQUEST_TIMEOUT)
             .body(encoded_body)
             .send()
             .await
@@ -911,6 +917,69 @@ mod tests {
                 .state,
             OAuthConnectionState::Connected
         ));
+    }
+
+    #[tokio::test]
+    async fn refresh_keeps_existing_refresh_token_when_response_is_blank() {
+        let manager = setup_manager().await;
+        insert_server(&manager.pool, "serv_refresh_blank").await;
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .and(body_string_contains("refresh_token=refresh-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "access-new",
+                "refresh_token": "   ",
+                "token_type": "bearer",
+                "expires_in": 3600
+            })))
+            .mount(&mock_server)
+            .await;
+
+        manager
+            .upsert_config(
+                "serv_refresh_blank",
+                OAuthConfigInput {
+                    authorization_endpoint: format!("{}/authorize", mock_server.uri()),
+                    token_endpoint: format!("{}/token", mock_server.uri()),
+                    client_id: "client-1".to_string(),
+                    client_secret: None,
+                    scopes: Some("read write".to_string()),
+                    redirect_uri: "http://localhost:5173/oauth/callback".to_string(),
+                },
+            )
+            .await
+            .expect("save oauth config");
+        server::upsert_server_oauth_token(
+            &manager.pool,
+            &ServerOAuthToken {
+                id: None,
+                server_id: "serv_refresh_blank".to_string(),
+                access_token: "access-old".to_string(),
+                refresh_token: Some("refresh-123".to_string()),
+                token_type: "bearer".to_string(),
+                expires_at: Some((Utc::now() - Duration::minutes(1)).to_rfc3339()),
+                scope: Some("read write".to_string()),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("store expired token");
+
+        manager
+            .refresh_access_token("serv_refresh_blank")
+            .await
+            .expect("refresh token");
+
+        let stored = server::get_server_oauth_token(&manager.pool, "serv_refresh_blank")
+            .await
+            .expect("load stored token")
+            .expect("stored token exists");
+        assert_eq!(stored.access_token, "access-new");
+        assert_eq!(stored.refresh_token.as_deref(), Some("refresh-123"));
     }
 
     #[tokio::test]

--- a/backend/src/core/oauth/manager.rs
+++ b/backend/src/core/oauth/manager.rs
@@ -282,53 +282,7 @@ impl OAuthManager {
             form.push(("client_secret", secret.clone()));
         }
 
-        {
-            let endpoint_url = Url::parse(&config.token_endpoint).context("Invalid OAuth token_endpoint URL")?;
-            let is_loopback = matches!(endpoint_url.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
-            if endpoint_url.scheme() != "https" && !is_loopback {
-                bail!("OAuth token endpoint must use HTTPS: {}", config.token_endpoint);
-            }
-        }
-
-        let encoded_body = {
-            let mut serializer = url::form_urlencoded::Serializer::new(String::new());
-            for (key, value) in &form {
-                serializer.append_pair(key, value);
-            }
-            serializer.finish()
-        };
-
-        let response = self
-            .http_client
-            .post(&config.token_endpoint)
-            .header(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
-            .body(encoded_body)
-            .send()
-            .await
-            .context("Failed to call OAuth token endpoint")?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let token_endpoint = config.token_endpoint.as_str();
-            let response_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "<failed to read response body>".to_string());
-            let truncated_response_body: String = if response_body.chars().count() > 512 {
-                let prefix: String = response_body.chars().take(512).collect();
-                format!("{prefix}...")
-            } else {
-                response_body
-            };
-            bail!(
-                "OAuth token endpoint returned error status: {status} for {token_endpoint}. Response body: {truncated_response_body}"
-            );
-        }
-
-        let token_response = response
-            .json::<OAuthTokenResponse>()
-            .await
-            .context("Failed to parse OAuth token response")?;
+        let token_response = self.request_token_response(&config.token_endpoint, &form).await?;
 
         let expires_at = token_response
             .expires_in
@@ -351,6 +305,99 @@ impl OAuthManager {
         .await?;
 
         self.get_status(&pending.server_id).await
+    }
+
+    pub async fn get_effective_server_headers(
+        &self,
+        server_id: &str,
+        manual_headers: Option<HashMap<String, String>>,
+    ) -> Result<Option<HashMap<String, String>>> {
+        if server::has_manual_authorization_header(&manual_headers) {
+            return Ok(manual_headers.filter(|headers| !headers.is_empty()));
+        }
+
+        let mut effective = manual_headers.unwrap_or_default();
+        if let Some(token) = server::get_server_oauth_token(&self.pool, server_id).await? {
+            let token = if is_token_expired(&token)
+                && token
+                    .refresh_token
+                    .as_ref()
+                    .is_some_and(|value| !value.trim().is_empty())
+            {
+                self.refresh_access_token(server_id).await?
+            } else {
+                token
+            };
+
+            if !is_token_expired(&token) && !token.access_token.trim().is_empty() {
+                effective.insert(
+                    "authorization".to_string(),
+                    format!("Bearer {}", token.access_token.trim()),
+                );
+            }
+        }
+
+        if effective.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(effective))
+        }
+    }
+
+    pub async fn refresh_access_token(
+        &self,
+        server_id: &str,
+    ) -> Result<ServerOAuthToken> {
+        let config = server::get_server_oauth_config(&self.pool, server_id)
+            .await?
+            .ok_or_else(|| anyhow!("OAuth config missing for server '{}'", server_id))?;
+        let token = server::get_server_oauth_token(&self.pool, server_id)
+            .await?
+            .ok_or_else(|| anyhow!("OAuth token missing for server '{}'", server_id))?;
+        let refresh_token = token
+            .refresh_token
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| anyhow!("OAuth token for server '{}' has no refresh token", server_id))?;
+        let server_model = server::get_server_by_id(&self.pool, server_id)
+            .await?
+            .ok_or_else(|| anyhow!("Server '{}' not found", server_id))?;
+        if !server_model.server_type.is_http_transport() {
+            bail!("OAuth is only supported for HTTP-based MCP servers (sse or streamable_http)");
+        }
+        let resource = oauth_resource_from_server(&server_model)?;
+
+        let mut form = vec![
+            ("grant_type", "refresh_token".to_string()),
+            ("refresh_token", refresh_token.trim().to_string()),
+            ("client_id", config.client_id.clone()),
+            ("resource", resource),
+        ];
+        if let Some(secret) = config.client_secret.as_ref().filter(|value| !value.trim().is_empty()) {
+            form.push(("client_secret", secret.clone()));
+        }
+
+        let token_response = self.request_token_response(&config.token_endpoint, &form).await?;
+        if token_response.access_token.trim().is_empty() {
+            bail!("OAuth refresh response did not include a usable access_token");
+        }
+
+        let refreshed = ServerOAuthToken {
+            id: token.id,
+            server_id: server_id.to_string(),
+            access_token: token_response.access_token,
+            refresh_token: token_response.refresh_token.or(token.refresh_token),
+            token_type: token_response.token_type.unwrap_or(token.token_type),
+            expires_at: token_response
+                .expires_in
+                .map(|seconds| (Utc::now() + Duration::seconds(seconds)).to_rfc3339()),
+            scope: token_response.scope.or(token.scope),
+            created_at: None,
+            updated_at: None,
+        };
+
+        server::upsert_server_oauth_token(&self.pool, &refreshed).await?;
+        Ok(refreshed)
     }
 
     pub async fn get_status(
@@ -514,6 +561,57 @@ impl OAuthManager {
             .json::<DynamicClientRegistrationResponse>()
             .await
             .context("Failed to parse OAuth dynamic client registration response")
+    }
+
+    async fn request_token_response(
+        &self,
+        token_endpoint: &str,
+        form: &[(&str, String)],
+    ) -> Result<OAuthTokenResponse> {
+        let endpoint_url = Url::parse(token_endpoint).context("Invalid OAuth token_endpoint URL")?;
+        let is_loopback = matches!(endpoint_url.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
+        if endpoint_url.scheme() != "https" && !is_loopback {
+            bail!("OAuth token endpoint must use HTTPS: {}", token_endpoint);
+        }
+
+        let encoded_body = {
+            let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+            for (key, value) in form {
+                serializer.append_pair(key, value);
+            }
+            serializer.finish()
+        };
+
+        let response = self
+            .http_client
+            .post(token_endpoint)
+            .header(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(encoded_body)
+            .send()
+            .await
+            .context("Failed to call OAuth token endpoint")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let response_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<failed to read response body>".to_string());
+            let truncated_response_body: String = if response_body.chars().count() > 512 {
+                let prefix: String = response_body.chars().take(512).collect();
+                format!("{prefix}...")
+            } else {
+                response_body
+            };
+            bail!(
+                "OAuth token endpoint returned error status: {status} for {token_endpoint}. Response body: {truncated_response_body}"
+            );
+        }
+
+        response
+            .json::<OAuthTokenResponse>()
+            .await
+            .context("Failed to parse OAuth token response")
     }
 
     async fn fetch_json<T: for<'de> Deserialize<'de>>(
@@ -737,6 +835,131 @@ mod tests {
             .expect("load stored token")
             .expect("stored token exists");
         assert_eq!(stored.access_token, "access-123");
+    }
+
+    #[tokio::test]
+    async fn effective_headers_refresh_expired_oauth_token() {
+        let manager = setup_manager().await;
+        insert_server(&manager.pool, "serv_refresh").await;
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .and(body_string_contains("refresh_token=refresh-123"))
+            .and(body_string_contains("resource=https%3A%2F%2Fexample.com%2Fmcp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "access-new",
+                "token_type": "bearer",
+                "expires_in": 3600
+            })))
+            .mount(&mock_server)
+            .await;
+
+        manager
+            .upsert_config(
+                "serv_refresh",
+                OAuthConfigInput {
+                    authorization_endpoint: format!("{}/authorize", mock_server.uri()),
+                    token_endpoint: format!("{}/token", mock_server.uri()),
+                    client_id: "client-1".to_string(),
+                    client_secret: None,
+                    scopes: Some("read write".to_string()),
+                    redirect_uri: "http://localhost:5173/oauth/callback".to_string(),
+                },
+            )
+            .await
+            .expect("save oauth config");
+        server::upsert_server_oauth_token(
+            &manager.pool,
+            &ServerOAuthToken {
+                id: None,
+                server_id: "serv_refresh".to_string(),
+                access_token: "access-old".to_string(),
+                refresh_token: Some("refresh-123".to_string()),
+                token_type: "bearer".to_string(),
+                expires_at: Some((Utc::now() - Duration::minutes(1)).to_rfc3339()),
+                scope: Some("read write".to_string()),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("store expired token");
+
+        let headers = manager
+            .get_effective_server_headers("serv_refresh", None)
+            .await
+            .expect("refresh expired token")
+            .expect("headers");
+
+        assert_eq!(
+            headers.get("authorization").map(String::as_str),
+            Some("Bearer access-new")
+        );
+        let stored = server::get_server_oauth_token(&manager.pool, "serv_refresh")
+            .await
+            .expect("load refreshed token")
+            .expect("refreshed token exists");
+        assert_eq!(stored.access_token, "access-new");
+        assert_eq!(stored.refresh_token.as_deref(), Some("refresh-123"));
+        assert!(matches!(
+            manager
+                .get_status("serv_refresh")
+                .await
+                .expect("status after refresh")
+                .state,
+            OAuthConnectionState::Connected
+        ));
+    }
+
+    #[tokio::test]
+    async fn effective_headers_keep_manual_authorization_override() {
+        let manager = setup_manager().await;
+        insert_server(&manager.pool, "serv_manual_refresh").await;
+
+        manager
+            .upsert_config(
+                "serv_manual_refresh",
+                OAuthConfigInput {
+                    authorization_endpoint: "https://issuer.example.com/authorize".to_string(),
+                    token_endpoint: "http://not-loopback.example.com/token".to_string(),
+                    client_id: "client-1".to_string(),
+                    client_secret: None,
+                    scopes: Some("read write".to_string()),
+                    redirect_uri: "http://localhost:5173/oauth/callback".to_string(),
+                },
+            )
+            .await
+            .expect("save oauth config");
+        server::upsert_server_oauth_token(
+            &manager.pool,
+            &ServerOAuthToken {
+                id: None,
+                server_id: "serv_manual_refresh".to_string(),
+                access_token: "access-old".to_string(),
+                refresh_token: Some("refresh-123".to_string()),
+                token_type: "bearer".to_string(),
+                expires_at: Some((Utc::now() - Duration::minutes(1)).to_rfc3339()),
+                scope: Some("read write".to_string()),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("store expired token");
+
+        let manual = HashMap::from([("Authorization".to_string(), "Bearer manual-token".to_string())]);
+        let headers = manager
+            .get_effective_server_headers("serv_manual_refresh", Some(manual))
+            .await
+            .expect("manual header should not trigger refresh")
+            .expect("headers");
+
+        assert_eq!(
+            headers.get("Authorization").map(String::as_str),
+            Some("Bearer manual-token")
+        );
     }
 
     #[tokio::test]

--- a/backend/src/core/pool/connection.rs
+++ b/backend/src/core/pool/connection.rs
@@ -223,7 +223,6 @@ impl UpstreamConnectionPool {
         tracing::info!("Database reference updated for connection pool");
     }
 
-
     /// Idle timeout for standard instances (may become configurable later)
     pub fn standard_instance_idle_timeout() -> Duration {
         let env_override = std::env::var("MCPMATE_INSTANCE_IDLE_TIMEOUT_SECS")
@@ -710,7 +709,9 @@ impl UpstreamConnectionPool {
                 Ok(map) if !map.is_empty() => Some(map),
                 _ => None,
             };
-            crate::config::server::get_effective_server_headers(pool, id, manual_headers).await?
+            crate::core::oauth::OAuthManager::new(pool.clone())
+                .get_effective_server_headers(id, manual_headers)
+                .await?
         } else {
             None
         };


### PR DESCRIPTION
## Motivation

MCPMate already stores refresh_token values after the server OAuth authorization-code flow, but runtime header resolution only skipped expired access tokens. That meant upstream HTTP MCP servers could lose Authorization injection after expiry even when a refresh token was available.

## Scope of changes

- Add OAuthManager effective-header resolution for server OAuth tokens.
- Refresh expired access tokens with the stored refresh_token before runtime Authorization header injection.
- Preserve manual Authorization header precedence so user-configured headers are never overwritten by OAuth.
- Preserve the previous behavior for expired tokens without a refresh token: no expired token is injected.
- Reuse the existing token endpoint HTTPS or loopback validation for refresh requests.
- Route connection-pool runtime config conversion through OAuthManager so upstream startup uses the refreshed token path.

## Linked project item

GitHub Project: 0.3.0: OAuth token refresh (PVTI_lAHOAYlBbs4BYAQyzguwQ6Q).

## Config, schema, migration, and compatibility impact

No database schema migration is required. Existing server_oauth_tokens refresh_token rows are used when present. Manual Authorization headers keep taking precedence over stored OAuth tokens.

This PR does not encrypt OAuth tokens or move them into secure-store custody; that remains a separate 0.3.0 security hardening slice.

## Validation evidence

- RED first: RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml effective_headers_refresh_expired_oauth_token -- --test-threads=1 failed because OAuthManager had no effective-header refresh API.
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml effective_headers_refresh_expired_oauth_token -- --test-threads=1 passed with local mock HTTP permission.
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml core::oauth::manager::tests -- --test-threads=1 passed.
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml config::server::oauth::tests -- --test-threads=1 passed.
- RUSTC_WRAPPER= cargo test --manifest-path backend/Cargo.toml oauth -- --test-threads=1 passed.
- RUSTC_WRAPPER= cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings passed.
- rustfmt --edition 2024 backend/src/core/oauth/manager.rs backend/src/core/pool/connection.rs completed with existing stable rustfmt warnings for nightly-only config options.
- git diff --check passed.

## Known risks, gaps, and follow-up work

Runtime refresh failure now surfaces as a connection/config materialization error when a refresh token exists but the token endpoint fails. That is intentional: MCPMate should not silently start an upstream connection without the expected OAuth Authorization header.

Follow-up work remains for secure OAuth token custody, Board security settings, and broader OAuth account features.