### PR TITLE
fix(client): align attach/detach lifecycle with file-verified guards

### DIFF
--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -1040,7 +1040,7 @@ pub async fn client_detach(
 ) -> Result<Json<ClientDetachResp>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let existing_state = service.fetch_state(&request.identifier).await.map_err(|err| {
+    let existing_state = service.fetch_state_repairing_local_target(&request.identifier).await.map_err(|err| {
         tracing::error!(client = %request.identifier, error = %err, "Failed to load client state before detach");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -1131,7 +1131,7 @@ pub async fn client_attach(
 ) -> Result<Json<ClientAttachResp>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let existing_state = service.fetch_state(&request.identifier).await.map_err(|err| {
+    let existing_state = service.fetch_state_repairing_local_target(&request.identifier).await.map_err(|err| {
         tracing::error!(client = %request.identifier, error = %err, "Failed to load client state before attach");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -3,7 +3,9 @@
 use super::backups::parse_policy_payload;
 use super::inspection::{
     build_config_file_parse_inspect_data, build_parse_metadata, configured_server_entries_data,
-    derive_attachment_state, detect_mcpmate_in_client_config, inspect_client_config_lenient,
+    ClientFileGuardRejection, derive_attachment_state, detect_mcpmate_in_client_config,
+    attachment_state_drift_reason, evaluate_client_attach_file_guard, evaluate_client_detach_file_guard,
+    inspect_client_config_lenient,
     mark_configured_server_managed_status, parse_api_transports, parse_rule_from_api_data, transports_data_from_state,
 };
 use super::runtime::sync_bound_client_runtime_state;
@@ -227,10 +229,16 @@ pub async fn config_details(
 ) -> Result<Json<ClientConfigResp>, StatusCode> {
     let service = get_client_service(&app_state)?;
     let state = service
-        .fetch_state(&request.identifier)
+        .fetch_state_repairing_local_target(&request.identifier)
         .await
-        .ok()
-        .flatten()
+        .map_err(|err| {
+            tracing::error!(
+                client = %request.identifier,
+                error = %err,
+                "Failed to load client state for config details"
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
         .ok_or_else(|| {
             tracing::error!("Failed to resolve client config details for {}", request.identifier);
             StatusCode::NOT_FOUND
@@ -291,6 +299,9 @@ pub async fn config_details(
         .as_ref()
         .map(configured_server_entries_data)
         .unwrap_or_default();
+    if let Some(reason) = attachment_state_drift_reason(&state, &configured_servers_analysis) {
+        degraded_reasons.push(reason.to_string());
+    }
     if let Some(database) = app_state.database.as_ref() {
         mark_configured_server_managed_status(&database.pool, &mut configured_server_entries)
             .await
@@ -650,6 +661,35 @@ fn map_config_error_status(err: &ConfigError) -> StatusCode {
     }
 }
 
+fn client_file_guard_warnings(
+    guard: Result<Option<&'static str>, ClientFileGuardRejection>,
+    operation: &'static str,
+    identifier: &str,
+    attachment_state: AttachmentState,
+) -> Result<Vec<String>, StatusCode> {
+    match guard {
+        Ok(Some(warning)) => Ok(vec![warning.to_string()]),
+        Ok(None) => Ok(Vec::new()),
+        Err(ClientFileGuardRejection::UndetectableFile) => {
+            tracing::warn!(
+                client = %identifier,
+                operation,
+                "Rejected client file guard: config file state undetectable"
+            );
+            Err(StatusCode::BAD_REQUEST)
+        }
+        Err(ClientFileGuardRejection::NonApplicableDbState) => {
+            tracing::warn!(
+                client = %identifier,
+                operation,
+                attachment = ?attachment_state,
+                "Rejected client file guard: non-applicable DB state"
+            );
+            Err(StatusCode::BAD_REQUEST)
+        }
+    }
+}
+
 /// Handler for POST /api/client/config/restore
 /// Restores configuration from a named backup snapshot
 pub async fn config_restore(
@@ -1000,23 +1040,26 @@ pub async fn client_detach(
 ) -> Result<Json<ClientDetachResp>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let mut warnings: Vec<String> = Vec::new();
+    let existing_state = service.fetch_state(&request.identifier).await.map_err(|err| {
+        tracing::error!(client = %request.identifier, error = %err, "Failed to load client state before detach");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
-    // Conflict detection: check if MCPMate is actually present before detaching
-    if let Some(state) = service.fetch_state(&request.identifier).await.ok().flatten() {
-        if let Some(present) = detect_mcpmate_in_client_config(service.as_ref(), &state).await {
-            if !present {
-                warnings
-                    .push("MCPMate entry not found in config file; detach has no effect on file content".to_string());
-            }
-        }
-    }
+    let Some(state) = existing_state.as_ref() else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    let attachment_state = state.attachment_state();
+    let mcpmate_present = detect_mcpmate_in_client_config(service.as_ref(), state).await;
+    let warnings = client_file_guard_warnings(
+        evaluate_client_detach_file_guard(mcpmate_present, attachment_state),
+        "detach",
+        &request.identifier,
+        attachment_state,
+    )?;
 
     let changed = service.detach_client(&request.identifier).await.map_err(|err| {
-        let status = match err {
-            ConfigError::DataAccessError(_) | ConfigError::PathResolutionError(_) => StatusCode::BAD_REQUEST,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
-        };
+        let status = map_config_error_status(&err);
         tracing::error!(client = %request.identifier, status = %status.as_u16(), error = %err, "Failed to detach client");
         status
     })?;
@@ -1097,22 +1140,14 @@ pub async fn client_attach(
         return Err(StatusCode::NOT_FOUND);
     };
 
-    // Conflict detection: check if MCPMate already present in config file
-    let mut warnings: Vec<String> = Vec::new();
-    if let Some(present) = detect_mcpmate_in_client_config(service.as_ref(), state).await {
-        if present {
-            warnings.push("MCPMate entry already present in config file; attach will overwrite".to_string());
-        }
-    }
-
-    if state.attachment_state() != AttachmentState::Detached {
-        tracing::warn!(
-            client = %request.identifier,
-            attachment = ?state.attachment_state(),
-            "Rejected client attach while not detached"
-        );
-        return Err(StatusCode::BAD_REQUEST);
-    }
+    let attachment_state = state.attachment_state();
+    let mcpmate_present = detect_mcpmate_in_client_config(service.as_ref(), state).await;
+    let warnings = client_file_guard_warnings(
+        evaluate_client_attach_file_guard(mcpmate_present, attachment_state),
+        "attach",
+        &request.identifier,
+        attachment_state,
+    )?;
 
     let effective_mode = service.get_effective_config_mode(&request.identifier).await.map_err(|err| {
         tracing::error!(client = %request.identifier, error = %err, "Failed to resolve effective config mode for attach");
@@ -1416,6 +1451,9 @@ fn map_mode(mode: ClientConfigMode) -> ConfigMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::handlers::client::inspection::{
+        ATTACH_OVERWRITE_WARNING, DETACH_NO_EFFECT_WARNING,
+    };
     use crate::api::models::client::{ClientConfigFileParseData, ClientFormatRuleData, ClientSettingsUpdateReq};
     use crate::api::routes::AppState;
     use crate::clients::models::{ClientConfigFileState, ClientRegistrationOrigin};
@@ -1636,6 +1674,60 @@ mod tests {
             selected: Some(true),
             ..Default::default()
         }
+    }
+
+    async fn seed_runtime_attachable_client(
+        context: &TestContext,
+        identifier: &str,
+        config_path: &std::path::Path,
+    ) -> serde_json::Value {
+        use crate::api::models::client::ClientBackupPolicyPayload;
+
+        tokio::fs::write(config_path, "{}")
+            .await
+            .expect("seed runtime client config file");
+
+        let Json(update_response) = update_settings(
+            State(context.app_state.clone()),
+            Json(ClientSettingsUpdateReq {
+                config_mode: Some("hosted".to_string()),
+                transport: Some("streamable_http".to_string()),
+                display_name: Some("Runtime Attach Client".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
+                config_path: Some(config_path.to_string_lossy().to_string()),
+                config_file_parse: Some(json_object_parse("mcpServers")),
+                transports: Some(HashMap::from([("streamable_http".to_string(), streamable_http_rule())])),
+                ..settings_update_req(identifier)
+            }),
+        )
+        .await
+        .expect("update runtime attachable client");
+
+        assert!(update_response.success);
+
+        let Json(apply_response) = config_apply(
+            State(context.app_state.clone()),
+            Json(ClientConfigUpdateReq {
+                identifier: identifier.to_string(),
+                mode: ClientConfigMode::Hosted,
+                preview: false,
+                selected_config: ClientConfigSelected::Default,
+                backup_policy: Some(ClientBackupPolicyPayload {
+                    policy: "off".to_string(),
+                    limit: None,
+                }),
+            }),
+        )
+        .await
+        .expect("apply runtime attachable client config");
+
+        assert!(apply_response.success);
+        assert!(apply_response.data.expect("apply data").applied);
+
+        let written = tokio::fs::read_to_string(config_path)
+            .await
+            .expect("read applied config");
+        serde_json::from_str(&written).expect("parse applied config")
     }
 
     #[tokio::test]
@@ -3981,4 +4073,235 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), StatusCode::FORBIDDEN);
     }
+
+    #[tokio::test]
+    async fn client_attach_allows_reattach_when_file_already_contains_mcpmate() {
+        let context = create_test_context().await;
+        let identifier = "custom.runtime.attach";
+        let config_path = context._temp_dir.path().join("runtime-attach-client.json");
+        let parsed = seed_runtime_attachable_client(&context, identifier, &config_path).await;
+        assert!(parsed["mcpServers"].get("MCPMate").is_some());
+
+        let Json(attach_response) = client_attach(
+            State(context.app_state.clone()),
+            Json(ClientAttachReq {
+                identifier: identifier.to_string(),
+            }),
+        )
+        .await
+        .expect("reattach while file already contains MCPMate");
+
+        assert!(attach_response.success);
+        let data = attach_response.data.expect("attach data");
+        assert!(
+            data.warnings
+                .iter()
+                .any(|warning| warning == ATTACH_OVERWRITE_WARNING),
+            "expected overwrite warning, got {:?}",
+            data.warnings
+        );
+        assert_eq!(data.attachment_state, "attached");
+    }
+
+    #[tokio::test]
+    async fn client_detach_removes_mcpmate_when_db_detached_but_file_still_present() {
+        let context = create_test_context().await;
+        let identifier = "custom.runtime.detach";
+        let config_path = context._temp_dir.path().join("runtime-detach-client.json");
+        seed_runtime_attachable_client(&context, identifier, &config_path).await;
+
+        sqlx::query("UPDATE client SET attachment_state = 'detached' WHERE identifier = ?")
+            .bind(identifier)
+            .execute(&context.db_pool)
+            .await
+            .expect("force detached DB state while file still contains MCPMate");
+
+        let Json(detach_response) = client_detach(
+            State(context.app_state.clone()),
+            Json(ClientDetachReq {
+                identifier: identifier.to_string(),
+            }),
+        )
+        .await
+        .expect("detach while file still contains MCPMate");
+
+        assert!(detach_response.success);
+        let data = detach_response.data.expect("detach data");
+        assert!(data.changed);
+        assert!(data.warnings.is_empty());
+        assert_eq!(data.attachment_state, "detached");
+
+        let written = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read detached config");
+        let parsed: serde_json::Value = serde_json::from_str(&written).expect("parse detached config");
+        assert!(parsed["mcpServers"].get("MCPMate").is_none());
+    }
+
+    #[tokio::test]
+    async fn client_detach_warns_when_mcpmate_absent_from_file() {
+        let context = create_test_context().await;
+        let identifier = "custom.runtime.detach-idempotent";
+        let config_path = context._temp_dir.path().join("runtime-detach-idempotent.json");
+        tokio::fs::write(&config_path, r#"{"mcpServers":{}}"#)
+            .await
+            .expect("seed empty runtime config");
+
+        let Json(update_response) = update_settings(
+            State(context.app_state.clone()),
+            Json(ClientSettingsUpdateReq {
+                config_mode: Some("hosted".to_string()),
+                transport: Some("streamable_http".to_string()),
+                display_name: Some("Runtime Detach Idempotent".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
+                config_path: Some(config_path.to_string_lossy().to_string()),
+                config_file_parse: Some(json_object_parse("mcpServers")),
+                transports: Some(HashMap::from([("streamable_http".to_string(), streamable_http_rule())])),
+                ..settings_update_req(identifier)
+            }),
+        )
+        .await
+        .expect("update runtime detach idempotent client");
+        assert!(update_response.success);
+
+        sqlx::query("UPDATE client SET attachment_state = 'detached' WHERE identifier = ?")
+            .bind(identifier)
+            .execute(&context.db_pool)
+            .await
+            .expect("mark client detached");
+
+        let Json(detach_response) = client_detach(
+            State(context.app_state.clone()),
+            Json(ClientDetachReq {
+                identifier: identifier.to_string(),
+            }),
+        )
+        .await
+        .expect("idempotent detach");
+
+        assert!(detach_response.success);
+        let data = detach_response.data.expect("detach data");
+        assert!(!data.changed);
+        assert!(
+            data.warnings
+                .iter()
+                .any(|warning| warning == DETACH_NO_EFFECT_WARNING),
+            "expected no-effect warning, got {:?}",
+            data.warnings
+        );
+    }
+
+    #[tokio::test]
+    async fn client_detach_rejects_undetectable_config_file() {
+        let context = create_test_context().await;
+        let config_path = context._temp_dir.path().join("undetectable-detach.json");
+        tokio::fs::write(&config_path, r#"{"mcpServers":{"MCPMate":{"url":"http://127.0.0.1:8000/mcp"}}}"#)
+            .await
+            .expect("seed undetectable detach config");
+
+        context
+            .client_service
+            .set_active_client_settings(
+                "client-a",
+                ActiveClientSettingsUpdate {
+                    display_name: Some("Undetectable Detach Client".to_string()),
+                    config_mode: Some("hosted".to_string()),
+                    transport: Some("streamable_http".to_string()),
+                    config_file_state: Some(ClientConfigFileState::WithConfigFile),
+                    config_path: Some(config_path.to_string_lossy().to_string()),
+                    ..ActiveClientSettingsUpdate::default()
+                },
+            )
+            .await
+            .expect("seed active client state");
+
+        sqlx::query(
+            r#"
+            UPDATE client
+            SET config_file_parse = 'not-json',
+                approval_status = 'approved',
+                attachment_state = 'attached'
+            WHERE identifier = ?
+            "#,
+        )
+        .bind("client-a")
+        .execute(&context.db_pool)
+        .await
+        .expect("persist invalid parse override");
+
+        let result = client_detach(
+            State(context.app_state.clone()),
+            Json(ClientDetachReq {
+                identifier: "client-a".to_string(),
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn config_details_repairs_local_target_before_deriving_attachment_state() {
+        let context = create_test_context().await;
+        let config_path = context._temp_dir.path().join("drift-attachment.json");
+        tokio::fs::write(
+            &config_path,
+            r#"{"mcpServers":{"MCPMate":{"url":"http://127.0.0.1:8000/mcp"}}}"#,
+        )
+        .await
+        .expect("seed drifted attachment config");
+
+        let Json(update_response) = update_settings(
+            State(context.app_state.clone()),
+            Json(ClientSettingsUpdateReq {
+                config_mode: Some("hosted".to_string()),
+                transport: Some("streamable_http".to_string()),
+                display_name: Some("Drift Attachment Client".to_string()),
+                config_file_state: Some(ClientConfigFileState::WithConfigFile),
+                config_path: Some(config_path.to_string_lossy().to_string()),
+                config_file_parse: Some(json_object_parse("mcpServers")),
+                transports: Some(HashMap::from([("streamable_http".to_string(), streamable_http_rule())])),
+                ..settings_update_req("client-a")
+            }),
+        )
+        .await
+        .expect("seed drift attachment client settings");
+        assert!(update_response.success);
+
+        sqlx::query(
+            r#"
+            UPDATE client
+            SET connection_mode = 'manual',
+                attachment_state = 'not_applicable'
+            WHERE identifier = ?
+            "#,
+        )
+        .bind("client-a")
+        .execute(&context.db_pool)
+        .await
+        .expect("persist drifted attachment metadata");
+
+        let Json(details_response) = config_details(
+            State(context.app_state.clone()),
+            Query(ClientConfigReq {
+                identifier: "client-a".to_string(),
+            }),
+        )
+        .await
+        .expect("config details response");
+
+        assert!(details_response.success);
+        let details = details_response.data.expect("details data");
+        assert_eq!(details.attachment_state.as_deref(), Some("attached"));
+        assert!(
+            !details
+                .degraded_reasons
+                .iter()
+                .any(|reason| reason == "attachment_requires_local_config_target"),
+            "repair should remove attachment drift, got {:?}",
+            details.degraded_reasons
+        );
+    }
+
 }

--- a/backend/src/api/handlers/client/inspection.rs
+++ b/backend/src/api/handlers/client/inspection.rs
@@ -5,7 +5,8 @@ use crate::api::models::client::{
 use crate::clients::ClientConfigService;
 use crate::clients::analyzer::{ConfigAnalysis, ConfigInspectionReport, inspect_config_content};
 use crate::clients::models::{
-    ClientConfigFileParse, ContainerType, FormatRule, TemplateFormat, canonical_config_transport_key,
+    AttachmentState, ClientConfigFileParse, ContainerType, FormatRule, TemplateFormat,
+    canonical_config_transport_key,
 };
 use crate::clients::service::core::ClientStateRow;
 use crate::clients::service::rules::ConfigRuleInspection;
@@ -77,19 +78,82 @@ pub(super) async fn detect_mcpmate_in_client_config(
     Some(inspected.analysis.mcpmate_present)
 }
 
+pub(crate) const ATTACH_OVERWRITE_WARNING: &str =
+    "MCPMate entry already present in config file; attach will overwrite";
+
+pub(crate) const DETACH_NO_EFFECT_WARNING: &str =
+    "MCPMate entry not found in config file; detach has no effect on file content";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ClientFileGuardRejection {
+    UndetectableFile,
+    NonApplicableDbState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClientFileGuardOperation {
+    Attach,
+    Detach,
+}
+
+fn evaluate_client_file_guard(
+    operation: ClientFileGuardOperation,
+    mcpmate_present: Option<bool>,
+    db_state: AttachmentState,
+) -> Result<Option<&'static str>, ClientFileGuardRejection> {
+    let attachable = matches!(db_state, AttachmentState::Detached | AttachmentState::Attached);
+    match mcpmate_present {
+        None => Err(ClientFileGuardRejection::UndetectableFile),
+        Some(true) if attachable => Ok(match operation {
+            ClientFileGuardOperation::Attach => Some(ATTACH_OVERWRITE_WARNING),
+            ClientFileGuardOperation::Detach => None,
+        }),
+        Some(false) if attachable => Ok(match operation {
+            ClientFileGuardOperation::Attach => None,
+            ClientFileGuardOperation::Detach => Some(DETACH_NO_EFFECT_WARNING),
+        }),
+        Some(_) => Err(ClientFileGuardRejection::NonApplicableDbState),
+    }
+}
+
+pub(super) fn evaluate_client_attach_file_guard(
+    mcpmate_present: Option<bool>,
+    db_state: AttachmentState,
+) -> Result<Option<&'static str>, ClientFileGuardRejection> {
+    evaluate_client_file_guard(ClientFileGuardOperation::Attach, mcpmate_present, db_state)
+}
+
+pub(super) fn evaluate_client_detach_file_guard(
+    mcpmate_present: Option<bool>,
+    db_state: AttachmentState,
+) -> Result<Option<&'static str>, ClientFileGuardRejection> {
+    evaluate_client_file_guard(ClientFileGuardOperation::Detach, mcpmate_present, db_state)
+}
+
 pub(super) fn derive_attachment_state(
     state: &ClientStateRow,
     config_analysis: &ConfigAnalysis,
 ) -> String {
+    if !state.has_local_config_target() {
+        return state.attachment_state().as_str().to_string();
+    }
+
     if config_analysis.mcpmate_present {
-        return "attached".to_string();
+        "attached".to_string()
+    } else {
+        "detached".to_string()
     }
+}
 
-    if state.has_local_config_target() {
-        return "detached".to_string();
+pub(super) fn attachment_state_drift_reason(
+    state: &ClientStateRow,
+    config_analysis: &ConfigAnalysis,
+) -> Option<&'static str> {
+    if config_analysis.mcpmate_present && !state.has_local_config_target() {
+        Some("attachment_requires_local_config_target")
+    } else {
+        None
     }
-
-    state.attachment_state().as_str().to_string()
 }
 
 pub(super) fn configured_server_entries_data(
@@ -240,6 +304,144 @@ pub(super) fn build_config_file_parse_inspect_data(
         inferred_parse: inspection.inferred_parse.as_ref().map(parse_data_from_rule),
         validation: inspection.validation.map(validation_data_from_rule),
         preview: inspection.preview,
+    }
+}
+
+#[cfg(test)]
+mod file_guard_tests {
+    use super::*;
+    use crate::clients::service::core::ClientStateRow;
+
+    #[test]
+    fn derive_attachment_state_requires_local_config_target_before_file_truth() {
+        let state = ClientStateRow::test_attachment_fixture(
+            "manual",
+            Some("~/.cursor/mcp.json"),
+            Some("not_applicable"),
+        );
+        let analysis = ConfigAnalysis {
+            mcpmate_present: true,
+            ..ConfigAnalysis::default()
+        };
+
+        assert_eq!(derive_attachment_state(&state, &analysis), "not_applicable");
+        assert_eq!(
+            attachment_state_drift_reason(&state, &analysis),
+            Some("attachment_requires_local_config_target")
+        );
+    }
+
+    #[test]
+    fn derive_attachment_state_reflects_file_when_local_config_target_is_active() {
+        let state = ClientStateRow::test_attachment_fixture(
+            "local_config_detected",
+            Some("~/.cursor/mcp.json"),
+            Some("detached"),
+        );
+
+        let attached = ConfigAnalysis {
+            mcpmate_present: true,
+            ..ConfigAnalysis::default()
+        };
+        assert_eq!(derive_attachment_state(&state, &attached), "attached");
+
+        let detached = ConfigAnalysis {
+            mcpmate_present: false,
+            ..ConfigAnalysis::default()
+        };
+        assert_eq!(derive_attachment_state(&state, &detached), "detached");
+    }
+
+    #[test]
+    fn evaluate_client_attach_file_guard_matrix() {
+        let cases = [
+            (
+                (Some(true), AttachmentState::Attached),
+                Ok(Some(ATTACH_OVERWRITE_WARNING)),
+            ),
+            (
+                (Some(true), AttachmentState::Detached),
+                Ok(Some(ATTACH_OVERWRITE_WARNING)),
+            ),
+            (
+                (Some(true), AttachmentState::NotApplicable),
+                Err(ClientFileGuardRejection::NonApplicableDbState),
+            ),
+            (
+                (Some(false), AttachmentState::Attached),
+                Ok(None),
+            ),
+            (
+                (Some(false), AttachmentState::Detached),
+                Ok(None),
+            ),
+            (
+                (Some(false), AttachmentState::NotApplicable),
+                Err(ClientFileGuardRejection::NonApplicableDbState),
+            ),
+            (
+                (None, AttachmentState::Detached),
+                Err(ClientFileGuardRejection::UndetectableFile),
+            ),
+            (
+                (None, AttachmentState::Attached),
+                Err(ClientFileGuardRejection::UndetectableFile),
+            ),
+        ];
+
+        for ((mcpmate_present, db_state), expected) in cases {
+            assert_eq!(
+                evaluate_client_attach_file_guard(mcpmate_present, db_state),
+                expected,
+                "attach mcpmate_present={mcpmate_present:?}, db_state={db_state:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn evaluate_client_detach_file_guard_matrix() {
+        let cases = [
+            (
+                (Some(true), AttachmentState::Attached),
+                Ok(None),
+            ),
+            (
+                (Some(true), AttachmentState::Detached),
+                Ok(None),
+            ),
+            (
+                (Some(true), AttachmentState::NotApplicable),
+                Err(ClientFileGuardRejection::NonApplicableDbState),
+            ),
+            (
+                (Some(false), AttachmentState::Attached),
+                Ok(Some(DETACH_NO_EFFECT_WARNING)),
+            ),
+            (
+                (Some(false), AttachmentState::Detached),
+                Ok(Some(DETACH_NO_EFFECT_WARNING)),
+            ),
+            (
+                (Some(false), AttachmentState::NotApplicable),
+                Err(ClientFileGuardRejection::NonApplicableDbState),
+            ),
+            (
+                (None, AttachmentState::Detached),
+                Err(ClientFileGuardRejection::UndetectableFile),
+            ),
+            (
+                (None, AttachmentState::Attached),
+                Err(ClientFileGuardRejection::UndetectableFile),
+            ),
+        ];
+
+        for ((mcpmate_present, db_state), expected) in cases {
+            assert_eq!(
+                evaluate_client_detach_file_guard(mcpmate_present, db_state),
+                expected,
+                "detach mcpmate_present={mcpmate_present:?}, db_state={db_state:?}"
+            );
+        }
     }
 }
 

--- a/backend/src/clients/service/core.rs
+++ b/backend/src/clients/service/core.rs
@@ -208,6 +208,21 @@ impl PersistedTemplateConfig {
 }
 
 impl ClientStateRow {
+    #[cfg(test)]
+    pub(crate) fn test_attachment_fixture(
+        connection_mode: &str,
+        config_path: Option<&str>,
+        attachment_state: Option<&str>,
+    ) -> Self {
+        Self {
+            identifier: "test.client".to_string(),
+            config_path: config_path.map(str::to_string),
+            connection_mode: Some(connection_mode.to_string()),
+            attachment_state: attachment_state.map(str::to_string),
+            ..Self::default()
+        }
+    }
+
     pub fn identifier(&self) -> &str {
         &self.identifier
     }

--- a/backend/src/clients/service/settings.rs
+++ b/backend/src/clients/service/settings.rs
@@ -694,7 +694,7 @@ impl ClientConfigService {
         Ok(())
     }
 
-    async fn update_runtime_target(
+    pub(super) async fn update_runtime_target(
         &self,
         identifier: &str,
         config_path: Option<&str>,

--- a/backend/src/clients/service/state.rs
+++ b/backend/src/clients/service/state.rs
@@ -231,6 +231,7 @@ impl ClientConfigService {
             .await?;
 
         if row.approval_status() == "approved" {
+            self.ensure_local_config_target_metadata(identifier).await?;
             return Ok(row.approval_status().to_string());
         }
 
@@ -246,7 +247,79 @@ impl ClientConfigService {
         .await
         .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
 
+        self.ensure_local_config_target_metadata(identifier).await?;
+
         Ok("approved".to_string())
+    }
+
+    /// Load client state and repair local-config metadata drift when needed.
+    pub async fn fetch_state_repairing_local_target(
+        &self,
+        identifier: &str,
+    ) -> ConfigResult<Option<ClientStateRow>> {
+        let Some(state) = self.fetch_state(identifier).await? else {
+            return Ok(None);
+        };
+        if self
+            .ensure_local_config_target_metadata_for_state(identifier, &state)
+            .await?
+        {
+            self.fetch_state(identifier).await
+        } else {
+            Ok(Some(state))
+        }
+    }
+
+    /// Align `connection_mode` with a persisted config path so attach/detach lifecycle metadata matches file clients.
+    pub async fn ensure_local_config_target_metadata(
+        &self,
+        identifier: &str,
+    ) -> ConfigResult<bool> {
+        let Some(state) = self.fetch_state(identifier).await? else {
+            return Ok(false);
+        };
+        self.ensure_local_config_target_metadata_for_state(identifier, &state)
+            .await
+    }
+
+    async fn ensure_local_config_target_metadata_for_state(
+        &self,
+        identifier: &str,
+        state: &ClientStateRow,
+    ) -> ConfigResult<bool> {
+        if state.has_local_config_target() {
+            return Ok(false);
+        }
+        let Some(config_path) = state.config_path() else {
+            return Ok(false);
+        };
+        if state.effective_config_file_parse()?.is_none() {
+            return Ok(false);
+        }
+
+        self.update_runtime_target(
+            identifier,
+            Some(config_path),
+            Some(ClientConnectionMode::LocalConfigDetected.as_str()),
+            false,
+        )
+        .await?;
+
+        sqlx::query(
+            r#"
+            UPDATE client
+            SET attachment_state = 'detached'
+            WHERE identifier = ?
+              AND (attachment_state IS NULL OR attachment_state = 'not_applicable')
+            "#,
+        )
+        .bind(identifier)
+        .execute(&*self.db_pool)
+        .await
+        .map_err(|err| ConfigError::DataAccessError(err.to_string()))?;
+
+        tracing::info!(client = %identifier, "Repaired local config target metadata");
+        Ok(true)
     }
 
     pub async fn suspend_client(
@@ -336,7 +409,7 @@ impl ClientConfigService {
         name: &str,
         config_path: Option<&str>,
     ) -> ConfigResult<ClientStateRow> {
-        if let Some(existing) = self.fetch_state(identifier).await? {
+        if let Some(existing) = self.fetch_state_repairing_local_target(identifier).await? {
             return self.refresh_existing_state_name(identifier, name, existing).await;
         }
         let first_contact_behavior = self.get_first_contact_behavior().await?;
@@ -1112,5 +1185,41 @@ mod tests {
             .await
             .expect("deleted client can be recreated passively");
         assert_eq!(recreated.identifier, "test.client");
+    }
+
+    #[tokio::test]
+    async fn ensure_local_config_target_metadata_repairs_connection_mode_drift() {
+        let (_temp_dir, service) = create_test_service().await;
+
+        sqlx::query(
+            r#"
+            INSERT INTO client (
+                id, name, identifier, config_path, connection_mode, attachment_state,
+                config_format, container_type, container_keys, config_file_parse
+            )
+            VALUES (
+                'clnt_drift', 'Cursor Drift', 'cursor.drift', '/tmp/cursor-drift.json',
+                'manual', 'not_applicable', 'json', 'object', '["mcpServers"]',
+                '{"format":"json","container_type":"object_map","container_keys":["mcpServers"]}'
+            )
+            "#,
+        )
+        .execute(service.db_pool.as_ref())
+        .await
+        .expect("insert drifted client row");
+
+        let repaired = service
+            .ensure_local_config_target_metadata("cursor.drift")
+            .await
+            .expect("repair metadata");
+        assert!(repaired);
+
+        let state = service
+            .fetch_state("cursor.drift")
+            .await
+            .expect("fetch state")
+            .expect("state exists");
+        assert!(state.has_local_config_target());
+        assert_eq!(state.attachment_state().as_str(), "detached");
     }
 }

--- a/backend/src/clients/service/state.rs
+++ b/backend/src/clients/service/state.rs
@@ -293,8 +293,17 @@ impl ClientConfigService {
         let Some(config_path) = state.config_path() else {
             return Ok(false);
         };
-        if state.effective_config_file_parse()?.is_none() {
-            return Ok(false);
+        match state.effective_config_file_parse() {
+            Ok(Some(_)) => {}
+            Ok(None) => return Ok(false),
+            Err(err) => {
+                tracing::warn!(
+                    client = %identifier,
+                    error = %err,
+                    "Skipping local target repair due to invalid parse metadata"
+                );
+                return Ok(false);
+            }
         }
 
         self.update_runtime_target(

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -718,9 +718,8 @@ export function ClientDetailPage() {
     configDetails?.approval_status,
   );
   const isAttachmentApplicable =
-    canWriteClientConfig &&
-    (configDetails?.attachment_state === "attached" ||
-      configDetails?.attachment_state === "detached");
+    configDetails?.attachment_state === "attached" ||
+    configDetails?.attachment_state === "detached";
   const isAttachedClient =
     isAttachmentApplicable && configDetails?.attachment_state === "attached";
   const showLocalConfigMetadata =

--- a/board/src/pages/clients/client-detail-page.tsx
+++ b/board/src/pages/clients/client-detail-page.tsx
@@ -718,8 +718,9 @@ export function ClientDetailPage() {
     configDetails?.approval_status,
   );
   const isAttachmentApplicable =
-    configDetails?.attachment_state === "attached" ||
-    configDetails?.attachment_state === "detached";
+    canWriteClientConfig &&
+    (configDetails?.attachment_state === "attached" ||
+      configDetails?.attachment_state === "detached");
   const isAttachedClient =
     isAttachmentApplicable && configDetails?.attachment_state === "attached";
   const showLocalConfigMetadata =
@@ -2143,6 +2144,7 @@ export function ClientDetailPage() {
                               )
                             }
                             disabled={
+                              !canWriteClientConfig ||
                               detachMutation.isPending ||
                               attachMutation.isPending
                             }


### PR DESCRIPTION
## Summary

- Add file-verified attach/detach guards so idempotent re-attach and drift repair work when the config file already contains or still lacks MCPMate, without blunt DB-only rejection.
- Align `derive_attachment_state` with guard rules, repair `connection_mode` metadata drift on approve/detection/config-details load, and surface drift via degraded reasons when repair is impossible.
- Gate Board attach/detach actions on writable local config targets so UI cannot offer operations the API will reject.

## Test plan

- [x] `cargo test --lib file_guard` (guard matrix + derive_attachment_state)
- [x] `cargo test --lib ensure_local_config_target_metadata`
- [x] `cargo test --lib config_details_repairs`
- [x] `cargo test --lib client_attach_allows`
- [x] `cargo test --lib client_detach`
- [x] `bun run lint` in `board/` (0 errors)
- [ ] Manual: client detail page shows no Detach when `writable_config` is false or attachment is `not_applicable`
- [ ] Manual: re-attach when file already has MCPMate returns success with overwrite warning