### PR TITLE
fix(inspector): reuse native Inspect sessions

### DIFF
--- a/backend/src/api/models/inspector.rs
+++ b/backend/src/api/models/inspector.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Operating mode for Inspector endpoints.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum InspectorMode {
     /// Aggregate/managed view: unique naming, profile-aware (recommended)
@@ -16,6 +16,7 @@ pub enum InspectorMode {
 pub struct InspectorListQuery {
     pub server_id: Option<String>,
     pub server_name: Option<String>,
+    pub session_id: Option<String>,
     #[serde(default)]
     pub mode: InspectorMode,
     #[serde(default)]
@@ -40,6 +41,8 @@ pub struct InspectorPromptGetReq {
     pub name: String,
     pub server_id: Option<String>,
     pub server_name: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
     pub arguments: Option<serde_json::Map<String, serde_json::Value>>,
     #[serde(default)]
     pub mode: InspectorMode,
@@ -50,6 +53,8 @@ pub struct InspectorResourceReadQuery {
     pub uri: String,
     pub server_id: Option<String>,
     pub server_name: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
     #[serde(default)]
     pub mode: InspectorMode,
 }

--- a/backend/src/core/pool/connection.rs
+++ b/backend/src/core/pool/connection.rs
@@ -365,6 +365,22 @@ impl UpstreamConnectionPool {
             .insert(session_id.to_string(), Instant::now() + ttl);
     }
 
+    /// Refresh an existing validation session without creating a new owner.
+    pub fn refresh_validation_session(
+        &mut self,
+        session_id: &str,
+        ttl: Duration,
+    ) -> bool {
+        if !self.validation_sessions.contains_key(session_id) {
+            return false;
+        }
+
+        use std::time::Instant;
+        self.validation_expirations
+            .insert(session_id.to_string(), Instant::now() + ttl);
+        true
+    }
+
     /// Cleanup expired exploration/validation sessions
     pub fn cleanup_expired_sessions(&mut self) {
         use std::time::Instant;
@@ -749,6 +765,31 @@ impl UpstreamConnectionPool {
                 tracing::info!("Destroyed validation instance for server '{}'", server_name);
             }
         }
+
+        Ok(())
+    }
+
+    /// Destroy a full validation session and all server instances it owns.
+    pub async fn destroy_validation_session(
+        &mut self,
+        session_id: &str,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(session_servers) = self.validation_sessions.remove(session_id) {
+            for (server_name, mut connection) in session_servers {
+                if let Some(service) = connection.service.as_ref() {
+                    service.cancellation_token().cancel();
+                }
+                if connection.is_connected() {
+                    connection.update_disconnected();
+                }
+                tracing::info!(
+                    "Destroyed validation instance for server '{}' in session '{}'",
+                    server_name,
+                    session_id
+                );
+            }
+        }
+        self.validation_expirations.remove(session_id);
 
         Ok(())
     }

--- a/backend/src/core/pool/connection.rs
+++ b/backend/src/core/pool/connection.rs
@@ -371,13 +371,21 @@ impl UpstreamConnectionPool {
         session_id: &str,
         ttl: Duration,
     ) -> bool {
-        if !self.validation_sessions.contains_key(session_id) {
+        use std::time::Instant;
+        let now = Instant::now();
+        let is_active = self.validation_sessions.contains_key(session_id)
+            && self
+                .validation_expirations
+                .get(session_id)
+                .is_some_and(|expires_at| *expires_at > now);
+        if !is_active {
+            self.validation_sessions.remove(session_id);
+            self.validation_expirations.remove(session_id);
             return false;
         }
 
-        use std::time::Instant;
         self.validation_expirations
-            .insert(session_id.to_string(), Instant::now() + ttl);
+            .insert(session_id.to_string(), now + ttl);
         true
     }
 

--- a/backend/src/inspector/service.rs
+++ b/backend/src/inspector/service.rs
@@ -26,6 +26,8 @@ use crate::core::capability::resolver;
 use crate::core::proxy::server::supports_capability;
 use crate::inspector::calls::{InspectorCallInfo, InspectorCallRegistry, InspectorTerminal, RegisteredCall};
 
+const NATIVE_VALIDATION_SESSION_TTL: Duration = Duration::from_secs(300);
+
 #[derive(Debug, Clone)]
 pub struct ToolCallOutcome {
     pub result: Option<Value>,
@@ -38,7 +40,7 @@ pub struct PreparedCall {
     pub info: InspectorCallInfo,
     pub completion: oneshot::Receiver<InspectorTerminal>,
     pub server_id: String,
-    pub native_validation_session: Option<String>,
+    native_validation_session: Option<NativeValidationSessionGuard>,
 }
 
 static GLOBAL_CALL_REGISTRY: OnceLock<Arc<InspectorCallRegistry>> = OnceLock::new();
@@ -88,6 +90,50 @@ struct CapabilityPayload {
     mode: String,
     items: Vec<Value>,
     meta: Vec<Value>,
+}
+
+struct NativeValidationSessionGuard {
+    connection_pool: Arc<tokio::sync::Mutex<crate::core::pool::UpstreamConnectionPool>>,
+    session_id: Option<String>,
+}
+
+impl NativeValidationSessionGuard {
+    fn new(
+        state: &AppState,
+        session_id: String,
+    ) -> Self {
+        Self {
+            connection_pool: state.connection_pool.clone(),
+            session_id: Some(session_id),
+        }
+    }
+
+    fn session_id(&self) -> &str {
+        self.session_id
+            .as_deref()
+            .expect("native validation cleanup guard must own a session")
+    }
+
+    async fn cleanup(mut self) {
+        if let Some(session_id) = self.session_id.clone() {
+            destroy_validation_session(&self.connection_pool, &session_id).await;
+            self.session_id.take();
+        }
+    }
+}
+
+impl Drop for NativeValidationSessionGuard {
+    fn drop(&mut self) {
+        let Some(session_id) = self.session_id.take() else {
+            return;
+        };
+        let connection_pool = self.connection_pool.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                destroy_validation_session(&connection_pool, &session_id).await;
+            });
+        }
+    }
 }
 
 pub async fn list_tools(
@@ -165,25 +211,21 @@ pub async fn prompt_get(
         InspectorMode::Native => {
             ensure_native_allowed()?;
             let server_id = resolve_server(&req.server_id, &req.server_name).await?;
-            let session_id = ensure_native_session(state, &server_id).await?;
-            let server_name = resolver::to_name(&server_id)
+            let (session_id, cleanup) = native_validation_scope(state, &server_id, req.session_id.as_deref()).await?;
+            let res = match clone_native_validation_connection(state, &server_id, &session_id).await {
+                Ok(conn) => crate::core::capability::prompts::get_upstream_prompt_direct(
+                    &conn,
+                    &req.name,
+                    req.arguments.clone(),
+                )
                 .await
-                .ok()
-                .flatten()
-                .unwrap_or_else(|| server_id.clone());
-            // Clone the connection to reuse capability direct helper
-            let conn = {
-                let pool = state.connection_pool.lock().await;
-                pool.validation_sessions
-                    .get(&session_id)
-                    .and_then(|m| m.get(&server_name))
-                    .cloned()
-                    .ok_or_else(|| ApiError::InternalError("Validation connection not found".into()))?
+                .map_err(map_anyhow),
+                Err(err) => Err(err),
             };
-            let res =
-                crate::core::capability::prompts::get_upstream_prompt_direct(&conn, &req.name, req.arguments.clone())
-                    .await
-                    .map_err(map_anyhow)?;
+            if let Some(cleanup) = cleanup {
+                cleanup.cleanup().await;
+            }
+            let res = res?;
             Ok(json!({
                 "result": res,
                 "server_id": server_id,
@@ -243,23 +285,17 @@ pub async fn resource_read(
         InspectorMode::Native => {
             ensure_native_allowed()?;
             let server_id = resolve_server(&req.server_id, &req.server_name).await?;
-            let session_id = ensure_native_session(state, &server_id).await?;
-            let server_name = resolver::to_name(&server_id)
-                .await
-                .ok()
-                .flatten()
-                .unwrap_or_else(|| server_id.clone());
-            let conn = {
-                let pool = state.connection_pool.lock().await;
-                pool.validation_sessions
-                    .get(&session_id)
-                    .and_then(|m| m.get(&server_name))
-                    .cloned()
-                    .ok_or_else(|| ApiError::InternalError("Validation connection not found".into()))?
+            let (session_id, cleanup) = native_validation_scope(state, &server_id, req.session_id.as_deref()).await?;
+            let res = match clone_native_validation_connection(state, &server_id, &session_id).await {
+                Ok(conn) => crate::core::capability::resources::read_upstream_resource_direct(&conn, &req.uri)
+                    .await
+                    .map_err(map_anyhow),
+                Err(err) => Err(err),
             };
-            let res = crate::core::capability::resources::read_upstream_resource_direct(&conn, &req.uri)
-                .await
-                .map_err(map_anyhow)?;
+            if let Some(cleanup) = cleanup {
+                cleanup.cleanup().await;
+            }
+            let res = res?;
             Ok(json!({
                 "result": res,
                 "server_id": server_id,
@@ -274,16 +310,24 @@ pub async fn call_tool(
     req: &InspectorToolCallReq,
 ) -> Result<ToolCallOutcome, ApiError> {
     let prepared = start_tool_call_internal(state, req).await?;
-    let native_cleanup = prepared.native_validation_session.clone();
-    let server_id = prepared.server_id.clone();
+    let PreparedCall {
+        completion,
+        mut native_validation_session,
+        ..
+    } = prepared;
 
-    let result = prepared
-        .completion
-        .await
-        .map_err(|_| ApiError::InternalError("Inspector call channel dropped".into()))?;
+    let result = match completion.await {
+        Ok(result) => result,
+        Err(_) => {
+            if let Some(cleanup) = native_validation_session.take() {
+                cleanup.cleanup().await;
+            }
+            return Err(ApiError::InternalError("Inspector call channel dropped".into()));
+        }
+    };
 
-    if let Some(session) = native_cleanup {
-        cleanup_native_session(state, &server_id, Some(&session)).await;
+    if let Some(cleanup) = native_validation_session {
+        cleanup.cleanup().await;
     }
 
     match result {
@@ -310,17 +354,18 @@ pub async fn start_tool_call(
 ) -> Result<InspectorCallInfo, ApiError> {
     let prepared = start_tool_call_internal(state, req).await?;
     let info = prepared.info.clone();
-    let state_clone = state.clone();
 
     tokio::spawn(async move {
-        let completion = prepared.completion;
-        let server_id = prepared.server_id.clone();
-        let native_cleanup = prepared.native_validation_session.clone();
+        let PreparedCall {
+            completion,
+            native_validation_session,
+            ..
+        } = prepared;
 
         let _ = completion.await;
 
-        if let Some(session) = native_cleanup {
-            cleanup_native_session(&state_clone, &server_id, Some(&session)).await;
+        if let Some(cleanup) = native_validation_session {
+            cleanup.cleanup().await;
         }
     });
 
@@ -336,21 +381,25 @@ pub async fn open_session(
     }
 
     let server_id = resolve_server(&req.server_id, &req.server_name).await?;
-    let validation_session = if matches!(req.mode, InspectorMode::Native) {
-        Some(ensure_native_session(state, &server_id).await?)
+    let session_id = crate::generate_id!("inspses");
+    let (peer, validation_session) = if matches!(req.mode, InspectorMode::Native) {
+        let validation_session = native_session_id_for_inspector_session(&session_id);
+        ensure_native_session(state, &server_id, &validation_session).await?;
+        acquire_validation_peer(state, &server_id, &validation_session)
+            .await
+            .map_err(|e| ApiError::InternalError(e.to_string()))?;
+        (None, Some(validation_session))
     } else {
         {
             let mut pool = state.connection_pool.lock().await;
             pool.ensure_connected(&server_id).await.map_err(map_anyhow)?;
         }
-        None
+        let peer = acquire_peer_for_call(state, &server_id, None)
+            .await
+            .map_err(|e| ApiError::InternalError(e.to_string()))?;
+        (Some(peer), None)
     };
 
-    let peer = acquire_peer_for_call(state, &server_id, validation_session.as_deref())
-        .await
-        .map_err(|e| ApiError::InternalError(e.to_string()))?;
-
-    let session_id = crate::generate_id!("inspses");
     let info = state
         .inspector_sessions
         .open_session(
@@ -462,18 +511,38 @@ async fn start_tool_call_internal(
                 "Inspector session is bound to a different server".into(),
             ));
         }
+        if session.mode != req.mode {
+            return Err(ApiError::BadRequest(
+                "Inspector session is bound to a different mode".into(),
+            ));
+        }
     }
 
     let (peer, native_cleanup_session) = match (req.mode, active_session) {
-        (InspectorMode::Native, Some(session)) => (session.peer, None),
-        (InspectorMode::Native, None) => {
-            let validation_session = ensure_native_session(state, &server_id).await?;
-            let peer = acquire_peer_for_call(state, &server_id, Some(&validation_session))
+        (InspectorMode::Native, Some(session)) => {
+            let validation_session = session.validation_session.as_deref().ok_or_else(|| {
+                ApiError::InternalError("Native Inspector session is missing validation ownership".into())
+            })?;
+            let peer = acquire_validation_peer(state, &server_id, validation_session)
                 .await
                 .map_err(|e| ApiError::InternalError(e.to_string()))?;
-            (peer, Some(validation_session))
+            (peer, None)
         }
-        (_, Some(session)) => (session.peer, None),
+        (InspectorMode::Native, None) => {
+            let validation_session = native_temporary_session_id();
+            ensure_native_session(state, &server_id, &validation_session).await?;
+            let cleanup = NativeValidationSessionGuard::new(state, validation_session);
+            let peer = acquire_validation_peer(state, &server_id, cleanup.session_id())
+                .await
+                .map_err(|e| ApiError::InternalError(e.to_string()))?;
+            (peer, Some(cleanup))
+        }
+        (_, Some(session)) => {
+            let peer = session
+                .peer
+                .ok_or_else(|| ApiError::InternalError("Inspector session peer is not available".into()))?;
+            (peer, None)
+        }
         _ => {
             {
                 let mut pool = state.connection_pool.lock().await;
@@ -494,10 +563,16 @@ async fn start_tool_call_internal(
     options.timeout = Some(timeout);
 
     let call_id = crate::generate_id!("inspcall");
-    let handle = peer
-        .send_cancellable_request(request, options)
-        .await
-        .map_err(|e| ApiError::InternalError(e.to_string()))?;
+    let mut native_cleanup_session = native_cleanup_session;
+    let handle = match peer.send_cancellable_request(request, options).await {
+        Ok(handle) => handle,
+        Err(err) => {
+            if let Some(cleanup) = native_cleanup_session.take() {
+                cleanup.cleanup().await;
+            }
+            return Err(ApiError::InternalError(err.to_string()));
+        }
+    };
 
     let RegisteredCall { info, completion } = state
         .inspector_calls
@@ -672,15 +747,19 @@ async fn list_capability_payload(
         InspectorMode::Native => {
             ensure_native_allowed()?;
             let server_id = resolve_server(&query.server_id, &query.server_name).await?;
-            let session_id = ensure_native_session(state, &server_id).await?;
+            let (session_id, cleanup) = native_validation_scope(state, &server_id, query.session_id.as_deref()).await?;
             let redb = state.redb_cache.clone();
             let pool = state.connection_pool.clone();
-            let database = state
-                .database
-                .as_ref()
-                .ok_or(ApiError::InternalError("Database not available".into()))?
-                .clone();
-            let (extracted, meta) = list_capability_via_components(
+            let database = match state.database.as_ref() {
+                Some(database) => database.clone(),
+                None => {
+                    if let Some(cleanup) = cleanup {
+                        cleanup.cleanup().await;
+                    }
+                    return Err(ApiError::InternalError("Database not available".into()));
+                }
+            };
+            let result = list_capability_via_components(
                 redb,
                 pool,
                 database,
@@ -690,7 +769,11 @@ async fn list_capability_payload(
                 Some(session_id),
                 extractor,
             )
-            .await?;
+            .await;
+            if let Some(cleanup) = cleanup {
+                cleanup.cleanup().await;
+            }
+            let (extracted, meta) = result?;
             items = extracted;
             meta_entries.push(meta);
         }
@@ -733,18 +816,20 @@ async fn list_capability_via_components(
 
 async fn cleanup_native_session(
     state: &AppState,
-    server_id: &str,
+    _server_id: &str,
     session_id: Option<&str>,
 ) {
     if let Some(session) = session_id {
-        let server_name = resolver::to_name(server_id)
-            .await
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| server_id.to_string());
-        let mut pool = state.connection_pool.lock().await;
-        let _ = pool.destroy_validation_instance(&server_name, session).await;
+        destroy_validation_session(&state.connection_pool, session).await;
     }
+}
+
+async fn destroy_validation_session(
+    connection_pool: &Arc<tokio::sync::Mutex<crate::core::pool::UpstreamConnectionPool>>,
+    session_id: &str,
+) {
+    let mut pool = connection_pool.lock().await;
+    let _ = pool.destroy_validation_session(session_id).await;
 }
 
 fn map_anyhow(e: anyhow::Error) -> ApiError {
@@ -799,8 +884,8 @@ fn ensure_native_allowed() -> Result<(), ApiError> {
 async fn ensure_native_session(
     state: &AppState,
     server_id: &str,
+    session_id: &str,
 ) -> Result<String, ApiError> {
-    let session_id = format!("inspector_native::{}", server_id);
     let server_name = resolver::to_name(server_id)
         .await
         .ok()
@@ -810,13 +895,144 @@ async fn ensure_native_session(
     {
         let mut pool = state.connection_pool.lock().await;
         pool.cleanup_expired_sessions();
-        pool.upsert_validation_session(&session_id, Duration::from_secs(300));
-        pool.get_or_create_validation_instance(&server_name, &session_id, Duration::from_secs(300))
+        pool.upsert_validation_session(session_id, NATIVE_VALIDATION_SESSION_TTL);
+        if let Err(err) = pool
+            .get_or_create_validation_instance(&server_name, session_id, NATIVE_VALIDATION_SESSION_TTL)
             .await
-            .map_err(map_anyhow)?;
+        {
+            let _ = pool.destroy_validation_session(session_id).await;
+            return Err(map_anyhow(err));
+        }
     }
 
-    Ok(session_id)
+    Ok(session_id.to_string())
+}
+
+fn native_session_id_for_inspector_session(session_id: &str) -> String {
+    format!("inspector_native_session::{session_id}")
+}
+
+fn native_temporary_session_id() -> String {
+    crate::generate_id!("inspnative")
+}
+
+async fn native_validation_session_for_request(
+    state: &AppState,
+    server_id: &str,
+    inspector_session_id: &str,
+) -> Result<String, ApiError> {
+    let session = state
+        .inspector_sessions
+        .get_session(inspector_session_id)
+        .await
+        .ok_or_else(|| {
+            ApiError::NotFound(format!(
+                "Inspector session '{}' not found or expired",
+                inspector_session_id
+            ))
+        })?;
+
+    if session.mode != InspectorMode::Native {
+        return Err(ApiError::BadRequest(
+            "Inspector session is bound to a different mode".into(),
+        ));
+    }
+    if session.server_id != server_id {
+        return Err(ApiError::BadRequest(
+            "Inspector session is bound to a different server".into(),
+        ));
+    }
+
+    let validation_session = session
+        .validation_session
+        .ok_or_else(|| ApiError::InternalError("Native Inspector session is missing validation ownership".into()))?;
+
+    // Native Inspector reuse is intentionally scoped to the explicit inspector
+    // session id. Do not reuse a live validation instance by server id alone:
+    // service deployments can have different users or organizations inspecting
+    // the same server concurrently, and MCP sessions can carry state. When
+    // auth/RBAC lands, extend this ownership boundary with actor/org scope.
+    let mut pool = state.connection_pool.lock().await;
+    if pool.refresh_validation_session(&validation_session, NATIVE_VALIDATION_SESSION_TTL) {
+        Ok(validation_session)
+    } else {
+        Err(ApiError::NotFound(format!(
+            "Native Inspector validation session '{}' not found or expired",
+            inspector_session_id
+        )))
+    }
+}
+
+async fn native_validation_scope(
+    state: &AppState,
+    server_id: &str,
+    inspector_session_id: Option<&str>,
+) -> Result<(String, Option<NativeValidationSessionGuard>), ApiError> {
+    if let Some(inspector_session_id) = inspector_session_id {
+        let validation_session = native_validation_session_for_request(state, server_id, inspector_session_id).await?;
+        return Ok((validation_session, None));
+    }
+
+    let validation_session = native_temporary_session_id();
+    ensure_native_session(state, server_id, &validation_session).await?;
+    let cleanup = NativeValidationSessionGuard::new(state, validation_session);
+    Ok((cleanup.session_id().to_string(), Some(cleanup)))
+}
+
+async fn acquire_validation_peer(
+    state: &AppState,
+    server_id: &str,
+    session_id: &str,
+) -> Result<Peer<RoleClient>, anyhow::Error> {
+    let server_name = resolver::to_name(server_id)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| server_id.to_string());
+
+    let mut pool_guard = state.connection_pool.lock().await;
+    let peer = pool_guard
+        .validation_sessions
+        .get(session_id)
+        .and_then(|session_servers| session_servers.get(&server_name))
+        .and_then(|conn| conn.service.as_ref())
+        .map(|service| service.peer().clone());
+
+    if let Some(peer) = peer {
+        if pool_guard.refresh_validation_session(session_id, NATIVE_VALIDATION_SESSION_TTL) {
+            return Ok(peer);
+        }
+    }
+
+    Err(anyhow!(
+        "Native Inspector session '{}' is no longer connected for server '{}'",
+        session_id,
+        server_id
+    ))
+}
+
+async fn clone_native_validation_connection(
+    state: &AppState,
+    server_id: &str,
+    session_id: &str,
+) -> Result<crate::core::pool::UpstreamConnection, ApiError> {
+    let server_name = resolver::to_name(server_id)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| server_id.to_string());
+    let mut pool = state.connection_pool.lock().await;
+    if !pool.refresh_validation_session(session_id, NATIVE_VALIDATION_SESSION_TTL) {
+        return Err(ApiError::NotFound(format!(
+            "Native Inspector validation session '{}' not found or expired",
+            session_id
+        )));
+    }
+    pool.validation_sessions
+        .get(session_id)
+        .and_then(|session| session.get(&server_name))
+        .cloned()
+        .ok_or_else(|| ApiError::InternalError("Validation connection not found".into()))
 }
 
 async fn acquire_peer_for_call(

--- a/backend/src/inspector/sessions.rs
+++ b/backend/src/inspector/sessions.rs
@@ -24,7 +24,7 @@ struct SessionEntry {
     session_id: String,
     server_id: String,
     mode: InspectorMode,
-    peer: Peer<RoleClient>,
+    peer: Option<Peer<RoleClient>>,
     validation_session: Option<String>,
     expires_at: Instant,
 }
@@ -39,7 +39,8 @@ pub struct ActiveSession {
     pub session_id: String,
     pub server_id: String,
     pub mode: InspectorMode,
-    pub peer: Peer<RoleClient>,
+    pub peer: Option<Peer<RoleClient>>,
+    pub validation_session: Option<String>,
 }
 
 impl InspectorSessionManager {
@@ -52,7 +53,7 @@ impl InspectorSessionManager {
         session_id: String,
         server_id: String,
         mode: InspectorMode,
-        peer: Peer<RoleClient>,
+        peer: Option<Peer<RoleClient>>,
         validation_session: Option<String>,
     ) -> InspectorSessionInfo {
         let now = Instant::now();
@@ -96,6 +97,7 @@ impl InspectorSessionManager {
                         server_id: entry.server_id.clone(),
                         mode: entry.mode,
                         peer: entry.peer.clone(),
+                        validation_session: entry.validation_session.clone(),
                     })
                 }
             } else {

--- a/backend/tests/inspector_smoke.rs
+++ b/backend/tests/inspector_smoke.rs
@@ -27,8 +27,11 @@ use mcpmate::system::metrics::MetricsCollector;
 
 const CREATE_SERVER_PATH: &str = "/api/mcp/servers/create";
 const TOOL_LIST_PATH: &str = "/api/mcp/inspector/tool/list";
+const TOOL_CALL_PATH: &str = "/api/mcp/inspector/tool/call";
 const RESOURCE_LIST_PATH: &str = "/api/mcp/inspector/resource/list";
 const RESOURCE_READ_PATH: &str = "/api/mcp/inspector/resource/read";
+const SESSION_OPEN_PATH: &str = "/api/mcp/inspector/session/open";
+const SESSION_CLOSE_PATH: &str = "/api/mcp/inspector/session/close";
 
 struct EnvVarGuard {
     key: &'static str,
@@ -216,6 +219,15 @@ async fn read_json_response(response: axum::response::Response) -> Value {
     body
 }
 
+async fn read_json_response_with_status(response: axum::response::Response) -> (axum::http::StatusCode, Value) {
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("response body");
+    let body: Value = serde_json::from_slice(&bytes).expect("json response");
+    (status, body)
+}
+
 fn json_post_request(
     uri: &str,
     body: Value,
@@ -256,6 +268,118 @@ fn data_u64(
     body.pointer(pointer)
         .and_then(Value::as_u64)
         .unwrap_or_else(|| panic!("expected u64 at {pointer}: {body}"))
+}
+
+async fn create_stdio_fixture_server(
+    app: &Router,
+    temp_dir: &TempDir,
+) -> String {
+    let fixture = write_stdio_fixture(temp_dir);
+    let python = which::which("python3").expect("python3 is required for stdio MCP fixture");
+    let create_req = json_post_request(
+        CREATE_SERVER_PATH,
+        json!({
+            "name": "inspector-fixture",
+            "server_type": "stdio",
+            "command": python.to_string_lossy(),
+            "args": [fixture.to_string_lossy()]
+        }),
+    );
+
+    let create_body = read_json_response(app.clone().oneshot(create_req).await.unwrap()).await;
+    assert_api_success(&create_body);
+    data_str(&create_body, "/data/id").to_string()
+}
+
+async fn open_native_session(
+    app: &Router,
+    server_id: &str,
+) -> String {
+    let open_body = read_json_response(
+        app.clone()
+            .oneshot(json_post_request(
+                SESSION_OPEN_PATH,
+                json!({
+                    "server_id": server_id,
+                    "mode": "native"
+                }),
+            ))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_api_success(&open_body);
+    data_str(&open_body, "/data/session_id").to_string()
+}
+
+async fn close_inspector_session(
+    app: &Router,
+    session_id: &str,
+) {
+    let close_body = read_json_response(
+        app.clone()
+            .oneshot(json_post_request(
+                SESSION_CLOSE_PATH,
+                json!({
+                    "session_id": session_id
+                }),
+            ))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_api_success(&close_body);
+    assert_eq!(close_body.pointer("/data/closed").and_then(Value::as_bool), Some(true));
+}
+
+async fn call_native_echo(
+    app: &Router,
+    server_id: &str,
+    session_id: &str,
+    message: &str,
+) {
+    let response = read_json_response(
+        app.clone()
+            .oneshot(json_post_request(
+                TOOL_CALL_PATH,
+                json!({
+                    "tool": "echo",
+                    "server_id": server_id,
+                    "mode": "native",
+                    "session_id": session_id,
+                    "timeout_ms": 5000,
+                    "arguments": { "message": message }
+                }),
+            ))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_api_success(&response);
+    assert_eq!(
+        data_str(&response, "/data/result/content/0/text"),
+        format!("echo: {message}")
+    );
+}
+
+fn native_validation_session_id(session_id: &str) -> String {
+    format!("inspector_native_session::{session_id}")
+}
+
+async fn validation_session_exists(
+    state: &Arc<AppState>,
+    session_id: &str,
+) -> bool {
+    let pool = state.connection_pool.lock().await;
+    pool.validation_sessions.contains_key(session_id)
+}
+
+async fn temporary_validation_session_count(state: &Arc<AppState>) -> usize {
+    let pool = state.connection_pool.lock().await;
+    pool.validation_sessions
+        .keys()
+        .filter(|session_id| session_id.starts_with("inspnative"))
+        .count()
 }
 
 #[tokio::test]
@@ -317,6 +441,67 @@ async fn inspector_create_server_is_immediately_usable_without_restart() {
     assert_eq!(
         data_str(&resource_read_body, "/data/result/contents/0/text"),
         "hello from resource"
+    );
+
+    mcpmate::core::capability::resolver::clear_cache().await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn inspector_native_list_and_call_reuse_explicit_session() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let state = build_database_state(&temp_dir).await;
+
+    let app = Router::new()
+        .route(CREATE_SERVER_PATH, post(server::create_server))
+        .route(TOOL_LIST_PATH, get(inspector::tools_list))
+        .route(TOOL_CALL_PATH, post(inspector::tool_call))
+        .route(SESSION_OPEN_PATH, post(inspector::session_open))
+        .route(SESSION_CLOSE_PATH, post(inspector::session_close))
+        .with_state(state.clone());
+
+    let server_id = create_stdio_fixture_server(&app, &temp_dir).await;
+    let session_id = open_native_session(&app, &server_id).await;
+    let validation_session = native_validation_session_id(&session_id);
+    assert!(validation_session_exists(&state, &validation_session).await);
+    assert_eq!(temporary_validation_session_count(&state).await, 0);
+
+    let session_list_req = get_request(format!(
+        "{TOOL_LIST_PATH}?server_id={server_id}&mode=native&session_id={session_id}&refresh=true"
+    ));
+    let session_list_body = read_json_response(app.clone().oneshot(session_list_req).await.unwrap()).await;
+    assert_api_success(&session_list_body);
+    assert_eq!(data_u64(&session_list_body, "/data/total"), 1);
+    assert!(validation_session_exists(&state, &validation_session).await);
+    assert_eq!(temporary_validation_session_count(&state).await, 0);
+
+    let stateless_list_req = get_request(format!(
+        "{TOOL_LIST_PATH}?server_id={server_id}&mode=native&refresh=true"
+    ));
+    let stateless_list_body = read_json_response(app.clone().oneshot(stateless_list_req).await.unwrap()).await;
+    assert_api_success(&stateless_list_body);
+    assert_eq!(data_u64(&stateless_list_body, "/data/total"), 1);
+    assert!(validation_session_exists(&state, &validation_session).await);
+    assert_eq!(temporary_validation_session_count(&state).await, 0);
+
+    call_native_echo(&app, &server_id, &session_id, "session-reuse").await;
+
+    close_inspector_session(&app, &session_id).await;
+    assert!(!validation_session_exists(&state, &validation_session).await);
+
+    let closed_session_list_req = get_request(format!(
+        "{TOOL_LIST_PATH}?server_id={server_id}&mode=native&session_id={session_id}&refresh=true"
+    ));
+    let (closed_status, closed_body) =
+        read_json_response_with_status(app.clone().oneshot(closed_session_list_req).await.unwrap()).await;
+    assert_eq!(closed_status, axum::http::StatusCode::NOT_FOUND);
+    assert!(
+        closed_body
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("not found or expired"),
+        "expected explicit closed session error: {closed_body}"
     );
 
     mcpmate::core::capability::resolver::clear_cache().await;

--- a/backend/tests/inspector_smoke.rs
+++ b/backend/tests/inspector_smoke.rs
@@ -32,6 +32,7 @@ const RESOURCE_LIST_PATH: &str = "/api/mcp/inspector/resource/list";
 const RESOURCE_READ_PATH: &str = "/api/mcp/inspector/resource/read";
 const SESSION_OPEN_PATH: &str = "/api/mcp/inspector/session/open";
 const SESSION_CLOSE_PATH: &str = "/api/mcp/inspector/session/close";
+const TEMPORARY_NATIVE_VALIDATION_SESSION_PREFIX: &str = "INSPNATIVE";
 
 struct EnvVarGuard {
     key: &'static str,
@@ -378,7 +379,9 @@ async fn temporary_validation_session_count(state: &Arc<AppState>) -> usize {
     let pool = state.connection_pool.lock().await;
     pool.validation_sessions
         .keys()
-        .filter(|session_id| session_id.starts_with("inspnative"))
+        .filter(|session_id| {
+            session_id.starts_with(TEMPORARY_NATIVE_VALIDATION_SESSION_PREFIX)
+        })
         .count()
 }
 

--- a/board/src/components/i18n/inspector.ts
+++ b/board/src/components/i18n/inspector.ts
@@ -66,9 +66,9 @@ export const inspectorTranslations = {
 			active: "Inspector session active",
 			pending: "Inspector session pending",
 			connected:
-				"Connected to {{serverName}}. Follow-up tools reuse this session required for chaining actions. Expires {{expiry}}.",
+				"Connected to {{serverName}}. Follow-up calls reuse this Inspect session for chaining actions. Expires {{expiry}}.",
 			notConnected:
-				"No inspector session yet. We create one automatically on the next run and keep it alive until you close the drawer.",
+				"No inspector session yet. List or Run creates one, then reuses it while you stay in Inspect mode. Leaving Inspect keeps it briefly before closing.",
 		},
 		notifications: {
 			executed: "Inspector executed",
@@ -166,9 +166,9 @@ export const inspectorTranslations = {
 			active: "检视器会话已激活",
 			pending: "检视器会话待激活",
 			connected:
-				"已连接到 {{serverName}}。后续工具将复用此会话以支持链式操作。过期时间：{{expiry}}。",
+				"已连接到 {{serverName}}。后续调用将复用此检视会话以支持链式操作。过期时间：{{expiry}}。",
 			notConnected:
-				"暂无检视器会话。我们将在下次运行时自动创建并保持活跃状态直到关闭抽屉。",
+				"暂无检视器会话。List 或 Run 会创建会话，并在 Inspect 模式内复用；离开 Inspect 后会短暂保留再关闭。",
 		},
 		notifications: {
 			executed: "检视器已执行",
@@ -268,9 +268,9 @@ export const inspectorTranslations = {
 			active: "インスペクターセッションがアクティブ",
 			pending: "インスペクターセッション待機中",
 			connected:
-				"{{serverName}} に接続済み。後続のツールはこのセッションを再利用してチェーン操作をサポートします。有効期限：{{expiry}}。",
+				"{{serverName}} に接続済み。後続の呼び出しはこの Inspect セッションを再利用してチェーン操作をサポートします。有効期限：{{expiry}}。",
 			notConnected:
-				"インスペクターセッションはまだありません。次回実行時に自動的に作成し、ドロワーを閉じるまで維持されます。",
+				"インスペクターセッションはまだありません。List または Run で作成し、Inspect モード中は再利用します。Inspect を離れると短時間保持してから閉じます。",
 		},
 		notifications: {
 			executed: "インスペクターが実行されました",

--- a/board/src/components/inspector-drawer.tsx
+++ b/board/src/components/inspector-drawer.tsx
@@ -7,12 +7,16 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { inspectorApi, systemApi } from "../lib/api";
+import {
+	inspectorApi,
+	isInspectorSessionUnavailableError,
+	systemApi,
+} from "../lib/api";
 import { writeClipboardText } from "../lib/clipboard";
 import { smartFormat } from "../lib/format";
 import { usePageTranslations } from "../lib/i18n/usePageTranslations";
 import { notifyError, notifySuccess } from "../lib/notify";
-import type { InspectorSessionOpenData, InspectorSseEvent } from "../lib/types";
+import type { InspectorSseEvent } from "../lib/types";
 import type {
 	CapabilityArgument,
 	CapabilityRecord,
@@ -57,7 +61,12 @@ export interface InspectorDrawerProps {
 	kind: InspectorKind;
 	item: CapabilityRecord | null;
 	mode: "proxy" | "native";
+	sessionId?: string;
+	sessionExpiresAtEpochMs?: number;
+	capabilityOptions?: CapabilityRecord[];
 	onLog?: (entry: InspectorLogEntry) => void;
+	onEnsureSession?: () => Promise<string | undefined>;
+	onSessionUnavailable?: () => void;
 }
 
 type Field = {
@@ -319,7 +328,12 @@ export function InspectorDrawer({
 	kind,
 	item,
 	mode,
+	sessionId,
+	sessionExpiresAtEpochMs,
+	capabilityOptions,
 	onLog,
+	onEnsureSession,
+	onSessionUnavailable,
 }: InspectorDrawerProps) {
 	const { t } = useTranslation("inspector");
 	usePageTranslations("inspector");
@@ -366,18 +380,15 @@ export function InspectorDrawer({
 	const [result, setResult] = useState<unknown>(null);
 	const [events, setEvents] = useState<InspectorEventEntry[]>([]);
 	const eventsEndRef = useRef<HTMLDivElement | null>(null);
-	const [session, setSession] = useState<InspectorSessionOpenData | null>(null);
 	const wsRef = useRef<WebSocket | null>(null);
 	const [activeCallId, setActiveCallId] = useState<string | null>(null);
 	const activeCallIdRef = useRef<string | null>(null);
-	const lastSessionParams = useRef<{
-		mode: "proxy" | "native";
-		serverId?: string;
-		serverName?: string;
-	} | null>(null);
 	const [capOptions, setCapOptions] = useState<CapabilityRecord[]>([]);
 	const [capOptionsLoading, setCapOptionsLoading] = useState(false);
 	const [capOptionsError, setCapOptionsError] = useState<string | null>(null);
+	const [ensuredSessionId, setEnsuredSessionId] = useState<string | undefined>(
+		undefined,
+	);
 	const [view, setView] = useState<"response" | "events">("response");
 
 	// combobox open/width is handled in CapabilityCombobox
@@ -448,10 +459,22 @@ export function InspectorDrawer({
 		if (!open) {
 			return;
 		}
+		if (capabilityOptions !== undefined) {
+			setCapOptions(capabilityOptions);
+			setCapOptionsLoading(false);
+			setCapOptionsError(null);
+			return;
+		}
 		// Reset when missing server context
 		if (!serverId && !serverName) {
 			setCapOptions([]);
 			setCapOptionsLoading(false);
+			setCapOptionsError(null);
+			return;
+		}
+		if (mode === "native" && !sessionId) {
+			setCapOptions([]);
+			setCapOptionsLoading(true);
 			setCapOptionsError(null);
 			return;
 		}
@@ -460,13 +483,16 @@ export function InspectorDrawer({
 		setCapOptionsError(null);
 		(async () => {
 			try {
+				const commonPayload = {
+					server_id: serverId,
+					server_name: serverName,
+					mode,
+					session_id: mode === "native" ? sessionId : undefined,
+				};
 				let resp: InspectorResponse<any> | undefined;
 				if (kind === "tool") {
-					resp = (await inspectorApi.toolsList({
-						server_id: serverId,
-						server_name: serverName,
-						mode,
-					})) as InspectorResponse<{ tools?: unknown[] }> | undefined;
+					resp = (await inspectorApi.toolsList(commonPayload)) as
+						InspectorResponse<{ tools?: unknown[] }> | undefined;
 					const rawList = Array.isArray(resp?.data?.tools)
 						? resp?.data?.tools
 						: [];
@@ -475,11 +501,8 @@ export function InspectorDrawer({
 						.filter(Boolean) as CapabilityRecord[];
 					if (!cancelled) setCapOptions(normalized);
 				} else if (kind === "prompt") {
-					resp = (await inspectorApi.promptsList({
-						server_id: serverId,
-						server_name: serverName,
-						mode,
-					})) as InspectorResponse<{ prompts?: unknown[] }> | undefined;
+					resp = (await inspectorApi.promptsList(commonPayload)) as
+						InspectorResponse<{ prompts?: unknown[] }> | undefined;
 					const rawList = Array.isArray(resp?.data?.prompts)
 						? resp?.data?.prompts
 						: [];
@@ -488,11 +511,8 @@ export function InspectorDrawer({
 						.filter(Boolean) as CapabilityRecord[];
 					if (!cancelled) setCapOptions(normalized);
 				} else if (kind === "resource") {
-					resp = (await inspectorApi.resourcesList({
-						server_id: serverId,
-						server_name: serverName,
-						mode,
-					})) as InspectorResponse<{ resources?: unknown[] }> | undefined;
+					resp = (await inspectorApi.resourcesList(commonPayload)) as
+						InspectorResponse<{ resources?: unknown[] }> | undefined;
 					const rawList = Array.isArray(resp?.data?.resources)
 						? resp?.data?.resources
 						: [];
@@ -501,11 +521,8 @@ export function InspectorDrawer({
 						.filter(Boolean) as CapabilityRecord[];
 					if (!cancelled) setCapOptions(normalized);
 				} else {
-					resp = (await inspectorApi.templatesList({
-						server_id: serverId,
-						server_name: serverName,
-						mode,
-					})) as InspectorResponse<{ templates?: unknown[] }> | undefined;
+					resp = (await inspectorApi.templatesList(commonPayload)) as
+						InspectorResponse<{ templates?: unknown[] }> | undefined;
 					const rawList = Array.isArray(resp?.data?.templates)
 						? resp?.data?.templates
 						: [];
@@ -529,93 +546,26 @@ export function InspectorDrawer({
 		return () => {
 			cancelled = true;
 		};
-	}, [open, kind, serverId, serverName, mode, propItemKey]);
+	}, [
+		capabilityOptions,
+		kind,
+		mode,
+		open,
+		propItemKey,
+		serverId,
+		serverName,
+		sessionId,
+	]);
 
 	useEffect(() => {
 		activeCallIdRef.current = activeCallId;
 	}, [activeCallId]);
 
 	useEffect(() => {
-		let cancelled = false;
-
-		const ensureSession = async () => {
-			if (!open || kind !== "tool") {
-				if (session) {
-					try {
-						await inspectorApi.sessionClose({ session_id: session.session_id });
-					} catch (error) {
-						console.warn("Failed to close inspector session", error);
-					}
-					if (!cancelled) {
-						setSession(null);
-					}
-				}
-				lastSessionParams.current = null;
-				return;
-			}
-
-			const params = { mode, serverId, serverName };
-
-			if (
-				session &&
-				lastSessionParams.current &&
-				lastSessionParams.current.mode === mode &&
-				lastSessionParams.current.serverId === serverId &&
-				lastSessionParams.current.serverName === serverName
-			) {
-				return;
-			}
-
-			if (session) {
-				try {
-					await inspectorApi.sessionClose({ session_id: session.session_id });
-				} catch (error) {
-					console.warn("Failed to close inspector session", error);
-				}
-				if (cancelled) return;
-				setSession(null);
-			}
-
-			try {
-				const response = await inspectorApi.sessionOpen({
-					mode,
-					server_id: serverId,
-					server_name: serverName,
-				});
-				if (!cancelled && response?.success && response.data) {
-					setSession(response.data);
-					lastSessionParams.current = params;
-				}
-			} catch (error) {
-				if (!cancelled) {
-					notifyError("Failed to open inspector session", String(error));
-					lastSessionParams.current = null;
-				}
-			}
-		};
-
-		void ensureSession();
-
-		return () => {
-			cancelled = true;
-		};
-	}, [open, kind, mode, serverId, serverName, session]);
-
-	useEffect(() => {
-		return () => {
-			if (wsRef.current) {
-				wsRef.current.close();
-				wsRef.current = null;
-			}
-			if (session) {
-				void inspectorApi
-					.sessionClose({ session_id: session.session_id })
-					.catch((error) =>
-						console.warn("Failed to close inspector session", error),
-					);
-			}
-		};
-	}, [session]);
+		if (mode !== "native" || sessionId) {
+			setEnsuredSessionId(undefined);
+		}
+	}, [mode, sessionId]);
 
 	useEffect(() => {
 		if (!open && wsRef.current) {
@@ -955,15 +905,14 @@ export function InspectorDrawer({
 	const hasFieldInputs = fields.length > 0;
 	const expectsArguments =
 		kind !== "resource" && (hasSchemaInputs || hasFieldInputs);
-	const sessionExpiry = useMemo(() => {
-		if (!session?.expires_at_epoch_ms) return null;
-		const ms = Number(session.expires_at_epoch_ms);
+	const sessionExpiry = (() => {
+		const ms = Number(sessionExpiresAtEpochMs ?? NaN);
 		if (!Number.isFinite(ms)) return null;
 		return new Date(ms).toLocaleTimeString([], {
 			hour: "2-digit",
 			minute: "2-digit",
 		});
-	}, [session]);
+	})();
 
 	const handleInspectorEvent = useCallback(
 		(payload: InspectorSseEvent) => {
@@ -1153,6 +1102,14 @@ export function InspectorDrawer({
 				channel: "inspector" as const,
 				mode,
 			};
+			const effectiveSessionId =
+				mode === "native" ? sessionId ?? (await onEnsureSession?.()) : undefined;
+			if (mode === "native" && !effectiveSessionId) {
+				throw new Error(t("errors.sessionMissing"));
+			}
+			if (mode === "native" && effectiveSessionId && !sessionId) {
+				setEnsuredSessionId(effectiveSessionId);
+			}
 			if (kind === "tool") {
 				const args = expectsArguments
 					? useRaw
@@ -1161,7 +1118,7 @@ export function InspectorDrawer({
 					: undefined;
 				if (expectsArguments && args === undefined) return;
 
-				const effectiveServerId = session?.server_id ?? serverId;
+				const effectiveServerId = serverId;
 				if (!effectiveServerId && !serverName) {
 					throw new Error(t("errors.sessionMissing"));
 				}
@@ -1176,7 +1133,7 @@ export function InspectorDrawer({
 						server_name: serverName,
 						arguments: args,
 						timeout_ms: timeoutMs,
-						session_id: session?.session_id,
+						session_id: effectiveSessionId,
 					},
 				});
 
@@ -1187,7 +1144,7 @@ export function InspectorDrawer({
 					mode,
 					arguments: args,
 					timeout_ms: timeoutMs,
-					session_id: session?.session_id,
+					session_id: effectiveSessionId,
 				});
 
 				const data = response?.data ?? null;
@@ -1217,6 +1174,7 @@ export function InspectorDrawer({
 						server_id: serverId,
 						server_name: serverName,
 						arguments: args,
+						session_id: effectiveSessionId,
 					},
 				});
 				resp = (await inspectorApi.promptGet({
@@ -1225,6 +1183,7 @@ export function InspectorDrawer({
 					server_name: serverName,
 					mode,
 					arguments: args,
+					session_id: effectiveSessionId,
 				})) as InspectorResponse<Record<string, unknown>>;
 				if (!resp?.success) {
 					throw new Error(
@@ -1269,12 +1228,14 @@ export function InspectorDrawer({
 						arguments: args,
 						server_id: serverId,
 						server_name: serverName,
+						session_id: effectiveSessionId,
 					},
 				});
 				resp = (await inspectorApi.resourceRead({
 					uri: generatedUri,
 					server_id: serverId,
 					server_name: serverName,
+					session_id: effectiveSessionId,
 					mode,
 				})) as InspectorResponse<Record<string, unknown>>;
 				if (!resp?.success) {
@@ -1299,12 +1260,18 @@ export function InspectorDrawer({
 					...baseLog,
 					event: "request",
 					method: "resources/read",
-					payload: { uri, server_id: serverId, server_name: serverName },
+					payload: {
+						uri,
+						server_id: serverId,
+						server_name: serverName,
+						session_id: effectiveSessionId,
+					},
 				});
 				resp = (await inspectorApi.resourceRead({
 					uri,
 					server_id: serverId,
 					server_name: serverName,
+					session_id: effectiveSessionId,
 					mode,
 				})) as InspectorResponse<Record<string, unknown>>;
 				if (!resp?.success) {
@@ -1326,6 +1293,10 @@ export function InspectorDrawer({
 				);
 			}
 		} catch (e) {
+			if (mode === "native" && isInspectorSessionUnavailableError(e)) {
+				setEnsuredSessionId(undefined);
+				onSessionUnavailable?.();
+			}
 			onLog?.({
 				id: newLogId(),
 				timestamp: Date.now(),
@@ -1374,7 +1345,8 @@ export function InspectorDrawer({
 		}
 	}, [result, t]);
 
-	const sessionActive = Boolean(session);
+	const displaySessionId = sessionId ?? ensuredSessionId;
+	const sessionActive = Boolean(displaySessionId);
 	const sessionIndicator =
 		kind === "tool" ? (
 			<TooltipProvider delayDuration={150}>
@@ -1402,7 +1374,7 @@ export function InspectorDrawer({
 						{sessionActive ? (
 							<p>
 								{t("session.connected", {
-									serverName: serverName || session?.server_id,
+									serverName: serverName || serverId,
 									expiry: sessionExpiry ?? "soon",
 								})}
 							</p>

--- a/board/src/lib/api.ts
+++ b/board/src/lib/api.ts
@@ -391,6 +391,19 @@ export function isApiNotFoundError(error: unknown): boolean {
 	return /\b404\b/.test(error.message);
 }
 
+export function isInspectorSessionUnavailableError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+	const message = error.message.toLowerCase();
+	return (
+		(message.includes("inspector session") ||
+			message.includes("native inspector validation session")) &&
+		(message.includes("not found or expired") ||
+			message.includes("no longer connected"))
+	);
+}
+
 const toTrimmedString = (value: unknown): string | undefined => {
 	if (typeof value !== "string") return undefined;
 	const trimmed = value.trim();
@@ -1293,12 +1306,14 @@ export const inspectorApi = {
 	toolsList: (q: {
 		server_id?: string;
 		server_name?: string;
+		session_id?: string;
 		mode?: "proxy" | "native";
 		refresh?: boolean;
 	}) => {
 		const qs = new URLSearchParams();
 		if (q.server_id) qs.set("server_id", q.server_id);
 		if (q.server_name) qs.set("server_name", q.server_name);
+		if (q.session_id) qs.set("session_id", q.session_id);
 		if (q.mode) qs.set("mode", q.mode);
 		if (q.refresh != null) qs.set("refresh", String(q.refresh));
 		return fetchApi(`/api/mcp/inspector/tool/list?${qs}`);
@@ -1310,6 +1325,7 @@ export const inspectorApi = {
 		arguments?: Record<string, unknown>;
 		mode?: "proxy" | "native";
 		timeout_ms?: number;
+		session_id?: string;
 	}) =>
 		fetchApi(`/api/mcp/inspector/tool/call`, {
 			method: "POST",
@@ -1366,12 +1382,14 @@ export const inspectorApi = {
 	resourcesList: (q: {
 		server_id?: string;
 		server_name?: string;
+		session_id?: string;
 		mode?: "proxy" | "native";
 		refresh?: boolean;
 	}) => {
 		const qs = new URLSearchParams();
 		if (q.server_id) qs.set("server_id", q.server_id);
 		if (q.server_name) qs.set("server_name", q.server_name);
+		if (q.session_id) qs.set("session_id", q.session_id);
 		if (q.mode) qs.set("mode", q.mode);
 		if (q.refresh != null) qs.set("refresh", String(q.refresh));
 		return fetchApi(`/api/mcp/inspector/resource/list?${qs}`);
@@ -1380,23 +1398,27 @@ export const inspectorApi = {
 		uri: string;
 		server_id?: string;
 		server_name?: string;
+		session_id?: string;
 		mode?: "proxy" | "native";
 	}) => {
 		const qs = new URLSearchParams({ uri: q.uri });
 		if (q.server_id) qs.set("server_id", q.server_id);
 		if (q.server_name) qs.set("server_name", q.server_name);
+		if (q.session_id) qs.set("session_id", q.session_id);
 		if (q.mode) qs.set("mode", q.mode);
 		return fetchApi(`/api/mcp/inspector/resource/read?${qs}`);
 	},
 	promptsList: (q: {
 		server_id?: string;
 		server_name?: string;
+		session_id?: string;
 		mode?: "proxy" | "native";
 		refresh?: boolean;
 	}) => {
 		const qs = new URLSearchParams();
 		if (q.server_id) qs.set("server_id", q.server_id);
 		if (q.server_name) qs.set("server_name", q.server_name);
+		if (q.session_id) qs.set("session_id", q.session_id);
 		if (q.mode) qs.set("mode", q.mode);
 		if (q.refresh != null) qs.set("refresh", String(q.refresh));
 		return fetchApi(`/api/mcp/inspector/prompt/list?${qs}`);
@@ -1405,6 +1427,7 @@ export const inspectorApi = {
 		name: string;
 		server_id?: string;
 		server_name?: string;
+		session_id?: string;
 		arguments?: Record<string, unknown>;
 		mode?: "proxy" | "native";
 	}) =>
@@ -1415,12 +1438,14 @@ export const inspectorApi = {
 	templatesList: (q: {
 		server_id?: string;
 		server_name?: string;
+		session_id?: string;
 		mode?: "proxy" | "native";
 		refresh?: boolean;
 	}) => {
 		const qs = new URLSearchParams();
 		if (q.server_id) qs.set("server_id", q.server_id);
 		if (q.server_name) qs.set("server_name", q.server_name);
+		if (q.session_id) qs.set("session_id", q.session_id);
 		if (q.mode) qs.set("mode", q.mode);
 		if (q.refresh != null) qs.set("refresh", String(q.refresh));
 		return fetchApi(`/api/mcp/inspector/template/list?${qs}`);

--- a/board/src/pages/servers/server-detail-page.tsx
+++ b/board/src/pages/servers/server-detail-page.tsx
@@ -57,7 +57,13 @@ import {
 	TabsList,
 	TabsTrigger,
 } from "../../components/ui/tabs";
-import { auditApi, configSuitsApi, inspectorApi, serversApi } from "../../lib/api";
+import {
+	auditApi,
+	configSuitsApi,
+	inspectorApi,
+	isInspectorSessionUnavailableError,
+	serversApi,
+} from "../../lib/api";
 import { smartFormat } from "../../lib/format";
 import { writeClipboardText } from "../../lib/clipboard";
 import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
@@ -66,6 +72,7 @@ import { maskHeaderValue, sanitizeRecord } from "../../lib/security";
 import { useAppStore } from "../../lib/store";
 import { useUrlTab } from "../../lib/hooks/use-url-state";
 import type {
+	InspectorSessionOpenData,
 	ServerCapabilitySummary,
 	ServerDetail,
 } from "../../lib/types";
@@ -105,6 +112,7 @@ interface InspectorListResponse {
 		tools?: CapabilityRecord[];
 		resources?: CapabilityRecord[];
 		prompts?: CapabilityRecord[];
+		templates?: CapabilityRecord[];
 		items?: CapabilityRecord[];
 		meta?: unknown;
 		state?: string;
@@ -115,6 +123,7 @@ interface InspectorListResponse {
 interface InspectorListParams {
 	server_id: string;
 	server_name?: string;
+	session_id?: string;
 	mode: InspectorChannel;
 	refresh: boolean;
 }
@@ -129,6 +138,7 @@ const VIEW_MODES = {
 	browse: "browse" as const,
 	debug: "debug" as const,
 };
+const INSPECT_SESSION_GRACE_MS = 30_000;
 
 type InspectorChannel = "proxy" | "native";
 type DebugKind = "tools" | "resources" | "prompts";
@@ -215,6 +225,13 @@ export function ServerDetailPage() {
 		prompts: createDebugState(),
 		templates: createDebugState(),
 	});
+	const [inspectSession, setInspectSession] =
+		useState<InspectorSessionOpenData | null>(null);
+	const inspectSessionRef = useRef<InspectorSessionOpenData | null>(null);
+	const inspectSessionCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const mountedRef = useRef(true);
 
 	const {
 		data: server,
@@ -545,6 +562,140 @@ export function ServerDetailPage() {
 		});
 	}, []);
 
+	useEffect(() => {
+		inspectSessionRef.current = inspectSession;
+	}, [inspectSession]);
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
+
+	const clearInspectSessionCloseTimer = useCallback(() => {
+		if (inspectSessionCloseTimer.current) {
+			clearTimeout(inspectSessionCloseTimer.current);
+			inspectSessionCloseTimer.current = null;
+		}
+	}, []);
+
+	const closeInspectSession = useCallback(
+		async (session: InspectorSessionOpenData) => {
+			try {
+				await inspectorApi.sessionClose({ session_id: session.session_id });
+			} catch (error) {
+				console.warn("Failed to close inspector session", error);
+			}
+			if (
+				mountedRef.current &&
+				inspectSessionRef.current?.session_id === session.session_id
+			) {
+				setInspectSession(null);
+				inspectSessionRef.current = null;
+			}
+		},
+		[],
+	);
+
+	const invalidateInspectSession = useCallback(() => {
+		clearInspectSessionCloseTimer();
+		const current = inspectSessionRef.current;
+		inspectSessionRef.current = null;
+		if (mountedRef.current) {
+			setInspectSession(null);
+		}
+		if (current) {
+			void closeInspectSession(current);
+		}
+	}, [clearInspectSessionCloseTimer, closeInspectSession]);
+
+	const scheduleInspectSessionClose = useCallback(
+		(session: InspectorSessionOpenData) => {
+			clearInspectSessionCloseTimer();
+			inspectSessionCloseTimer.current = setTimeout(() => {
+				void closeInspectSession(session);
+			}, INSPECT_SESSION_GRACE_MS);
+		},
+		[clearInspectSessionCloseTimer, closeInspectSession],
+	);
+
+	const ensureInspectSession = useCallback(async (): Promise<
+		string | undefined
+	> => {
+		if (viewMode !== VIEW_MODES.debug || channel !== "native" || !serverId) {
+			return undefined;
+		}
+		clearInspectSessionCloseTimer();
+
+		const current = inspectSessionRef.current;
+		if (current?.mode === "native" && current.server_id === serverId) {
+			return current.session_id;
+		}
+
+		if (current) {
+			await closeInspectSession(current);
+		}
+
+		const response = await inspectorApi.sessionOpen({
+			mode: "native",
+			server_id: serverId,
+			server_name: server?.name,
+		});
+		if (!response?.success || !response.data) {
+			throw new Error(
+				response?.error ? String(response.error) : "Failed to open inspector session",
+			);
+		}
+
+		if (mountedRef.current) {
+			setInspectSession(response.data);
+		}
+		inspectSessionRef.current = response.data;
+		return response.data.session_id;
+	}, [
+		channel,
+		clearInspectSessionCloseTimer,
+		closeInspectSession,
+		server?.name,
+		serverId,
+		viewMode,
+	]);
+
+	useEffect(() => {
+		const current = inspectSessionRef.current;
+		if (!current) {
+			return;
+		}
+
+		const shouldKeepInspectSession =
+			viewMode === VIEW_MODES.debug &&
+			channel === "native" &&
+			current.server_id === serverId;
+
+		if (shouldKeepInspectSession) {
+			clearInspectSessionCloseTimer();
+			return;
+		}
+
+		scheduleInspectSessionClose(current);
+	}, [
+		channel,
+		clearInspectSessionCloseTimer,
+		scheduleInspectSessionClose,
+		serverId,
+		viewMode,
+	]);
+
+	useEffect(() => {
+		return () => {
+			const current = inspectSessionRef.current;
+			if (current) {
+				scheduleInspectSessionClose(current);
+			}
+		};
+	}, [scheduleInspectSessionClose]);
+
 	const clearLogsByPrefix = useCallback((prefix: string) => {
 		setLogs((prev) => prev.filter((entry) => !entry.method.startsWith(prefix)));
 	}, []);
@@ -582,45 +733,48 @@ export function ServerDetailPage() {
 						: kind === "prompts"
 							? "prompts/list"
 							: "templates/list";
-			const requestPayload: InspectorListParams = {
-				server_id: serverId,
-				mode: channel,
-				refresh: true,
+
+			const buildRequestPayload = (
+				nextSessionId?: string,
+			): InspectorListParams => {
+				const payload: InspectorListParams = {
+					server_id: serverId,
+					mode: channel,
+					refresh: true,
+				};
+				if (server?.name) payload.server_name = server.name;
+				if (nextSessionId) payload.session_id = nextSessionId;
+				return payload;
 			};
-			if (server?.name) requestPayload.server_name = server.name;
 
-			updateDebugState(kind, { loading: true, error: null });
-			pushLog({
-				id: makeLogId(),
-				timestamp: Date.now(),
-				channel: "inspector",
-				event: "request",
-				method,
-				mode: channel,
-				payload: requestPayload,
-			});
-
-			try {
+			const requestList = async (
+				payload: InspectorListParams,
+			): Promise<CapabilityRecord[]> => {
 				let resp: InspectorListResponse | undefined;
 				if (kind === "tools") {
-					resp = (await inspectorApi.toolsList(
-						requestPayload,
-					)) as InspectorListResponse;
+					resp = (await inspectorApi.toolsList(payload)) as InspectorListResponse;
 				} else if (kind === "resources") {
 					resp = (await inspectorApi.resourcesList(
-						requestPayload,
+						payload,
 					)) as InspectorListResponse;
 				} else if (kind === "prompts") {
 					resp = (await inspectorApi.promptsList(
-						requestPayload,
+						payload,
 					)) as InspectorListResponse;
 				} else {
 					resp = (await inspectorApi.templatesList(
-						requestPayload,
+						payload,
 					)) as InspectorListResponse;
 				}
-				const data = resp?.data ?? {};
-				const list: CapabilityRecord[] = Array.isArray(data.items)
+
+				if (!resp?.success) {
+					throw new Error(
+						resp?.error ? String(resp.error) : "Inspector list failed",
+					);
+				}
+
+				const data = resp.data ?? {};
+				return Array.isArray(data.items)
 					? data.items
 					: Array.isArray(data.tools)
 						? data.tools
@@ -628,9 +782,24 @@ export function ServerDetailPage() {
 							? data.resources
 							: Array.isArray(data.prompts)
 								? data.prompts
-								: Array.isArray((data as any).templates)
-									? (data as any).templates
+								: Array.isArray(data.templates)
+									? data.templates
 									: [];
+			};
+
+			const pushRequestLog = (payload: InspectorListParams) => {
+				pushLog({
+					id: makeLogId(),
+					timestamp: Date.now(),
+					channel: "inspector",
+					event: "request",
+					method,
+					mode: channel,
+					payload,
+				});
+			};
+
+			const commitSuccess = (list: CapabilityRecord[]) => {
 				updateDebugState(kind, {
 					loading: false,
 					error: null,
@@ -647,7 +816,9 @@ export function ServerDetailPage() {
 					mode: channel,
 					payload: { count: list.length },
 				});
-			} catch (error) {
+			};
+
+			const commitError = (error: unknown) => {
 				const message = error instanceof Error ? error.message : String(error);
 				updateDebugState(kind, { loading: false, error: message });
 				pushLog({
@@ -660,16 +831,56 @@ export function ServerDetailPage() {
 					message,
 					payload: error,
 				});
+			};
+
+			updateDebugState(kind, { loading: true, error: null });
+
+			let sessionId: string | undefined;
+			if (channel === "native") {
+				try {
+					sessionId = await ensureInspectSession();
+				} catch (error) {
+					commitError(error);
+					return;
+				}
+			}
+			let requestPayload = buildRequestPayload(sessionId);
+
+			pushRequestLog(requestPayload);
+
+			try {
+				commitSuccess(await requestList(requestPayload));
+			} catch (error) {
+				if (
+					channel === "native" &&
+					sessionId &&
+					isInspectorSessionUnavailableError(error)
+				) {
+					invalidateInspectSession();
+					try {
+						sessionId = await ensureInspectSession();
+						requestPayload = buildRequestPayload(sessionId);
+						pushRequestLog(requestPayload);
+						commitSuccess(await requestList(requestPayload));
+						return;
+					} catch (retryError) {
+						commitError(retryError);
+						return;
+					}
+				}
+				commitError(error);
 			}
 		},
 		[
 			channel,
+			ensureInspectSession,
+			invalidateInspectSession,
 			proxyAvailable,
 			pushLog,
 			server?.name,
 			serverId,
-			updateDebugState,
 			t,
+			updateDebugState,
 		],
 	);
 
@@ -679,6 +890,23 @@ export function ServerDetailPage() {
 		},
 		[],
 	);
+
+	const inspectorCapabilityOptions = useMemo<CapabilityRecord[] | undefined>(() => {
+		if (!inspector || viewMode !== VIEW_MODES.debug) {
+			return undefined;
+		}
+		if (inspector.kind === "tool") {
+			return debugData.tools.fetched ? debugData.tools.items : undefined;
+		}
+		if (inspector.kind === "resource") {
+			return debugData.resources.fetched ? debugData.resources.items : undefined;
+		}
+		if (inspector.kind === "prompt") {
+			return debugData.prompts.fetched ? debugData.prompts.items : undefined;
+		}
+		return debugData.templates.fetched ? debugData.templates.items : undefined;
+	}, [debugData, inspector, viewMode]);
+
 	const handleServerLogsNextPage = () => {
 		if (!serverLogsQuery.data?.next_cursor) return;
 		const nextCursor = serverLogsQuery.data.next_cursor;
@@ -1462,7 +1690,14 @@ export function ServerDetailPage() {
 				kind={inspector?.kind ?? "tool"}
 				item={inspector?.item ?? null}
 				mode={channel}
+				sessionId={channel === "native" ? inspectSession?.session_id : undefined}
+				sessionExpiresAtEpochMs={
+					channel === "native" ? inspectSession?.expires_at_epoch_ms : undefined
+				}
+				capabilityOptions={inspectorCapabilityOptions}
 				onLog={pushLog}
+				onEnsureSession={ensureInspectSession}
+				onSessionUnavailable={invalidateInspectSession}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Add explicit native Inspector session reuse across list, tool call, prompt get, and resource read flows.
- Keep native validation instances alive for the Inspect session lifetime and clean them up when the session closes.
- Update Board so the session starts on first List or Run, then reuses the same session in the Inspector drawer.
- Keep the drawer session indicator aligned with List-created sessions, including React StrictMode in development.

## User impact
- Users no longer pay the startup cost every time they open the Inspector drawer.
- Native Inspect flows can preserve session continuity between listing capabilities and running follow-up tool calls.
- The UI now avoids showing a capability list while simultaneously claiming there is no Inspect session.

## Validation
- Rebased on latest origin/main.
- Loocor completed local UAT before PR creation.
- Additional local validation was intentionally stopped per owner request; remaining review is left to GitHub Copilot review.

Fixes #19