### PR TITLE
Add diagnostics export and compress startup noise

### DIFF
--- a/board/src/App.tsx
+++ b/board/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { lazy, Suspense, useEffect, useState, type ReactNode } from "react";
+import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import {
 	BrowserRouter,
 	Navigate,
@@ -38,6 +38,11 @@ import {
 	setApiBaseUrl,
 	systemApi,
 } from "./lib/api";
+import {
+	backendReadinessStatusKey,
+	shouldReportBackendReadinessAttempt,
+} from "./lib/backend-readiness-diagnostics";
+import { recordDesktopDiagnosticEvent } from "./lib/desktop-diagnostics";
 import { isTauriEnvironmentSync } from "./lib/platform";
 
 const ClientDetailPage = lazy(() =>
@@ -298,6 +303,11 @@ function BackendReadinessGate({ children }: { children: ReactNode }) {
 	const [backendReady, setBackendReady] = useState(false);
 	const [attempt, setAttempt] = useState(0);
 	const [messageKey, setMessageKey] = useState<BackendReadinessMessageKey>("starting");
+	const [readinessStartedAtMs] = useState(() => Date.now());
+	const lastDiagnosticRef = useRef<{
+		reportedAtMs: number;
+		statusKey: string;
+	} | null>(null);
 
 	useEffect(() => {
 		if (!isTauriEnvironmentSync()) {
@@ -349,21 +359,60 @@ function BackendReadinessGate({ children }: { children: ReactNode }) {
 			retryTimer = window.setTimeout(() => setAttempt((value) => value + 1), 1_000);
 		}
 
+		function reportReadinessWait(payload: unknown, error: unknown): void {
+			const nowMs = Date.now();
+			const reportAttempt = attempt + 1;
+			const elapsedMs = nowMs - readinessStartedAtMs;
+			const statusKey = backendReadinessStatusKey(
+				isReadinessPayload(payload) ? payload : null,
+				error,
+			);
+			if (
+				!shouldReportBackendReadinessAttempt({
+					attempt: reportAttempt,
+					lastReportedAtMs: lastDiagnosticRef.current?.reportedAtMs ?? null,
+					lastStatusKey: lastDiagnosticRef.current?.statusKey ?? null,
+					nowMs,
+					statusKey,
+				})
+			) {
+				return;
+			}
+
+			lastDiagnosticRef.current = { reportedAtMs: nowMs, statusKey };
+			const data = { attempt: reportAttempt, elapsedMs, statusKey };
+			console.info("[MCPMate] waiting for backend readiness", data);
+			void recordDesktopDiagnosticEvent({
+				level: "info",
+				source: "backend-readiness",
+				message: "waiting for backend readiness",
+				data,
+			}).catch((error) => {
+				if (import.meta.env.DEV) {
+					console.warn("[MCPMate] failed to persist readiness diagnostic", error);
+				}
+			});
+		}
+
 		async function checkReadiness(): Promise<void> {
 			setMessageKey("waitingForBackend");
+			let payload: unknown = null;
+			let readinessError: unknown = null;
 			try {
 				setMessageKey("confirmingReadiness");
-				const payload = await systemApi.getReadiness();
+				payload = await systemApi.getReadiness();
 				if (cancelled) {
 					return;
 				}
-				if (payload.type === "ready" && payload.status === "ok") {
+				if (isReadinessPayload(payload) && payload.type === "ready" && payload.status === "ok") {
 					setBackendReady(true);
 					return;
 				}
-			} catch {
+			} catch (error) {
+				readinessError = error;
 				// Keep retrying until the backend API is reachable.
 			}
+			reportReadinessWait(payload, readinessError);
 			scheduleRetry();
 		}
 
@@ -375,7 +424,12 @@ function BackendReadinessGate({ children }: { children: ReactNode }) {
 				window.clearTimeout(retryTimer);
 			}
 		};
-	}, [desktopSourceReady, backendReady, attempt]);
+	}, [
+		attempt,
+		backendReady,
+		desktopSourceReady,
+		readinessStartedAtMs,
+	]);
 
 	if (!backendReady) {
 		if (isOperatorSurfacePath()) {
@@ -391,6 +445,14 @@ function BackendReadinessGate({ children }: { children: ReactNode }) {
 	}
 
 	return <>{children}</>;
+}
+
+function isReadinessPayload(value: unknown): value is {
+	reason?: string;
+	status?: string;
+	type?: string;
+} {
+	return typeof value === "object" && value !== null;
 }
 
 function isOperatorSurfacePath(): boolean {

--- a/board/src/lib/api.ts
+++ b/board/src/lib/api.ts
@@ -725,21 +725,26 @@ function normalizeServerDetail(enhanced: Record<string, unknown>, id: string): S
 	};
 }
 
+type FetchApiOptions = RequestInit & {
+	logFailure?: boolean;
+};
+
 // Core API request function
-async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> {
+async function fetchApi<T>(endpoint: string, options?: FetchApiOptions): Promise<T> {
 	const url = resolveApiUrl(endpoint);
+	const { logFailure = true, ...requestOptions } = options ?? {};
 	const headers =
-		options?.headers instanceof Headers
-			? options.headers
-			: new Headers(options?.headers ?? {});
+		requestOptions.headers instanceof Headers
+			? requestOptions.headers
+			: new Headers(requestOptions.headers ?? {});
 	// Avoid forcing JSON header on GET requests to keep caching friendly.
-	if (!headers.has("content-type") && options?.body) {
+	if (!headers.has("content-type") && requestOptions.body) {
 		headers.set("content-type", "application/json");
 	}
 	try {
 		const requestInit: RequestInit = {
 			credentials: "include",
-			...options,
+			...requestOptions,
 		};
 		requestInit.headers = headers;
 		const response = await fetch(url, requestInit);
@@ -747,11 +752,15 @@ async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> 
 		if (!response.ok) {
 			const errorText = await response.text();
 			let parsed: unknown;
+			let errorPayload: unknown = errorText;
 			try {
 				parsed = JSON.parse(errorText);
-				console.error(`API Error (${response.status}):`, parsed);
+				errorPayload = parsed;
 			} catch {
-				console.error(`API Error (${response.status}):`, errorText);
+				/* keep raw response text as the error payload */
+			}
+			if (logFailure) {
+				console.error(`API Error (${response.status}):`, errorPayload);
 			}
 			throw createApiError(response, parsed);
 		}
@@ -766,7 +775,9 @@ async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> 
 		}
 		return JSON.parse(text) as T;
 	} catch (error) {
-		console.error(`API request failed for ${endpoint}:`, error);
+		if (logFailure) {
+			console.error("API request failed for endpoint:", endpoint, error);
+		}
 		throw error;
 	}
 }
@@ -1583,7 +1594,7 @@ export const systemApi = {
 			type?: string;
 			status?: string;
 			reason?: string;
-		}>("/api/system/readiness"),
+		}>("/api/system/readiness", { logFailure: false }),
 	getStatus: () => fetchApi<SystemStatus>("/api/system/status"),
 	getMetrics: () => fetchApi<SystemMetrics>("/api/system/metrics"),
 	getSettings: async (): Promise<{

--- a/board/src/lib/backend-readiness-diagnostics.test.ts
+++ b/board/src/lib/backend-readiness-diagnostics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+	backendReadinessStatusKey,
+	shouldReportBackendReadinessAttempt,
+} from "./backend-readiness-diagnostics";
+
+describe("backend readiness diagnostics", () => {
+	test("reports the first attempt and suppresses repeated waits before the throttle window", () => {
+		const first = shouldReportBackendReadinessAttempt({
+			attempt: 1,
+			lastReportedAtMs: null,
+			lastStatusKey: null,
+			nowMs: 1_000,
+			statusKey: "network_error",
+		});
+		expect(first).toBe(true);
+
+		const repeated = shouldReportBackendReadinessAttempt({
+			attempt: 2,
+			lastReportedAtMs: 1_000,
+			lastStatusKey: "network_error",
+			nowMs: 1_500,
+			statusKey: "network_error",
+		});
+		expect(repeated).toBe(false);
+	});
+
+	test("reports status changes and throttled summaries", () => {
+		const changed = shouldReportBackendReadinessAttempt({
+			attempt: 3,
+			lastReportedAtMs: 1_000,
+			lastStatusKey: "network_error",
+			nowMs: 2_000,
+			statusKey: "not_ready",
+		});
+		expect(changed).toBe(true);
+
+		const throttled = shouldReportBackendReadinessAttempt({
+			attempt: 40,
+			lastReportedAtMs: 1_000,
+			lastStatusKey: "not_ready",
+			nowMs: 31_000,
+			statusKey: "not_ready",
+		});
+		expect(throttled).toBe(true);
+	});
+
+	test("normalizes readiness payloads and errors into stable status keys", () => {
+		expect(backendReadinessStatusKey({ type: "ready", status: "ok" }, null)).toBe(
+			"ready:ok",
+		);
+		expect(
+			backendReadinessStatusKey({ type: "starting", status: "pending" }, null),
+		).toBe("starting:pending");
+		expect(backendReadinessStatusKey(null, new TypeError("fetch failed"))).toBe(
+			"network_error",
+		);
+		expect(backendReadinessStatusKey(null, new Error("boom"))).toBe("error");
+	});
+});

--- a/board/src/lib/backend-readiness-diagnostics.ts
+++ b/board/src/lib/backend-readiness-diagnostics.ts
@@ -1,0 +1,39 @@
+export interface BackendReadinessAttempt {
+	attempt: number;
+	lastReportedAtMs: number | null;
+	lastStatusKey: string | null;
+	nowMs: number;
+	statusKey: string;
+	throttleMs?: number;
+}
+
+const DEFAULT_READINESS_REPORT_THROTTLE_MS = 30_000;
+
+export function shouldReportBackendReadinessAttempt(
+	attempt: BackendReadinessAttempt,
+): boolean {
+	if (attempt.attempt <= 1 || attempt.lastReportedAtMs === null) {
+		return true;
+	}
+	if (attempt.lastStatusKey !== attempt.statusKey) {
+		return true;
+	}
+	const throttleMs = attempt.throttleMs ?? DEFAULT_READINESS_REPORT_THROTTLE_MS;
+	return attempt.nowMs - attempt.lastReportedAtMs >= throttleMs;
+}
+
+export function backendReadinessStatusKey(
+	payload: { status?: string; type?: string } | null,
+	error: unknown,
+): string {
+	if (payload?.type || payload?.status) {
+		return `${payload.type ?? "unknown"}:${payload.status ?? "unknown"}`;
+	}
+	if (error instanceof TypeError) {
+		return "network_error";
+	}
+	if (error instanceof Error) {
+		return "error";
+	}
+	return "unknown";
+}

--- a/board/src/lib/desktop-diagnostics.test.ts
+++ b/board/src/lib/desktop-diagnostics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { recordDesktopDiagnosticEvent } from "./desktop-diagnostics";
+
+describe("desktop diagnostics bridge", () => {
+	test("records runtime diagnostics through the Tauri shell command", async () => {
+		const calls: Array<{ command: string; args?: Record<string, unknown> }> = [];
+
+		const recorded = await recordDesktopDiagnosticEvent(
+			{
+				level: "info",
+				source: "backend-readiness",
+				message: "waiting for backend readiness",
+				data: { attempt: 2 },
+			},
+			{
+				isTauri: true,
+				invoke: async (command, args) => {
+					calls.push({ command, args });
+				},
+			},
+		);
+
+		expect(recorded).toBe(true);
+		expect(calls).toEqual([
+			{
+				command: "mcp_shell_record_diagnostic_event",
+				args: {
+					payload: {
+						level: "info",
+						source: "backend-readiness",
+						message: "waiting for backend readiness",
+						data: { attempt: 2 },
+					},
+				},
+			},
+		]);
+	});
+
+	test("does not call desktop commands outside Tauri", async () => {
+		let called = false;
+
+		const recorded = await recordDesktopDiagnosticEvent(
+			{
+				level: "info",
+				source: "backend-readiness",
+				message: "waiting for backend readiness",
+			},
+			{
+				isTauri: false,
+				invoke: async () => {
+					called = true;
+				},
+			},
+		);
+
+		expect(recorded).toBe(false);
+		expect(called).toBe(false);
+	});
+
+});

--- a/board/src/lib/desktop-diagnostics.ts
+++ b/board/src/lib/desktop-diagnostics.ts
@@ -1,0 +1,44 @@
+import { isTauriEnvironmentSync } from "./platform";
+
+type DesktopDiagnosticLevel = "debug" | "info" | "warn" | "error";
+
+export interface DesktopDiagnosticEvent {
+	data?: Record<string, unknown>;
+	level: DesktopDiagnosticLevel;
+	message: string;
+	source: string;
+}
+
+type DesktopDiagnosticsInvoke = (
+	command: string,
+	args?: Record<string, unknown>,
+) => Promise<unknown>;
+
+interface DesktopDiagnosticsOptions {
+	invoke?: DesktopDiagnosticsInvoke;
+	isTauri?: boolean;
+}
+
+async function defaultInvoke(command: string, args?: Record<string, unknown>): Promise<unknown> {
+	const { invoke } = await import("@tauri-apps/api/core");
+	return invoke(command, args);
+}
+
+export async function recordDesktopDiagnosticEvent(
+	event: DesktopDiagnosticEvent,
+	options: DesktopDiagnosticsOptions = {},
+): Promise<boolean> {
+	if (!(options.isTauri ?? isTauriEnvironmentSync())) {
+		return false;
+	}
+	const invoke = options.invoke ?? defaultInvoke;
+	await invoke("mcp_shell_record_diagnostic_event", {
+		payload: {
+			level: event.level,
+			source: event.source,
+			message: event.message,
+			data: event.data ?? {},
+		},
+	});
+	return true;
+}

--- a/board/src/pages/settings/settings-page.tsx
+++ b/board/src/pages/settings/settings-page.tsx
@@ -58,11 +58,7 @@ import {
 	type DesktopCoreSourceResponse,
 	useDesktopCoreState,
 } from "../../lib/desktop-core-state";
-import {
-	notifyError,
-	notifySuccess,
-	stringifyError,
-} from "../../lib/notify";
+import { notifyError, notifySuccess, stringifyError } from "../../lib/notify";
 import { SUPPORTED_LANGUAGES } from "../../lib/i18n/index";
 import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import {
@@ -2168,7 +2164,6 @@ export function SettingsPage() {
 									/>
 								</div>
 
-								{/* Inspector Timeout */}
 								<div className="flex items-center justify-between gap-4">
 									<div>
 										<h3 className="text-base font-medium">

--- a/board/vite.config.ts
+++ b/board/vite.config.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from "node:fs";
-import type { ClientRequest } from "node:http";
+import type { ClientRequest, IncomingMessage } from "node:http";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import topLevelAwait from "vite-plugin-top-level-await";
 import wasm from "vite-plugin-wasm";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const packageJson = JSON.parse(
 	readFileSync(new URL("./package.json", import.meta.url), "utf8"),
@@ -32,6 +32,7 @@ const devWsBaseUrl = (() => {
 type HttpProxyError = Error & { code?: string };
 
 type HttpProxyResponse = {
+	headersSent?: boolean;
 	writeHead(statusCode: number, headers?: Record<string, string | number>): void;
 	end(chunk?: string): void;
 };
@@ -61,19 +62,162 @@ type HttpProxyServer = {
 	on(event: string, listener: (...args: unknown[]) => void): void;
 };
 
+const BACKEND_READINESS_PROXY_LOG_INTERVAL_MS = 5_000;
+
+function backendReadinessTargetLabel(): string {
+	try {
+		const parsed = new URL(devApiBaseUrl);
+		return `${parsed.host}/api/system/readiness`;
+	} catch {
+		return `${devApiBaseUrl}/api/system/readiness`;
+	}
+}
+
+function isBackendReadinessRequest(req: IncomingMessage): boolean {
+	const method = req.method?.toUpperCase();
+	if (method !== "GET" && method !== "HEAD") {
+		return false;
+	}
+	const pathName = req.url?.split(/[?#]/, 1)[0];
+	return pathName === "/api/system/readiness";
+}
+
+function isBackendStartupError(error: unknown): boolean {
+	const candidates: unknown[] = [error];
+	if (error && typeof error === "object" && "cause" in error) {
+		candidates.push((error as { cause?: unknown }).cause);
+	}
+	return candidates.some((candidate) => {
+		if (!candidate || typeof candidate !== "object" || !("code" in candidate)) {
+			return false;
+		}
+		return (candidate as { code?: unknown }).code === "ECONNREFUSED";
+	});
+}
+
+function createBackendReadinessProxyLogger() {
+	const targetLabel = backendReadinessTargetLabel();
+	let unavailableSinceMs: number | null = null;
+	let lastLoggedAtMs = 0;
+	let suppressedCount = 0;
+
+	return {
+		recordStartupError(): void {
+			const nowMs = Date.now();
+			if (unavailableSinceMs === null) {
+				unavailableSinceMs = nowMs;
+			}
+			suppressedCount += 1;
+			if (
+				lastLoggedAtMs !== 0 &&
+				nowMs - lastLoggedAtMs < BACKEND_READINESS_PROXY_LOG_INTERVAL_MS
+			) {
+				return;
+			}
+			const waitedSeconds = Math.round((nowMs - unavailableSinceMs) / 1_000);
+			const repeats = suppressedCount;
+			lastLoggedAtMs = nowMs;
+			suppressedCount = 0;
+			console.warn(
+				`[vite] backend readiness proxy waiting: ${targetLabel} ECONNREFUSED (x${repeats}, ${waitedSeconds}s)`,
+			);
+		},
+		recordSuccess(): void {
+			if (unavailableSinceMs === null) {
+				return;
+			}
+			const nowMs = Date.now();
+			const waitedSeconds = Math.round((nowMs - unavailableSinceMs) / 1_000);
+			const suppressedSuffix =
+				suppressedCount > 0 ? `, suppressed ${suppressedCount} repeat(s)` : "";
+			console.info(
+				`[vite] backend readiness proxy recovered: ${targetLabel} (${waitedSeconds}s${suppressedSuffix})`,
+			);
+			unavailableSinceMs = null;
+			lastLoggedAtMs = 0;
+			suppressedCount = 0;
+		},
+	};
+}
+
+function writeBackendStartingResponse(res: HttpProxyResponse): void {
+	if (res.headersSent) {
+		return;
+	}
+	res.writeHead(503, {
+		"Content-Type": "application/json",
+		"Retry-After": "1",
+	});
+	res.end(
+		JSON.stringify({
+			success: false,
+			error: { message: "Backend is starting" },
+		}),
+	);
+}
+
+function requestHeadersForBackend(req: IncomingMessage): Headers {
+	const headers = new Headers();
+	for (const [key, value] of Object.entries(req.headers)) {
+		if (key === "host" || key === "origin") {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				headers.append(key, item);
+			}
+			continue;
+		}
+		if (typeof value === "string") {
+			headers.set(key, value);
+		}
+	}
+	return headers;
+}
+
+function compressedBackendReadinessProxyPlugin(): Plugin {
+	return {
+		name: "mcpmate-compressed-backend-readiness-proxy",
+		configureServer(server) {
+			const readinessProxyLogger = createBackendReadinessProxyLogger();
+			server.middlewares.use(async (req, res, next) => {
+				if (!isBackendReadinessRequest(req)) {
+					next();
+					return;
+				}
+				try {
+					const targetUrl = new URL(req.url ?? "/api/system/readiness", devApiBaseUrl);
+					const response = await fetch(targetUrl, {
+						headers: requestHeadersForBackend(req),
+						method: req.method,
+					});
+					readinessProxyLogger.recordSuccess();
+					res.statusCode = response.status;
+					response.headers.forEach((value, key) => {
+						res.setHeader(key, value);
+					});
+					if (req.method?.toUpperCase() === "HEAD") {
+						res.end();
+						return;
+					}
+					res.end(Buffer.from(await response.arrayBuffer()));
+				} catch (error) {
+					if (isBackendStartupError(error)) {
+						readinessProxyLogger.recordStartupError();
+						writeBackendStartingResponse(res);
+						return;
+					}
+					next();
+				}
+			});
+		},
+	};
+}
+
 function attachBackendStartupProxyHandler(proxy: HttpProxyServer): void {
 	proxy.on("error", (error, _req, res) => {
 		if (error.code === "ECONNREFUSED" && isHttpProxyResponse(res)) {
-			res.writeHead(503, {
-				"Content-Type": "application/json",
-				"Retry-After": "1",
-			});
-			res.end(
-				JSON.stringify({
-					success: false,
-					error: { message: "Backend is starting" },
-				}),
-			);
+			writeBackendStartingResponse(res);
 			return;
 		}
 	});
@@ -91,11 +235,21 @@ function removeOriginHeader(proxyReq: ClientRequest): void {
 	}
 }
 
+function configureBackendProxy(
+	proxy: HttpProxyServer,
+	event: "proxyReq" | "proxyReqWs",
+): void {
+	attachBackendStartupProxyHandler(proxy);
+	proxy.on(event, (proxyReq: ClientRequest) => {
+		removeOriginHeader(proxyReq);
+	});
+}
+
 export default defineConfig({
 	define: {
 		"import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
 	},
-	plugins: [react(), wasm(), topLevelAwait()],
+	plugins: [compressedBackendReadinessProxyPlugin(), react(), wasm(), topLevelAwait()],
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
@@ -110,46 +264,26 @@ export default defineConfig({
 				target: devApiBaseUrl,
 				changeOrigin: true,
 				secure: false,
-				configure: (proxy: HttpProxyServer) => {
-					attachBackendStartupProxyHandler(proxy);
-					proxy.on("proxyReq", (proxyReq: ClientRequest) => {
-						removeOriginHeader(proxyReq);
-					});
-				},
+				configure: (proxy: HttpProxyServer) => configureBackendProxy(proxy, "proxyReq"),
 			},
 			"^/docs(?:/|$)": {
 				target: devApiBaseUrl,
 				changeOrigin: true,
 				secure: false,
-				configure: (proxy: HttpProxyServer) => {
-					attachBackendStartupProxyHandler(proxy);
-					proxy.on("proxyReq", (proxyReq: ClientRequest) => {
-						removeOriginHeader(proxyReq);
-					});
-				},
+				configure: (proxy: HttpProxyServer) => configureBackendProxy(proxy, "proxyReq"),
 			},
 			"^/openapi\\.json$": {
 				target: devApiBaseUrl,
 				changeOrigin: true,
 				secure: false,
-				configure: (proxy: HttpProxyServer) => {
-					attachBackendStartupProxyHandler(proxy);
-					proxy.on("proxyReq", (proxyReq: ClientRequest) => {
-						removeOriginHeader(proxyReq);
-					});
-				},
+				configure: (proxy: HttpProxyServer) => configureBackendProxy(proxy, "proxyReq"),
 			},
 			"^/ws(?:/|$)": {
 				target: devWsBaseUrl,
 				ws: true,
 				changeOrigin: true,
 				secure: false,
-				configure: (proxy: HttpProxyServer) => {
-					attachBackendStartupProxyHandler(proxy);
-					proxy.on("proxyReqWs", (proxyReq: ClientRequest) => {
-						removeOriginHeader(proxyReq);
-					});
-				},
+				configure: (proxy: HttpProxyServer) => configureBackendProxy(proxy, "proxyReqWs"),
 			},
 		},
 	},

--- a/desktop/src-tauri/src/core_service.rs
+++ b/desktop/src-tauri/src/core_service.rs
@@ -43,6 +43,30 @@ impl LocalCoreServiceStatusView {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalhostCoreProbeFailure {
+    pub status_code: Option<u16>,
+    pub error: Option<String>,
+}
+
+impl LocalhostCoreProbeFailure {
+    pub fn summary(&self) -> String {
+        if let Some(status_code) = self.status_code {
+            return format!("http_status={status_code}");
+        }
+        if let Some(error) = self.error.as_deref() {
+            return format!("error={error}");
+        }
+        "unknown".to_string()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalhostCoreProbe {
+    pub ready: bool,
+    pub failure: Option<LocalhostCoreProbeFailure>,
+}
+
 pub fn resolve_service_level() -> ServiceLevel {
     #[cfg(target_os = "windows")]
     {
@@ -257,31 +281,70 @@ fn service_install_ctx(
 }
 
 pub async fn probe_localhost_core(api_port: u16) -> bool {
+    probe_localhost_core_detail(api_port).await.ready
+}
+
+pub async fn probe_localhost_core_detail(api_port: u16) -> LocalhostCoreProbe {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_millis(500))
         .build();
 
     let Ok(client) = client else {
-        return false;
+        return LocalhostCoreProbe {
+            ready: false,
+            failure: Some(LocalhostCoreProbeFailure {
+                status_code: None,
+                error: Some("failed to build readiness HTTP client".to_string()),
+            }),
+        };
     };
 
     let url = format!("{}/api/system/status", api_url_from_port(api_port));
     match client.get(url).send().await {
-        Ok(response) => response.status().is_success(),
-        Err(_) => false,
+        Ok(response) => {
+            let status = response.status();
+            LocalhostCoreProbe {
+                ready: status.is_success(),
+                failure: (!status.is_success()).then_some(LocalhostCoreProbeFailure {
+                    status_code: Some(status.as_u16()),
+                    error: None,
+                }),
+            }
+        }
+        Err(err) => LocalhostCoreProbe {
+            ready: false,
+            failure: Some(LocalhostCoreProbeFailure {
+                status_code: None,
+                error: Some(err.to_string()),
+            }),
+        },
     }
 }
 
 pub async fn wait_for_localhost_core(api_port: u16) -> Result<()> {
-    for _ in 0..20 {
-        if probe_localhost_core(api_port).await {
-            info!(api_port, "Local MCPMate core health check succeeded");
+    let mut last_failure: Option<LocalhostCoreProbeFailure> = None;
+    for attempt in 1..=20 {
+        let probe = probe_localhost_core_detail(api_port).await;
+        if probe.ready {
+            info!(
+                api_port,
+                attempt, "Local MCPMate core health check succeeded"
+            );
             return Ok(());
         }
+        last_failure = probe.failure;
         tokio::time::sleep(Duration::from_millis(300)).await;
     }
 
-    warn!(api_port, "Local MCPMate core health check timed out");
+    warn!(
+        api_port,
+        attempts = 20,
+        last_failure = last_failure
+            .as_ref()
+            .map(LocalhostCoreProbeFailure::summary)
+            .unwrap_or_else(|| "unknown".to_string()),
+        "Local MCPMate core health check timed out"
+    );
     anyhow::bail!("localhost core service did not become ready in time")
 }
 
@@ -476,5 +539,30 @@ pub async fn sync_local_service_definition(
         start_local_service(app, config).await
     } else {
         read_local_service_status(config).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocalhostCoreProbeFailure;
+
+    #[test]
+    fn probe_failure_summary_prefers_status_code() {
+        let failure = LocalhostCoreProbeFailure {
+            status_code: Some(503),
+            error: Some("connection reset".to_string()),
+        };
+
+        assert_eq!(failure.summary(), "http_status=503");
+    }
+
+    #[test]
+    fn probe_failure_summary_uses_error_when_status_is_missing() {
+        let failure = LocalhostCoreProbeFailure {
+            status_code: None,
+            error: Some("connection refused".to_string()),
+        };
+
+        assert_eq!(failure.summary(), "error=connection refused");
     }
 }

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -80,7 +80,9 @@ pub(crate) fn record_frontend_diagnostic_event(
         .append(true)
         .open(&path)
         .with_context(|| format!("failed to open frontend diagnostics log {}", path.display()))?;
-    writeln!(file, "{line}").with_context(|| {
+    let mut entry = line.into_bytes();
+    entry.push(b'\n');
+    file.write_all(&entry).with_context(|| {
         format!(
             "failed to append frontend diagnostics log {}",
             path.display()

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -1,0 +1,767 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use mcpmate::common::MCPMatePaths;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+const FRONTEND_DIAGNOSTICS_FILE_NAME: &str = "frontend-diagnostics.jsonl";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DiagnosticEventPayload {
+    level: String,
+    source: String,
+    message: String,
+    #[serde(default)]
+    data: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DiagnosticsExportResponse {
+    pub export_path: String,
+    pub file_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredDiagnosticEvent<'a> {
+    recorded_at_unix_ms: u128,
+    level: &'a str,
+    source: &'a str,
+    message: &'a str,
+    data: &'a Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticsManifestEntry {
+    source_path: String,
+    included_as: String,
+    bytes: u64,
+}
+
+pub(crate) fn record_frontend_diagnostic_event(
+    paths: &MCPMatePaths,
+    payload: &DiagnosticEventPayload,
+) -> Result<PathBuf> {
+    let logs_dir = paths.logs_dir();
+    fs::create_dir_all(&logs_dir).with_context(|| {
+        format!(
+            "failed to create diagnostics logs dir {}",
+            logs_dir.display()
+        )
+    })?;
+    let path = logs_dir.join(FRONTEND_DIAGNOSTICS_FILE_NAME);
+    let redactor = DiagnosticsRedactor::new(paths);
+    let data = redactor.redact_json(payload.data.clone());
+    let level = redactor.redact_text(payload.level.as_str());
+    let source = redactor.redact_text(payload.source.as_str());
+    let message = redactor.redact_text(payload.message.as_str());
+    let event = StoredDiagnosticEvent {
+        recorded_at_unix_ms: unix_millis()?,
+        level: level.as_str(),
+        source: source.as_str(),
+        message: message.as_str(),
+        data: &data,
+    };
+    let line =
+        serde_json::to_string(&event).context("failed to serialize frontend diagnostic event")?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("failed to open frontend diagnostics log {}", path.display()))?;
+    writeln!(file, "{line}").with_context(|| {
+        format!(
+            "failed to append frontend diagnostics log {}",
+            path.display()
+        )
+    })?;
+    Ok(path)
+}
+
+pub(crate) fn export_diagnostics_bundle(
+    paths: &MCPMatePaths,
+    destination_root: &Path,
+    runtime_metadata: Value,
+    snapshot: Value,
+) -> Result<DiagnosticsExportResponse> {
+    let timestamp = current_timestamp()?;
+    let export_dir = destination_root.join(diagnostics_export_dir_name(&timestamp));
+    let logs_export_dir = export_dir.join("logs");
+    fs::create_dir_all(&logs_export_dir).with_context(|| {
+        format!(
+            "failed to create diagnostics export dir {}",
+            logs_export_dir.display()
+        )
+    })?;
+
+    let redactor = DiagnosticsRedactor::new(paths);
+    let mut entries = Vec::new();
+    for source in collect_diagnostic_sources(&paths.logs_dir())? {
+        let file_name = source
+            .file_name()
+            .context("diagnostic source path has no file name")?;
+        let target = logs_export_dir.join(file_name);
+        let included_name = file_name.to_string_lossy();
+        let content = fs::read(&source)
+            .with_context(|| format!("failed to read diagnostic source {}", source.display()))?;
+        let redacted = redactor.redact_text(&String::from_utf8_lossy(&content));
+        fs::write(&target, redacted.as_bytes())
+            .with_context(|| format!("failed to write diagnostic source {}", target.display()))?;
+        let bytes = redacted.len() as u64;
+        entries.push(DiagnosticsManifestEntry {
+            source_path: format!("[mcpmate-logs-dir]/{included_name}"),
+            included_as: format!("logs/{included_name}"),
+            bytes,
+        });
+    }
+
+    let runtime_path = export_dir.join("runtime.json");
+    let runtime_metadata = redactor.redact_json(runtime_metadata);
+    fs::write(
+        &runtime_path,
+        serde_json::to_vec_pretty(&runtime_metadata)
+            .context("failed to serialize runtime diagnostics")?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to write runtime diagnostics {}",
+            runtime_path.display()
+        )
+    })?;
+
+    let snapshot_path = export_dir.join("snapshot.json");
+    let snapshot = redactor.redact_json(snapshot);
+    fs::write(
+        &snapshot_path,
+        serde_json::to_vec_pretty(&snapshot).context("failed to serialize diagnostics snapshot")?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to write diagnostics snapshot {}",
+            snapshot_path.display()
+        )
+    })?;
+
+    let manifest = json!({
+        "version": 1,
+        "generatedAt": timestamp,
+        "baseDir": "[mcpmate-data-dir]",
+        "logsDir": "[mcpmate-logs-dir]",
+        "snapshot": "snapshot.json",
+        "runtime": "runtime.json",
+        "files": entries,
+    });
+    let manifest_path = export_dir.join("manifest.json");
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&manifest).context("failed to serialize diagnostics manifest")?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to write diagnostics manifest {}",
+            manifest_path.display()
+        )
+    })?;
+
+    Ok(DiagnosticsExportResponse {
+        export_path: export_dir.display().to_string(),
+        file_count: entries.len() + 3,
+    })
+}
+
+fn collect_diagnostic_sources(logs_dir: &Path) -> Result<Vec<PathBuf>> {
+    if !logs_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let canonical_logs_dir = logs_dir.canonicalize().with_context(|| {
+        format!(
+            "failed to resolve diagnostics logs dir {}",
+            logs_dir.display()
+        )
+    })?;
+    let mut sources = Vec::new();
+    for entry in fs::read_dir(logs_dir)
+        .with_context(|| format!("failed to read diagnostics logs dir {}", logs_dir.display()))?
+    {
+        let entry = entry.with_context(|| {
+            format!(
+                "failed to read diagnostics logs dir entry {}",
+                logs_dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("failed to inspect diagnostic source {}", path.display()))?;
+        if !metadata.file_type().is_file() {
+            continue;
+        }
+        let canonical_path = path
+            .canonicalize()
+            .with_context(|| format!("failed to resolve diagnostic source {}", path.display()))?;
+        if canonical_path.starts_with(&canonical_logs_dir) && is_diagnostic_source(&path) {
+            sources.push(path);
+        }
+    }
+    sources.sort();
+    Ok(sources)
+}
+
+fn is_diagnostic_source(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    file_name == FRONTEND_DIAGNOSTICS_FILE_NAME
+        || file_name.starts_with("desktop-shell") && file_name.ends_with(".log")
+        || file_name.starts_with("desktop-core.") && file_name.ends_with(".log")
+}
+
+fn diagnostics_export_dir_name(timestamp: &str) -> String {
+    format!("mcpmate-diagnostics-{timestamp}")
+}
+
+struct DiagnosticsRedactor {
+    replacements: Vec<(String, &'static str)>,
+}
+
+impl DiagnosticsRedactor {
+    fn new(paths: &MCPMatePaths) -> Self {
+        let mut replacements = vec![
+            (paths.logs_dir().display().to_string(), "[mcpmate-logs-dir]"),
+            (paths.base_dir().display().to_string(), "[mcpmate-data-dir]"),
+        ];
+        if let Some(home_dir) = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+        {
+            replacements.push((home_dir.display().to_string(), "[user-home]"));
+        }
+        Self { replacements }
+    }
+
+    fn redact_json(&self, value: Value) -> Value {
+        match value {
+            Value::String(text) => Value::String(self.redact_text(&text)),
+            Value::Array(items) => Value::Array(
+                items
+                    .into_iter()
+                    .map(|item| self.redact_json(item))
+                    .collect(),
+            ),
+            Value::Object(map) => Value::Object(
+                map.into_iter()
+                    .map(|(key, value)| {
+                        if is_sensitive_key(&key) {
+                            (key, Value::String("[redacted-secret]".to_string()))
+                        } else {
+                            (key, self.redact_json(value))
+                        }
+                    })
+                    .collect(),
+            ),
+            other => other,
+        }
+    }
+
+    fn redact_text(&self, input: &str) -> String {
+        let mut output = input.to_string();
+        for (needle, replacement) in &self.replacements {
+            if !needle.is_empty() {
+                output = output.replace(needle, replacement);
+            }
+        }
+        output = redacted_user_home_path_regex()
+            .replace_all(&output, "[user-home]/[redacted-path]")
+            .to_string();
+        output = users_path_with_tail_regex()
+            .replace_all(&output, "[user-home]/[redacted-path]")
+            .to_string();
+        output = users_path_regex()
+            .replace_all(&output, "[user-home]")
+            .to_string();
+        output = windows_users_path_with_tail_regex()
+            .replace_all(&output, "[user-home]\\[redacted-path]")
+            .to_string();
+        output = windows_users_path_regex()
+            .replace_all(&output, "[user-home]")
+            .to_string();
+        output = escaped_windows_users_path_with_tail_regex()
+            .replace_all(&output, "[user-home]\\\\[redacted-path]")
+            .to_string();
+        output = escaped_windows_users_path_regex()
+            .replace_all(&output, "[user-home]")
+            .to_string();
+        output = unix_home_path_with_tail_regex()
+            .replace_all(&output, "[user-home]/[redacted-path]")
+            .to_string();
+        output = unix_home_path_regex()
+            .replace_all(&output, "[user-home]")
+            .to_string();
+        output = volumes_path_regex()
+            .replace_all(&output, "[external-volume]/[redacted-path]")
+            .to_string();
+        output = bearer_regex()
+            .replace_all(&output, "${prefix}[redacted-secret]")
+            .to_string();
+        output = cookie_header_regex()
+            .replace_all(&output, "${prefix}[redacted-secret]")
+            .to_string();
+        output = cli_secret_arg_regex()
+            .replace_all(&output, "${prefix}[redacted-secret]")
+            .to_string();
+        output = assignment_secret_regex()
+            .replace_all(&output, "${prefix}[redacted-secret]")
+            .to_string();
+        output = json_secret_regex()
+            .replace_all(&output, "${prefix}\"[redacted-secret]\"")
+            .to_string();
+        output = url_regex()
+            .replace_all(&output, |captures: &regex::Captures<'_>| {
+                format!("{}://[redacted]", &captures["scheme"])
+            })
+            .to_string();
+        output
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized = key.replace(['-', '_'], "").to_ascii_lowercase();
+    [
+        "authorization",
+        "apikey",
+        "authtoken",
+        "accesstoken",
+        "refreshtoken",
+        "clientsecret",
+        "password",
+        "secret",
+        "token",
+        "cookie",
+        "credential",
+        "databaseurl",
+        "connectionstring",
+        "session",
+        "jwt",
+        "dsn",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn redacted_user_home_path_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"\[user-home\](?:[/\\][^\r\n"']+)+"#)
+            .expect("compile redacted user home path regex")
+    })
+}
+
+fn users_path_with_tail_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"/Users/[^/\r\n"']+(?:/[^\r\n"']+)+"#)
+            .expect("compile users path with tail regex")
+    })
+}
+
+fn users_path_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"/Users/[^/\r\n"']+"#).expect("compile users path regex"))
+}
+
+fn windows_users_path_with_tail_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)[a-z]:\\Users\\[^\\\r\n"']+(?:\\[^\\\r\n"']+)+"#)
+            .expect("compile windows users path with tail regex")
+    })
+}
+
+fn windows_users_path_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)[a-z]:\\Users\\[^\\\r\n"']+"#).expect("compile windows users path regex")
+    })
+}
+
+fn escaped_windows_users_path_with_tail_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)[a-z]:(?:\\\\)+Users(?:\\\\)+[^\\\r\n"']+(?:(?:\\\\)+[^\\\r\n"']+)+"#)
+            .expect("compile escaped windows users path with tail regex")
+    })
+}
+
+fn escaped_windows_users_path_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)[a-z]:(?:\\\\)+Users(?:\\\\)+[^\\\r\n"']+"#)
+            .expect("compile escaped windows users path regex")
+    })
+}
+
+fn unix_home_path_with_tail_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"/home/[^/\r\n"']+(?:/[^\r\n"']+)+"#)
+            .expect("compile unix home path with tail regex")
+    })
+}
+
+fn unix_home_path_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"/home/[^/\r\n"']+"#).expect("compile unix home path regex"))
+}
+
+fn volumes_path_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"/Volumes/[^/\r\n"']+(?:/[^\r\n"']+)*"#).expect("compile volumes path regex")
+    })
+}
+
+fn bearer_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"(?i)(?P<prefix>\bauthorization\s*[:=]\s*)(?:bearer\s+)?[^\s,;]+")
+            .expect("compile bearer regex")
+    })
+}
+
+fn cookie_header_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"(?i)(?P<prefix>\b(?:set-cookie|cookie)\s*[:=]\s*)[^\r\n]+")
+            .expect("compile cookie header regex")
+    })
+}
+
+fn cli_secret_arg_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"(?i)(?P<prefix>(?:^|[\s,;])--?[a-z0-9_-]*(?:api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|client[_-]?secret|authorization|password|secret|token|cookie|credential|database[_-]?url|connection[_-]?string|session|jwt|dsn)[a-z0-9_-]*(?:\s+|=))(?:[^\s,;]+)")
+            .expect("compile cli secret argument regex")
+    })
+}
+
+fn assignment_secret_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"(?i)(?P<prefix>\b[a-z0-9_-]*(?:api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|client[_-]?secret|authorization|password|secret|token|cookie|credential|database[_-]?url|connection[_-]?string|session|jwt|dsn)[a-z0-9_-]*\s*[:=]\s*)[^\s,;]+")
+        .expect("compile assignment secret regex")
+    })
+}
+
+fn json_secret_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)(?P<prefix>"[^"]*(?:api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|client[_-]?secret|authorization|password|secret|token|cookie|credential|database[_-]?url|connection[_-]?string|session|jwt|dsn)[^"]*"\s*:\s*)"[^"]*""#)
+        .expect("compile json secret regex")
+    })
+}
+
+fn url_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)\b(?P<scheme>[a-z][a-z0-9+.-]*)://[^\s"']+"#).expect("compile url regex")
+    })
+}
+
+fn current_timestamp() -> Result<String> {
+    Ok(format!("{}Z", unix_millis()?))
+}
+
+fn unix_millis() -> Result<u128> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before Unix epoch")?
+        .as_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use mcpmate::common::MCPMatePaths;
+    use serde_json::json;
+
+    #[test]
+    fn diagnostics_export_dir_name_uses_timestamp() {
+        assert_eq!(
+            super::diagnostics_export_dir_name("20260604T120000Z"),
+            "mcpmate-diagnostics-20260604T120000Z"
+        );
+    }
+
+    #[test]
+    fn diagnostic_source_filter_includes_runtime_logs_and_frontend_events() {
+        assert!(super::is_diagnostic_source(Path::new("desktop-shell.log")));
+        assert!(super::is_diagnostic_source(Path::new(
+            "desktop-shell.2026-06-04.log"
+        )));
+        assert!(super::is_diagnostic_source(Path::new(
+            "desktop-core.startup-123.log"
+        )));
+        assert!(super::is_diagnostic_source(Path::new(
+            "frontend-diagnostics.jsonl"
+        )));
+        assert!(!super::is_diagnostic_source(Path::new("notes.txt")));
+    }
+
+    #[test]
+    fn diagnostics_export_copies_logs_and_writes_runtime_files() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "mcpmate-diagnostics-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let base_dir = test_dir.join("base");
+        let destination = test_dir.join("export");
+        let logs_dir = base_dir.join("logs");
+        std::fs::create_dir_all(&logs_dir).expect("create logs dir");
+        std::fs::create_dir_all(&destination).expect("create export dir");
+        std::fs::write(logs_dir.join("desktop-shell.log"), "shell log").expect("write shell log");
+        std::fs::write(logs_dir.join("frontend-diagnostics.jsonl"), "{}\n")
+            .expect("write frontend log");
+        std::fs::write(logs_dir.join("notes.txt"), "ignore").expect("write ignored file");
+
+        let paths = MCPMatePaths::from_base_dir(&base_dir).expect("paths");
+        let response = super::export_diagnostics_bundle(
+            &paths,
+            &destination,
+            json!({ "selectedSource": "localhost" }),
+            json!({ "backend": { "status": "ok" } }),
+        )
+        .expect("export diagnostics");
+        let export_path = Path::new(&response.export_path);
+
+        assert!(export_path.join("manifest.json").exists());
+        assert!(export_path.join("runtime.json").exists());
+        assert!(export_path.join("snapshot.json").exists());
+        assert!(export_path.join("logs/desktop-shell.log").exists());
+        assert!(export_path.join("logs/frontend-diagnostics.jsonl").exists());
+        assert!(!export_path.join("logs/notes.txt").exists());
+        assert_eq!(response.file_count, 5);
+
+        let _ = std::fs::remove_dir_all(&test_dir);
+    }
+
+    #[test]
+    fn diagnostics_export_redacts_sensitive_log_content_and_private_paths() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "mcpmate-diagnostics-redaction-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let base_dir = test_dir.join("Users").join("loocor").join(".mcpmate");
+        let destination = test_dir.join("export");
+        let logs_dir = base_dir.join("logs");
+        std::fs::create_dir_all(&logs_dir).expect("create logs dir");
+        std::fs::create_dir_all(&destination).expect("create export dir");
+        std::fs::write(
+            logs_dir.join("desktop-shell.log"),
+            format!(
+                "HOME=/Users/loocor\nAuthorization: Bearer secret-token\nbase={}\nclientPath=/Users/loocor/Documents/SecretClient/project.json\nvolumePath=/Volumes/SecretDrive/project/config.json",
+                base_dir.display()
+            ),
+        )
+        .expect("write shell log");
+
+        let paths = MCPMatePaths::from_base_dir(&base_dir).expect("paths");
+        let response = super::export_diagnostics_bundle(
+            &paths,
+            &destination,
+            json!({
+                "dataDir": base_dir.display().to_string(),
+                "token": "secret-token",
+                "remoteUrl": "https://user:pass@example.com/private?token=secret-token",
+                "workspacePath": "/Users/loocor/Documents/SecretClient/project.json",
+                "externalPath": "/Volumes/SecretDrive/project/config.json",
+            }),
+            json!({
+                "backend": {
+                    "apiBaseUrl": "https://user:pass@example.com/private?token=secret-token",
+                    "workspacePath": "/Users/loocor/Documents/SecretClient/project.json",
+                    "databaseUrl": "postgres://user:pass@db.example/app"
+                }
+            }),
+        )
+        .expect("export diagnostics");
+        let export_path = Path::new(&response.export_path);
+        let exported_log =
+            std::fs::read_to_string(export_path.join("logs/desktop-shell.log")).expect("read log");
+        let manifest =
+            std::fs::read_to_string(export_path.join("manifest.json")).expect("read manifest");
+        let runtime =
+            std::fs::read_to_string(export_path.join("runtime.json")).expect("read runtime");
+        let snapshot =
+            std::fs::read_to_string(export_path.join("snapshot.json")).expect("read snapshot");
+
+        assert!(!exported_log.contains("/Users/loocor"));
+        assert!(!exported_log.contains("SecretClient"));
+        assert!(!exported_log.contains("SecretDrive"));
+        assert!(!exported_log.contains("secret-token"));
+        assert!(exported_log.contains("[user-home]"));
+        assert!(exported_log.contains("[external-volume]/[redacted-path]"));
+        assert!(exported_log.contains("[redacted-secret]"));
+        assert!(!manifest.contains(base_dir.to_string_lossy().as_ref()));
+        assert!(!runtime.contains(base_dir.to_string_lossy().as_ref()));
+        assert!(!runtime.contains("SecretClient"));
+        assert!(!runtime.contains("SecretDrive"));
+        assert!(!runtime.contains("secret-token"));
+        assert!(!runtime.contains("https://user:pass@example.com"));
+        assert!(!snapshot.contains("SecretClient"));
+        assert!(!snapshot.contains("secret-token"));
+        assert!(!snapshot.contains("https://user:pass@example.com"));
+        assert!(!snapshot.contains("postgres://user:pass@db.example"));
+
+        let _ = std::fs::remove_dir_all(&test_dir);
+    }
+
+    #[test]
+    fn frontend_diagnostic_events_are_redacted_before_persisting() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "mcpmate-frontend-diagnostics-redaction-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let base_dir = test_dir.join("base");
+        let paths = MCPMatePaths::from_base_dir(&base_dir).expect("paths");
+        let payload = super::DiagnosticEventPayload {
+            level: "info".to_string(),
+            source: "test".to_string(),
+            message: "Authorization: Bearer secret-token".to_string(),
+            data: json!({
+                "token": "secret-token",
+                "url": "https://user:pass@example.com/private?token=secret-token",
+            }),
+        };
+
+        let path = super::record_frontend_diagnostic_event(&paths, &payload)
+            .expect("record frontend diagnostic");
+        let content = std::fs::read_to_string(path).expect("read frontend diagnostics");
+
+        assert!(!content.contains("secret-token"));
+        assert!(!content.contains("user:pass@example.com"));
+        assert!(content.contains("[redacted-secret]"));
+        assert!(content.contains("https://[redacted]"));
+
+        let _ = std::fs::remove_dir_all(&test_dir);
+    }
+
+    #[test]
+    fn diagnostics_redaction_catches_prefixed_secret_keys_and_windows_paths() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "mcpmate-diagnostics-prefixed-secret-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let paths = MCPMatePaths::from_base_dir(test_dir.join("base")).expect("paths");
+        let redactor = super::DiagnosticsRedactor::new(&paths);
+        let redacted = redactor.redact_text(
+            "OPENAI_API_KEY=sk-secret ANTHROPIC_AUTH_TOKEN=anthropic-secret x-api-key: x-secret --api-key sk-cli --token token-cli Cookie: sid=cookie-secret; theme=dark\nSet-Cookie: refresh=refresh-secret\nDATABASE_URL=postgres://user:pass@db.example/app connection_string=mysql://user:pass@db.example/app C:\\Users\\loocor\\AppData\\Local",
+        );
+        let redacted_json = redactor.redact_json(json!({
+            "openai_api_key": "sk-secret",
+            "githubToken": "gh-secret",
+            "sessionId": "session-secret",
+            "cookie": "cookie-secret",
+            "databaseUrl": "postgres://user:pass@db.example/app",
+            "dsn": "postgres://user:pass@db.example/app",
+            "profilePath": "C:\\Users\\loocor\\AppData\\Local\\MCPMate",
+        }));
+
+        assert!(!redacted.contains("sk-secret"));
+        assert!(!redacted.contains("anthropic-secret"));
+        assert!(!redacted.contains("x-secret"));
+        assert!(!redacted.contains("sk-cli"));
+        assert!(!redacted.contains("token-cli"));
+        assert!(!redacted.contains("cookie-secret"));
+        assert!(!redacted.contains("refresh-secret"));
+        assert!(!redacted.contains("postgres://user:pass@db.example"));
+        assert!(!redacted.contains("mysql://user:pass@db.example"));
+        assert!(!redacted.contains("C:\\Users\\loocor"));
+        let redacted_json_text = redacted_json.to_string();
+        assert!(!redacted_json_text.contains("sk-secret"));
+        assert!(!redacted_json_text.contains("gh-secret"));
+        assert!(!redacted_json_text.contains("session-secret"));
+        assert!(!redacted_json_text.contains("cookie-secret"));
+        assert!(!redacted_json_text.contains("postgres://user:pass@db.example"));
+        assert!(!redacted_json_text.contains("C:\\Users\\loocor"));
+    }
+
+    #[test]
+    fn diagnostics_redaction_catches_paths_with_spaces_and_escaped_windows_paths() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "mcpmate-diagnostics-path-space-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let paths = MCPMatePaths::from_base_dir(test_dir.join("base")).expect("paths");
+        let redactor = super::DiagnosticsRedactor::new(&paths);
+        let redacted = redactor.redact_text(
+            r#"configPath="/Users/loocor/Secret Project/config.json"
+volumePath="/Volumes/Secret Drive/client config.json"
+escapedWindowsPath="C:\\Users\\loocor\\Secret Project\\config.json""#,
+        );
+
+        assert!(!redacted.contains("Secret Project"));
+        assert!(!redacted.contains("Secret Drive"));
+        assert!(!redacted.contains(r#"C:\\Users\\loocor"#));
+        assert!(redacted.contains("[user-home]/[redacted-path]"));
+        assert!(redacted.contains("[external-volume]/[redacted-path]"));
+        assert!(redacted.contains(r#"[user-home]\\[redacted-path]"#));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn diagnostics_export_skips_log_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let test_dir = std::env::temp_dir().join(format!(
+            "mcpmate-diagnostics-symlink-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let base_dir = test_dir.join("base");
+        let destination = test_dir.join("export");
+        let logs_dir = base_dir.join("logs");
+        std::fs::create_dir_all(&logs_dir).expect("create logs dir");
+        std::fs::create_dir_all(&destination).expect("create export dir");
+        let outside = test_dir.join("outside-secret.txt");
+        std::fs::write(&outside, "outside secret").expect("write outside file");
+        symlink(&outside, logs_dir.join("desktop-shell.log")).expect("create log symlink");
+
+        let paths = MCPMatePaths::from_base_dir(&base_dir).expect("paths");
+        let response = super::export_diagnostics_bundle(&paths, &destination, json!({}), json!({}))
+            .expect("export diagnostics");
+        let export_path = Path::new(&response.export_path);
+
+        assert!(!export_path.join("logs/desktop-shell.log").exists());
+
+        let _ = std::fs::remove_dir_all(&test_dir);
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,10 @@
 use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Write},
     process::{Child, Command, Stdio},
-    sync::Arc,
+    sync::{Arc, Mutex},
+    thread,
+    time::Instant,
 };
 
 #[cfg(target_os = "windows")]
@@ -21,6 +25,7 @@ mod audit;
 mod config;
 mod core_service;
 mod deeplink;
+mod diagnostics;
 mod environment;
 mod oauth;
 mod operator_window;
@@ -33,6 +38,7 @@ use core_service::{
     sync_local_service_definition, uninstall_local_service,
 };
 use deeplink::DeepLinkState;
+use diagnostics::{DiagnosticEventPayload, DiagnosticsExportResponse};
 use mcpmate::system::config::api_url_from_port;
 use mcpmate::system::settings::{
     apply_settings_with_effects_for_paths, get_settings_sync_for_paths,
@@ -42,6 +48,7 @@ use shell::{ShellPreferences, ShellState};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_updater::Builder as UpdaterPluginBuilder;
 use tauri_plugin_updater::UpdaterExt;
+use tokio::net::TcpStream;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::{Duration, sleep};
 use tracing::{info, warn};
@@ -213,6 +220,220 @@ async fn read_core_state_view(
     Ok(DesktopCoreSourceView::from_config(config, local_service))
 }
 
+async fn diagnostics_runtime_metadata(
+    app: &tauri::AppHandle,
+    managed_state: &DesktopManagedCoreState,
+) -> serde_json::Value {
+    fn path_result_json<E: std::fmt::Display>(
+        result: std::result::Result<std::path::PathBuf, E>,
+    ) -> serde_json::Value {
+        match result {
+            Ok(path) => json!({ "status": "ok", "path": path.display().to_string() }),
+            Err(err) => json!({ "status": "error", "error": err.to_string() }),
+        }
+    }
+
+    let config = DesktopCoreSourceConfig::load(global_paths());
+    let core_source = diagnostics_core_source_view(config.as_ref(), managed_state).await;
+
+    json!({
+        "desktopPlatform": desktop_platform(),
+        "appIdentifier": app.config().identifier,
+        "currentExe": path_result_json(std::env::current_exe()),
+        "resourceDir": path_result_json(app.path().resource_dir()),
+        "dataDir": global_paths().base_dir().display().to_string(),
+        "logsDir": global_paths().logs_dir().display().to_string(),
+        "coreSource": core_source,
+    })
+}
+
+async fn diagnostics_snapshot(
+    app: &tauri::AppHandle,
+    managed_state: &DesktopManagedCoreState,
+) -> serde_json::Value {
+    let config = DesktopCoreSourceConfig::load(global_paths());
+    let core_source = diagnostics_core_source_view(config.as_ref(), managed_state).await;
+    let localhost_probe = match &config {
+        Ok(config) => json!({
+            "apiPort": probe_tcp_port("127.0.0.1", config.localhost.api_port).await,
+            "mcpPort": probe_tcp_port("127.0.0.1", config.localhost.mcp_port).await,
+        }),
+        Err(err) => json!({
+            "status": "error",
+            "error": err.to_string(),
+        }),
+    };
+    let api_base_url = config
+        .as_ref()
+        .map(|config| match config.selected_source {
+            DesktopCoreSourceKind::Localhost => api_url_from_port(config.localhost.api_port),
+            DesktopCoreSourceKind::Remote => config.remote.base_url.trim().to_string(),
+        })
+        .ok();
+    let backend = match api_base_url {
+        Some(api_base_url) => json!({
+            "apiBaseUrl": api_base_url,
+            "readiness": probe_backend_endpoint(&api_base_url, "/api/system/readiness").await,
+            "status": probe_backend_endpoint(&api_base_url, "/api/system/status").await,
+        }),
+        None => json!({
+            "status": "error",
+            "error": "desktop core source config unavailable",
+        }),
+    };
+
+    json!({
+        "generatedAtUnixMs": unix_millis_snapshot(),
+        "desktop": {
+            "appIdentifier": app.config().identifier,
+            "appVersion": app.package_info().version.to_string(),
+            "crateVersion": env!("CARGO_PKG_VERSION"),
+            "platform": desktop_platform(),
+            "buildProfile": if cfg!(debug_assertions) { "debug" } else { "release" },
+        },
+        "coreSource": core_source,
+        "localhost": localhost_probe,
+        "backend": backend,
+    })
+}
+
+async fn diagnostics_core_source_view(
+    config: std::result::Result<&DesktopCoreSourceConfig, &Error>,
+    managed_state: &DesktopManagedCoreState,
+) -> serde_json::Value {
+    match config {
+        Ok(config) => match read_core_state_view(config, managed_state).await {
+            Ok(view) => json!({
+                "status": "ok",
+                "view": view,
+            }),
+            Err(err) => json!({
+                "status": "error",
+                "error": err.to_string(),
+                "selectedSource": config.selected_source,
+                "localhostRuntimeMode": config.localhost_runtime_mode,
+                "localhostApiPort": config.localhost.api_port,
+                "localhostMcpPort": config.localhost.mcp_port,
+            }),
+        },
+        Err(err) => json!({
+            "status": "error",
+            "error": err.to_string(),
+        }),
+    }
+}
+
+async fn probe_tcp_port(host: &str, port: u16) -> serde_json::Value {
+    let address = format!("{host}:{port}");
+    let started_at = Instant::now();
+    match tokio::time::timeout(Duration::from_millis(500), TcpStream::connect(&address)).await {
+        Ok(Ok(_stream)) => json!({
+            "status": "open",
+            "host": host,
+            "port": port,
+            "durationMs": started_at.elapsed().as_millis(),
+        }),
+        Ok(Err(err)) => json!({
+            "status": "closed",
+            "host": host,
+            "port": port,
+            "durationMs": started_at.elapsed().as_millis(),
+            "error": err.to_string(),
+        }),
+        Err(_elapsed) => json!({
+            "status": "timeout",
+            "host": host,
+            "port": port,
+            "durationMs": started_at.elapsed().as_millis(),
+        }),
+    }
+}
+
+async fn probe_backend_endpoint(api_base_url: &str, path: &str) -> serde_json::Value {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(800))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            return json!({
+                "status": "error",
+                "error": err.to_string(),
+            });
+        }
+    };
+    let url = format!("{}{}", api_base_url.trim_end_matches('/'), path);
+    let started_at = Instant::now();
+    match client.get(&url).send().await {
+        Ok(response) => {
+            let http_status = response.status().as_u16();
+            let content_type = response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
+            let body = match response.json::<serde_json::Value>().await {
+                Ok(value) => json!({
+                    "type": "json",
+                    "value": value,
+                }),
+                Err(err) => json!({
+                    "type": "unavailable",
+                    "error": err.to_string(),
+                }),
+            };
+            json!({
+                "status": "ok",
+                "url": url,
+                "httpStatus": http_status,
+                "durationMs": started_at.elapsed().as_millis(),
+                "contentType": content_type,
+                "body": body,
+            })
+        }
+        Err(err) => json!({
+            "status": "error",
+            "url": url,
+            "durationMs": started_at.elapsed().as_millis(),
+            "error": err.to_string(),
+        }),
+    }
+}
+
+fn unix_millis_snapshot() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+async fn export_diagnostics_with_dialog(
+    app: &tauri::AppHandle,
+    managed_state: &DesktopManagedCoreState,
+) -> Result<Option<DiagnosticsExportResponse>> {
+    let Some(destination_root) = rfd::FileDialog::new()
+        .set_title("Export MCPMate Diagnostics")
+        .pick_folder()
+    else {
+        info!("Diagnostics export canceled by user");
+        return Ok(None);
+    };
+
+    let runtime_metadata = diagnostics_runtime_metadata(app, managed_state).await;
+    let snapshot = diagnostics_snapshot(app, managed_state).await;
+    let response = diagnostics::export_diagnostics_bundle(
+        global_paths(),
+        &destination_root,
+        runtime_metadata,
+        snapshot,
+    )?;
+    info!(
+        file_count = response.file_count,
+        "Diagnostics export completed"
+    );
+    Ok(Some(response))
+}
+
 async fn sync_and_emit_core_state(
     app: &tauri::AppHandle,
     shell_state: &ShellState,
@@ -289,7 +510,8 @@ pub fn run() -> Result<()> {
     builder = builder.manage(deep_link_state);
     builder = builder.manage(desktop_managed_core_state.clone());
 
-    builder = builder.on_menu_event(|app_handle, event| {
+    let managed_state_for_app_menu = desktop_managed_core_state.clone();
+    builder = builder.on_menu_event(move |app_handle, event| {
         if event.id.as_ref() == shell::APP_MENU_CHECK_UPDATES {
             let handle = app_handle.clone();
             tauri::async_runtime::spawn(async move {
@@ -375,6 +597,33 @@ pub fn run() -> Result<()> {
                             .dialog()
                             .message(format!("Unable to check for updates: {}", err))
                             .title("Update Check Failed")
+                            .buttons(MessageDialogButtons::Ok)
+                            .show(|_| {});
+                    }
+                }
+            });
+        } else if event.id.as_ref() == shell::APP_MENU_EXPORT_DIAGNOSTICS {
+            let handle = app_handle.clone();
+            let managed_state = managed_state_for_app_menu.clone();
+            tauri::async_runtime::spawn(async move {
+                match export_diagnostics_with_dialog(&handle, &managed_state).await {
+                    Ok(Some(response)) => {
+                        handle
+                            .dialog()
+                            .message(format!(
+                                "Diagnostics exported to:\n{}",
+                                response.export_path
+                            ))
+                            .title("Diagnostics Exported")
+                            .buttons(MessageDialogButtons::Ok)
+                            .show(|_| {});
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        handle
+                            .dialog()
+                            .message(format!("Unable to export diagnostics: {}", err))
+                            .title("Diagnostics Export Failed")
                             .buttons(MessageDialogButtons::Ok)
                             .show(|_| {});
                     }
@@ -865,6 +1114,7 @@ pub fn run() -> Result<()> {
         mcp_shell_show_operator_intro_once,
         mcp_shell_close_operator_panel,
         mcp_shell_set_operator_panel_pinned,
+        mcp_shell_record_diagnostic_event,
         deeplink::mcp_deep_link_take_pending_server_import,
         deeplink::mcp_deep_link_log_frontend_import,
         account::mcp_account_start_github_login,
@@ -1021,6 +1271,13 @@ async fn mcp_shell_set_operator_panel_pinned(
     pinned: bool,
 ) -> Result<(), String> {
     shell::set_operator_window_pinned(&app, pinned).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+fn mcp_shell_record_diagnostic_event(payload: DiagnosticEventPayload) -> Result<(), String> {
+    diagnostics::record_frontend_diagnostic_event(global_paths(), &payload)
+        .map(|_| ())
+        .map_err(|err| err.to_string())
 }
 
 #[tauri::command]
@@ -1373,6 +1630,7 @@ async fn initialize_selected_core_source(
 fn spawn_desktop_managed_core(
     app: &tauri::AppHandle,
     config: &DesktopCoreSourceConfig,
+    startup_id: &str,
 ) -> Result<Child> {
     let binary = resolve_local_core_binary(app)?;
     let base_dir = global_paths().base_dir().to_path_buf();
@@ -1386,6 +1644,7 @@ fn spawn_desktop_managed_core(
         working_directory = %base_dir.display(),
         api_port = config.localhost.api_port,
         mcp_port = config.localhost.mcp_port,
+        startup_id,
         "Spawning desktop-managed localhost core"
     );
     let mut command = Command::new(&binary);
@@ -1404,32 +1663,170 @@ fn spawn_desktop_managed_core(
         .current_dir(&base_dir)
         .env("MCPMATE_DATA_DIR", &base_dir)
         .env("MCPMATE_API_PORT", config.localhost.api_port.to_string())
-        .env("MCPMATE_MCP_PORT", config.localhost.mcp_port.to_string());
-    configure_desktop_managed_stdio(&mut command);
+        .env("MCPMATE_MCP_PORT", config.localhost.mcp_port.to_string())
+        .env("MCPMATE_STARTUP_ID", startup_id);
+    configure_desktop_managed_stdio(&mut command, startup_id)?;
 
     #[cfg(target_os = "windows")]
     command.creation_flags(CREATE_NO_WINDOW);
 
-    let child = command
+    let mut child = command
         .spawn()
         .context("failed to spawn desktop-managed localhost core")?;
+    configure_spawned_desktop_managed_stdio(&mut child, startup_id)?;
     info!(
         pid = child.id(),
-        "Spawned desktop-managed localhost core process"
+        startup_id, "Spawned desktop-managed localhost core process"
     );
     Ok(child)
 }
 
-fn configure_desktop_managed_stdio(command: &mut Command) {
+fn configure_desktop_managed_stdio(command: &mut Command, startup_id: &str) -> Result<()> {
     #[cfg(debug_assertions)]
     {
-        command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        tracing::debug!(
+            startup_id,
+            "Desktop-managed core stdio tee configured for debug shell"
+        );
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
     }
 
     #[cfg(not(debug_assertions))]
     {
-        command.stdout(Stdio::null()).stderr(Stdio::null());
+        let stdout = open_desktop_managed_core_stdio_log(startup_id)?;
+        let stderr = stdout
+            .try_clone()
+            .context("failed to clone desktop-managed core stdio log handle")?;
+        command
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr));
     }
+
+    Ok(())
+}
+
+fn configure_spawned_desktop_managed_stdio(child: &mut Child, startup_id: &str) -> Result<()> {
+    #[cfg(debug_assertions)]
+    {
+        let log = Arc::new(Mutex::new(open_desktop_managed_core_stdio_log(startup_id)?));
+        if let Some(stdout) = child.stdout.take() {
+            spawn_desktop_managed_core_stdio_tee(stdout, Arc::clone(&log), startup_id, false)?;
+        }
+        if let Some(stderr) = child.stderr.take() {
+            spawn_desktop_managed_core_stdio_tee(stderr, log, startup_id, true)?;
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = child;
+        let _ = startup_id;
+    }
+
+    Ok(())
+}
+
+fn desktop_managed_core_log_file_name(startup_id: &str) -> String {
+    format!("desktop-core.{startup_id}.log")
+}
+
+fn open_desktop_managed_core_stdio_log(startup_id: &str) -> Result<File> {
+    let logs_dir = global_paths().logs_dir().to_path_buf();
+    std::fs::create_dir_all(&logs_dir)
+        .with_context(|| format!("failed to create desktop logs dir {}", logs_dir.display()))?;
+    let log_path = logs_dir.join(desktop_managed_core_log_file_name(startup_id));
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| {
+            format!(
+                "failed to open desktop-managed core stdio log {}",
+                log_path.display()
+            )
+        })?;
+    info!(
+        startup_id,
+        log_path = %log_path.display(),
+        "Desktop-managed core stdio log configured"
+    );
+    Ok(file)
+}
+
+#[cfg(debug_assertions)]
+fn spawn_desktop_managed_core_stdio_tee<R>(
+    reader: R,
+    log: Arc<Mutex<File>>,
+    startup_id: &str,
+    stderr: bool,
+) -> Result<()>
+where
+    R: Read + Send + 'static,
+{
+    let startup_id = startup_id.to_string();
+    thread::Builder::new()
+        .name(format!(
+            "mcpmate-core-{}-stdio-tee",
+            if stderr { "stderr" } else { "stdout" }
+        ))
+        .spawn(move || {
+            if let Err(err) = tee_desktop_managed_core_stdio(reader, log, stderr) {
+                warn!(
+                    startup_id,
+                    error = %err,
+                    "Desktop-managed core stdio tee stopped with error"
+                );
+            }
+        })
+        .context("failed to spawn desktop-managed core stdio tee thread")?;
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+fn tee_desktop_managed_core_stdio<R>(
+    mut reader: R,
+    log: Arc<Mutex<File>>,
+    stderr: bool,
+) -> Result<()>
+where
+    R: Read,
+{
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .context("failed to read desktop-managed core stdio")?;
+        if read == 0 {
+            break;
+        }
+        {
+            let mut log = log
+                .lock()
+                .map_err(|_| Error::msg("desktop-managed core stdio log lock poisoned"))?;
+            log.write_all(&buffer[..read])
+                .context("failed to write desktop-managed core stdio log")?;
+            log.flush()
+                .context("failed to flush desktop-managed core stdio log")?;
+        }
+        if stderr {
+            let mut output = std::io::stderr().lock();
+            output
+                .write_all(&buffer[..read])
+                .context("failed to write desktop-managed core stderr")?;
+            output
+                .flush()
+                .context("failed to flush desktop-managed core stderr")?;
+        } else {
+            let mut output = std::io::stdout().lock();
+            output
+                .write_all(&buffer[..read])
+                .context("failed to write desktop-managed core stdout")?;
+            output
+                .flush()
+                .context("failed to flush desktop-managed core stdout")?;
+        }
+    }
+    Ok(())
 }
 
 async fn read_desktop_managed_status(
@@ -1468,11 +1865,15 @@ async fn start_desktop_managed_core(
     if core_service::probe_localhost_core(config.localhost.api_port).await {
         return read_desktop_managed_status(state, config).await;
     }
-    let child = spawn_desktop_managed_core(app, config)?;
-    info!("Desktop-managed localhost core spawn returned successfully");
+    let startup_id = uuid::Uuid::new_v4().to_string();
+    let child = spawn_desktop_managed_core(app, config, &startup_id)?;
+    info!(
+        startup_id,
+        "Desktop-managed localhost core spawn returned successfully"
+    );
     state.replace(child).await;
 
-    spawn_core_ready_notification(app.clone(), state.clone(), config.clone());
+    spawn_core_ready_notification(app.clone(), state.clone(), config.clone(), startup_id);
 
     read_desktop_managed_status(state, config).await
 }
@@ -1481,10 +1882,16 @@ fn spawn_core_ready_notification(
     app: tauri::AppHandle,
     state: DesktopManagedCoreState,
     config: DesktopCoreSourceConfig,
+    startup_id: String,
 ) {
     tauri::async_runtime::spawn(async move {
         if let Err(err) = core_service::wait_for_localhost_core(config.localhost.api_port).await {
-            warn!(error = %err, api_port = config.localhost.api_port, "Desktop-managed localhost core did not become ready in time");
+            warn!(
+                error = %err,
+                api_port = config.localhost.api_port,
+                startup_id,
+                "Desktop-managed localhost core did not become ready in time"
+            );
             return;
         }
 
@@ -1556,10 +1963,17 @@ fn try_use_default_paths() -> Result<MCPMatePaths> {
 
 #[cfg(test)]
 mod tests {
-    use super::desktop_platform;
+    use super::{desktop_managed_core_log_file_name, desktop_platform};
 
     #[test]
     fn desktop_platform_matches_admin_discovery_values() {
         assert!(matches!(desktop_platform(), "macos" | "windows" | "linux"));
+    }
+
+    #[test]
+    fn desktop_managed_core_log_file_name_includes_startup_id() {
+        let file_name = desktop_managed_core_log_file_name("startup-123");
+
+        assert_eq!(file_name, "desktop-core.startup-123.log");
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -411,10 +411,14 @@ async fn export_diagnostics_with_dialog(
     app: &tauri::AppHandle,
     managed_state: &DesktopManagedCoreState,
 ) -> Result<Option<DiagnosticsExportResponse>> {
-    let Some(destination_root) = rfd::FileDialog::new()
-        .set_title("Export MCPMate Diagnostics")
-        .pick_folder()
-    else {
+    let destination_root = tauri::async_runtime::spawn_blocking(|| {
+        rfd::FileDialog::new()
+            .set_title("Export MCPMate Diagnostics")
+            .pick_folder()
+    })
+    .await
+    .context("diagnostics folder picker task failed")?;
+    let Some(destination_root) = destination_root else {
         info!("Diagnostics export canceled by user");
         return Ok(None);
     };
@@ -1673,7 +1677,16 @@ fn spawn_desktop_managed_core(
     let mut child = command
         .spawn()
         .context("failed to spawn desktop-managed localhost core")?;
-    configure_spawned_desktop_managed_stdio(&mut child, startup_id)?;
+    if let Err(err) = configure_spawned_desktop_managed_stdio(&mut child, startup_id) {
+        if let Err(cleanup_err) = cleanup_untracked_desktop_managed_child(&mut child, startup_id) {
+            warn!(
+                startup_id,
+                error = %cleanup_err,
+                "Failed to clean up desktop-managed core after stdio setup failure"
+            );
+        }
+        return Err(err).context("failed to configure desktop-managed core stdio");
+    }
     info!(
         pid = child.id(),
         startup_id, "Spawned desktop-managed localhost core process"
@@ -1723,6 +1736,32 @@ fn configure_spawned_desktop_managed_stdio(child: &mut Child, startup_id: &str) 
         let _ = startup_id;
     }
 
+    Ok(())
+}
+
+fn cleanup_untracked_desktop_managed_child(child: &mut Child, startup_id: &str) -> Result<()> {
+    match child.try_wait() {
+        Ok(Some(_status)) => return Ok(()),
+        Ok(None) => {}
+        Err(err) => {
+            warn!(
+                startup_id,
+                error = %err,
+                "Failed to query desktop-managed core before cleanup"
+            );
+        }
+    }
+
+    match child.kill() {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::InvalidInput => {}
+        Err(err) => {
+            return Err(err).context("failed to kill untracked desktop-managed core process");
+        }
+    }
+    child
+        .wait()
+        .context("failed to wait for untracked desktop-managed core process exit")?;
     Ok(())
 }
 

--- a/desktop/src-tauri/src/shell.rs
+++ b/desktop/src-tauri/src/shell.rs
@@ -63,6 +63,7 @@ pub const MENU_OPEN_SETTINGS: &str = "mcpmate.tray.open_settings";
 pub const MENU_SHOW_ABOUT: &str = "mcpmate.tray.show_about";
 pub const MENU_QUIT: &str = "mcpmate.tray.quit";
 pub const APP_MENU_CHECK_UPDATES: &str = "menu.help.check_for_updates";
+pub const APP_MENU_EXPORT_DIAGNOSTICS: &str = "menu.help.export_diagnostics";
 pub const APP_MENU_ABOUT: &str = "menu.help.about";
 
 pub const EVENT_OPEN_SETTINGS: &str = "mcpmate://open-settings";
@@ -637,14 +638,22 @@ pub fn initialize_app_menu(app: &mut tauri::App) -> Result<()> {
         true,
         None::<&str>,
     )?;
+    let export_diagnostics_item = MenuItem::with_id(
+        app,
+        APP_MENU_EXPORT_DIAGNOSTICS,
+        "Export Diagnostics…",
+        true,
+        None::<&str>,
+    )?;
 
     if let Some(MenuItemKind::Submenu(help_menu)) = menu.get(&HELP_SUBMENU_ID.to_string()) {
         let existing_items = help_menu.items()?.len();
         help_menu.insert(&check_updates_item, 0)?;
+        help_menu.insert(&export_diagnostics_item, 0)?;
         help_menu.insert(&about_item, 0)?;
         if existing_items > 0 {
             let separator = PredefinedMenuItem::separator(app)?;
-            help_menu.insert(&separator, 2)?;
+            help_menu.insert(&separator, 3)?;
         }
     } else {
         let help_menu = Submenu::with_id_and_items(
@@ -652,7 +661,7 @@ pub fn initialize_app_menu(app: &mut tauri::App) -> Result<()> {
             HELP_SUBMENU_ID,
             "Help",
             true,
-            &[&about_item, &check_updates_item],
+            &[&about_item, &export_diagnostics_item, &check_updates_item],
         )?;
         menu.append(&help_menu)?;
     }


### PR DESCRIPTION
## Summary
- Adds a desktop-menu diagnostics export flow for issue #85, including redacted runtime metadata, snapshot data, and shell/core logs.
- Persists desktop-managed core stdio into log files in both debug and release builds, with startup IDs and probe failure context for later diagnosis.
- Compresses repeated backend readiness and Vite proxy noise in the Board app, and removes the obsolete Settings page export entry so the menu remains the single export path.

## Testing
- `bun test` for the new diagnostics helper coverage passed.
- `bun run build` and `bun run lint` passed on the Board app; lint still reports existing repository warnings only.
- Rust validation passed, including `cargo test` for the new diagnostics/core probes and `cargo clippy --all-targets --all-features -- -D warnings` on `desktop/src-tauri`.

## Notes
- No schema, config migration, or compatibility change was introduced.
- Remaining risk is limited to the new diagnostics payload shape and log redaction coverage, which are covered by unit tests and local validation.