### PR TITLE
fix(ci): install libdbus-1-dev for docker-publish clippy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libdbus-1-dev pkg-config
+
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary

- Install `libdbus-1-dev` and `pkg-config` in the Docker Publish workflow's `validate` job before running `cargo clippy`.
- Follows the same pattern already used in `secure-store.yml`.

## Root Cause

PR #94 added `keyring` → `secret-service` → `libdbus-sys` to the dependency tree. On Ubuntu runners, `libdbus-sys` requires the `libdbus-1-dev` system package. Without it, `cargo clippy --all-targets --all-features` fails with:

```
The system library `dbus-1` required by crate `libdbus-sys` was not found.
```

## Test plan

- [ ] Docker Publish workflow passes on this PR