### PR TITLE
feat(ui): merge appearance settings into general tab with auto theme option

### DIFF
--- a/board/src/pages/settings/i18n/index.ts
+++ b/board/src/pages/settings/i18n/index.ts
@@ -3,7 +3,6 @@ export const settingsTranslations = {
     title: "Tune dashboard preferences and defaults",
     tabs: {
       general: "General",
-      appearance: "Appearance",
       audit: "Logs",
       profile: "Profile",
       security: "Security",
@@ -115,37 +114,27 @@ export const settingsTranslations = {
     },
     general: {
       title: "General",
-      description: "Baseline preferences for the main workspace views.",
+      description:
+        "Baseline preferences for workspace layout, theme, language, and desktop shell options.",
       defaultView: "Default View",
       defaultViewDescription: "Choose the default layout for displaying items.",
+      themeTitle: "Theme",
+      themeDescription: "Switch between light, dark, and system theme.",
       language: "Language",
       languageDescription: "Select the dashboard language.",
       languagePlaceholder: "Select language",
-    },
-    appearance: {
-      title: "Appearance",
-      description: "Customize the look and feel of the dashboard.",
-      themeTitle: "Theme",
-      themeDescription: "Switch between light and dark mode.",
-      systemPreferenceTitle: "System Preference",
-      systemPreferenceDescription:
-        "Follow the operating system preference automatically.",
       menuBarTitle: "Menu Bar Icon",
-      menuBarDescription: "Control the visibility of the menu bar icon.",
-      menuBarIconTitle: "Menu Bar Icon Mode",
+      menuBarDescription: "Choose when the desktop tray icon should appear.",
       dockTitle: "Dock / Taskbar Icon",
       dockDescription:
         "Show MCPMate in the Dock (macOS), taskbar (Windows/Linux), or run from the tray or menu bar only.",
-      dockIconTitle: "Dock Icon Mode",
       dockHiddenNotice:
         "The Dock or taskbar entry is hidden. The tray icon stays visible so you can reopen MCPMate.",
-      menuBarPlaceholder: "Select menu bar icon mode",
-      wipLabel: "Work in Progress",
-      defaultMarketPlaceholder: "Select default market",
     },
     options: {
       theme: {
         light: "Light",
+        auto: "Auto",
         dark: "Dark",
       },
       defaultView: {
@@ -425,16 +414,11 @@ export const settingsTranslations = {
       homepage: "Homepage",
       noPackages: "No third-party packages detected during the latest update.",
     },
-    notices: {
-      dockHidden:
-        "The Dock or taskbar entry is hidden. The tray icon stays visible so you can reopen MCPMate.",
-    },
   },
   "zh-CN": {
     title: "调整面板偏好与默认行为",
     tabs: {
       general: "通用",
-      appearance: "外观",
       audit: "日志",
       profile: "配置集",
       system: "系统",
@@ -541,36 +525,26 @@ export const settingsTranslations = {
     },
     general: {
       title: "通用",
-      description: "管理工作区的默认视图与基础偏好。",
+      description: "管理工作区布局、主题、语言与桌面壳层选项。",
       defaultView: "默认视图",
       defaultViewDescription: "选择条目显示的默认布局方式。",
+      themeTitle: "主题",
+      themeDescription: "在浅色、深色与跟随系统之间切换。",
       language: "界面语言",
       languageDescription: "切换控制台显示语言。",
       languagePlaceholder: "请选择语言",
-    },
-    appearance: {
-      title: "外观",
-      description: "自定义仪表盘的外观和感觉。",
-      themeTitle: "主题",
-      themeDescription: "在浅色和深色模式之间切换。",
-      systemPreferenceTitle: "系统偏好",
-      systemPreferenceDescription: "自动跟随操作系统偏好设置。",
       menuBarTitle: "菜单栏图标",
-      menuBarDescription: "控制菜单栏图标的可见性。",
-      menuBarIconTitle: "菜单栏图标模式",
+      menuBarDescription: "选择桌面托盘图标的显示时机。",
       dockTitle: "Dock / 任务栏图标",
       dockDescription:
         "在 macOS Dock 或 Windows/Linux 任务栏中显示 MCPMate，或仅从托盘或菜单栏运行。",
-      dockIconTitle: "Dock 图标模式",
       dockHiddenNotice:
         "Dock 或任务栏入口已隐藏，托盘图标保持可见以便重新打开 MCPMate。",
-      menuBarPlaceholder: "选择菜单栏图标模式",
-      wipLabel: "开发中",
-      defaultMarketPlaceholder: "选择默认市场",
     },
     options: {
       theme: {
         light: "浅色",
+        auto: "自动",
         dark: "深色",
       },
       defaultView: {
@@ -829,16 +803,11 @@ export const settingsTranslations = {
       homepage: "主页",
       noPackages: "在最新更新期间未检测到第三方包。",
     },
-    notices: {
-      dockHidden:
-        "Dock 或任务栏入口已隐藏，托盘图标保持可见以便重新打开 MCPMate。",
-    },
   },
   "ja-JP": {
     title: "ダッシュボード設定と既定値の調整",
     tabs: {
       general: "一般",
-      appearance: "外観",
       audit: "ログ",
       profile: "プロファイル管理",
       system: "システム",
@@ -952,37 +921,27 @@ export const settingsTranslations = {
     },
     general: {
       title: "一般",
-      description: "ワークスペースの基本設定を管理します。",
+      description:
+        "ワークスペースのレイアウト、テーマ、言語、デスクトップシェル設定を管理します。",
       defaultView: "既定のビュー",
       defaultViewDescription: "項目の表示レイアウトを選択します。",
+      themeTitle: "テーマ",
+      themeDescription: "ライト、ダーク、システム設定の追従を切り替えます。",
       language: "表示言語",
       languageDescription: "ダッシュボードで使用する言語を切り替えます。",
       languagePlaceholder: "言語を選択",
-    },
-    appearance: {
-      title: "外観",
-      description: "ダッシュボードの外観と操作性をカスタマイズします。",
-      themeTitle: "テーマ",
-      themeDescription: "ライトモードとダークモードを切り替えます。",
-      systemPreferenceTitle: "システム設定",
-      systemPreferenceDescription:
-        "オペレーティングシステムの設定を自動的に追従します。",
       menuBarTitle: "メニューバーアイコン",
-      menuBarDescription: "メニューバーアイコンの表示を制御します。",
-      menuBarIconTitle: "メニューバーアイコンモード",
+      menuBarDescription: "デスクトップトレイアイコンの表示タイミングを選択します。",
       dockTitle: "Dock / タスクバーアイコン",
       dockDescription:
         "macOS の Dock、Windows/Linux のタスクバーに表示するか、トレイ／メニューバーのみで実行します。",
-      dockIconTitle: "Dock アイコンモード",
       dockHiddenNotice:
         "Dock／タスクバーからの表示をオフにしました。トレイアイコンは残るため、そこから MCPMate を開き直せます。",
-      menuBarPlaceholder: "メニューバーアイコンモードを選択",
-      wipLabel: "開発中",
-      defaultMarketPlaceholder: "デフォルトマーケットを選択",
     },
     options: {
       theme: {
         light: "ライト",
+        auto: "自動",
         dark: "ダーク",
       },
       defaultView: {
@@ -1267,10 +1226,6 @@ export const settingsTranslations = {
       homepage: "ホームページ",
       noPackages:
         "最新の更新中にサードパーティパッケージが検出されませんでした。",
-    },
-    notices: {
-      dockHidden:
-        "Dock／タスクバーからの表示をオフにしました。トレイアイコンは残るため、そこから MCPMate を開き直せます。",
     },
   },
 } as const;

--- a/board/src/pages/settings/settings-page.tsx
+++ b/board/src/pages/settings/settings-page.tsx
@@ -1,5 +1,10 @@
 import { isProfileTokenEstimateMethod } from "../../lib/profile-token-estimate-method";
-import type { AuditPolicyData, AuditRetentionPolicy } from "../../lib/types";
+import type {
+	AuditPolicyData,
+	AuditRetentionPolicy,
+	CapabilitySource,
+	Theme,
+} from "../../lib/types";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import {
 	Activity,
@@ -101,7 +106,6 @@ import {
 	type MenuBarIconMode,
 	useAppStore,
 } from "../../lib/store";
-import type { CapabilitySource, Theme } from "../../lib/types";
 import type { OpenSourceDocument } from "../../types/open-source";
 import { AboutLicensesSection } from "./about-licenses-section";
 

--- a/board/src/pages/settings/settings-page.tsx
+++ b/board/src/pages/settings/settings-page.tsx
@@ -9,9 +9,11 @@ import {
 	ExternalLink,
 	FileSearch,
 	Bug,
+	Grid3X3,
 	LayoutGrid,
+	List,
+	Monitor,
 	Moon,
-	Palette,
 	RotateCcw,
 	Server,
 	ShieldCheck,
@@ -99,7 +101,7 @@ import {
 	type MenuBarIconMode,
 	useAppStore,
 } from "../../lib/store";
-import type { CapabilitySource } from "../../lib/types";
+import type { CapabilitySource, Theme } from "../../lib/types";
 import type { OpenSourceDocument } from "../../types/open-source";
 import { AboutLicensesSection } from "./about-licenses-section";
 
@@ -110,6 +112,12 @@ const THEME_CONFIG = [
 		icon: Sun,
 		labelKey: "settings:options.theme.light",
 		fallback: "Light",
+	},
+	{
+		value: "system" as const,
+		icon: Monitor,
+		labelKey: "settings:options.theme.auto",
+		fallback: "Auto",
 	},
 	{
 		value: "dark" as const,
@@ -145,11 +153,13 @@ const CLIENT_FILTER_CONFIG = [
 const DEFAULT_VIEW_CONFIG = [
 	{
 		value: "list" as const,
+		icon: List,
 		labelKey: "settings:options.defaultView.list",
 		fallback: "List",
 	},
 	{
 		value: "grid" as const,
+		icon: Grid3X3,
 		labelKey: "settings:options.defaultView.grid",
 		fallback: "Grid",
 	},
@@ -1276,6 +1286,10 @@ export function SettingsPage() {
 		"w-full justify-center gap-2 px-2 py-2 text-left text-sm font-medium text-slate-600 data-[state=active]:text-emerald-700 md:justify-start md:px-3 dark:text-slate-300";
 	const settingItemTitleClass = "text-base font-medium";
 	const settingItemDescriptionClass = "text-sm text-muted-foreground";
+	const generalSettingsRowClass =
+		"flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4";
+	const generalSettingsLabelClass = "min-w-0 space-y-0.5";
+	const generalSettingsControlClass = "w-full shrink-0 sm:w-72";
 	/** Clients tab: left column wraps without stealing flex space from controls; right keeps a floor width so Segments are not squeezed. */
 	const clientsSettingsRowClass =
 		"flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6";
@@ -1296,9 +1310,10 @@ export function SettingsPage() {
 
 	const defaultViewOptions = useMemo<SegmentOption[]>(
 		() =>
-			DEFAULT_VIEW_CONFIG.map(({ value, labelKey, fallback }) => ({
+			DEFAULT_VIEW_CONFIG.map(({ value, icon: Icon, labelKey, fallback }) => ({
 				value,
 				label: t(labelKey, { defaultValue: fallback }),
+				icon: <Icon className="h-4 w-4" />,
 			})),
 		[t, i18n.language],
 	);
@@ -1539,7 +1554,6 @@ export function SettingsPage() {
 			showLicenseTab
 				? [
 					"general",
-					"appearance",
 					"servers",
 					"clients",
 					"profile",
@@ -1552,7 +1566,6 @@ export function SettingsPage() {
 				]
 				: [
 					"general",
-					"appearance",
 					"servers",
 					"clients",
 					"profile",
@@ -1593,12 +1606,6 @@ export function SettingsPage() {
 						<LayoutGrid className="h-4 w-4 shrink-0" />
 						<span className="hidden md:inline truncate">
 							{t("settings:tabs.general", { defaultValue: "General" })}
-						</span>
-					</TabsTrigger>
-					<TabsTrigger value="appearance" className={tabTriggerClass}>
-						<Palette className="h-4 w-4 shrink-0" />
-						<span className="hidden md:inline truncate">
-							{t("settings:tabs.appearance", { defaultValue: "Appearance" })}
 						</span>
 					</TabsTrigger>
 					<TabsTrigger value="servers" className={tabTriggerClass}>
@@ -1673,27 +1680,27 @@ export function SettingsPage() {
 								<CardDescription>
 									{t("settings:general.description", {
 										defaultValue:
-											"Baseline preferences for the main workspace views.",
+											"Baseline preferences for workspace layout, theme, language, and desktop shell options.",
 									})}
 								</CardDescription>
 							</CardHeader>
 							<CardContent className="space-y-5">
 								{/* Default View */}
-								<div className="flex items-center justify-between gap-4">
-									<div className="space-y-0.5">
-										<h3 className="text-base font-medium">
+								<div className={generalSettingsRowClass}>
+									<div className={generalSettingsLabelClass}>
+										<h3 className={settingItemTitleClass}>
 											{t("settings:general.defaultView", {
 												defaultValue: "Default View",
 											})}
 										</h3>
-										<p className="text-xs text-muted-foreground">
+										<p className={settingItemDescriptionClass}>
 											{t("settings:general.defaultViewDescription", {
 												defaultValue:
 													"Choose the default layout for displaying items.",
 											})}
 										</p>
 									</div>
-									<div className="w-48">
+									<div className={generalSettingsControlClass}>
 										<Segment
 											options={defaultViewOptions}
 											value={dashboardSettings.defaultView}
@@ -1708,133 +1715,93 @@ export function SettingsPage() {
 									</div>
 								</div>
 
+								{/* Theme */}
+								<div className={generalSettingsRowClass}>
+									<div className={generalSettingsLabelClass}>
+										<h3 className={settingItemTitleClass}>
+											{t("settings:general.themeTitle", {
+												defaultValue: "Theme",
+											})}
+										</h3>
+										<p className={settingItemDescriptionClass}>
+											{t("settings:general.themeDescription", {
+												defaultValue: "Switch between light, dark, and system theme.",
+											})}
+										</p>
+									</div>
+									<div className={generalSettingsControlClass}>
+										<Segment
+											options={themeOptions}
+											value={theme}
+											onValueChange={(value) => setTheme(value as Theme)}
+											showDots={false}
+										/>
+									</div>
+								</div>
+
 								{/* Language Selection */}
-								<div className="flex items-center justify-between gap-4">
-									<div className="space-y-0.5">
-										<h3 className="text-base font-medium">
+								<div className={generalSettingsRowClass}>
+									<div className={generalSettingsLabelClass}>
+										<h3 className={settingItemTitleClass}>
 											{t("settings:general.language", {
 												defaultValue: "Language",
 											})}
 										</h3>
-										<p className="text-sm text-muted-foreground">
+										<p className={settingItemDescriptionClass}>
 											{t("settings:general.languageDescription", {
 												defaultValue: "Select the dashboard language.",
 											})}
 										</p>
 									</div>
-									<Select
-										value={dashboardSettings.language}
-										onValueChange={(value: DashboardLanguage) =>
-											setDashboardSetting("language", value)
-										}
-									>
-										<SelectTrigger id={languageId} className="w-48">
-											<SelectValue
-												placeholder={t("settings:general.languagePlaceholder", {
-													defaultValue: "Select language",
-												})}
-											/>
-										</SelectTrigger>
-										<SelectContent>
-											{languageOptions.map((option) => (
-												<SelectItem key={option.value} value={option.value}>
-													{option.label}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</div>
-							</CardContent>
-						</Card>
-					</TabsContent>
-
-					<TabsContent value="appearance" className="mt-0 h-full">
-						<Card className="h-full">
-							<CardHeader>
-								<CardTitle>
-									{t("settings:appearance.title", {
-										defaultValue: "Appearance",
-									})}
-								</CardTitle>
-								<CardDescription>
-									{t("settings:appearance.description", {
-										defaultValue:
-											"Customize the look and feel of the dashboard.",
-									})}
-								</CardDescription>
-							</CardHeader>
-							<CardContent className="space-y-5">
-								<div className="space-y-4">
-									<div className="flex items-center justify-between gap-4">
-										<div className="space-y-0.5">
-											<h3 className="text-base font-medium">
-												{t("settings:appearance.themeTitle", {
-													defaultValue: "Theme",
-												})}
-											</h3>
-											<p className="text-xs text-muted-foreground">
-												{t("settings:appearance.themeDescription", {
-													defaultValue: "Switch between light and dark mode.",
-												})}
-											</p>
-										</div>
-										<div className="w-48">
-											<Segment
-												options={themeOptions}
-												value={theme === "system" ? "light" : theme}
-												onValueChange={(value) =>
-													setTheme(value as "light" | "dark")
-												}
-												showDots={false}
-											/>
-										</div>
-									</div>
-
-									<div className="flex items-center justify-between gap-4">
-										<div className="space-y-0.5">
-											<h3 className="text-base font-medium">
-												{t("settings:appearance.systemPreferenceTitle", {
-													defaultValue: "System Preference",
-												})}
-											</h3>
-											<p className="text-xs text-muted-foreground">
-												{t("settings:appearance.systemPreferenceDescription", {
-													defaultValue:
-														"Follow the operating system preference automatically.",
-												})}
-											</p>
-										</div>
-										<Switch
-											checked={theme === "system"}
-											onCheckedChange={(checked) =>
-												setTheme(checked ? "system" : "light")
+									<div className={generalSettingsControlClass}>
+										<Select
+											value={dashboardSettings.language}
+											onValueChange={(value: DashboardLanguage) =>
+												setDashboardSetting("language", value)
 											}
-										/>
+										>
+											<SelectTrigger id={languageId} className="w-full">
+												<SelectValue
+													placeholder={t("settings:general.languagePlaceholder", {
+														defaultValue: "Select language",
+													})}
+												/>
+											</SelectTrigger>
+											<SelectContent>
+												{languageOptions.map((option) => (
+													<SelectItem key={option.value} value={option.value}>
+														{option.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
 									</div>
+								</div>
 
-									{isTauriShell && (
-										<div className="space-y-4">
-											<div className="flex items-center justify-between gap-4">
-												<div className="space-y-0.5">
-													<h3 className="text-base font-medium">
-														{t("settings:appearance.menuBarTitle", {
-															defaultValue: "Menu Bar Icon",
-														})}
-													</h3>
-													<p className="text-sm text-muted-foreground">
-														{t("settings:appearance.menuBarDescription", {
-															defaultValue:
-																"Choose when the desktop tray icon should appear.",
-														})}
-													</p>
-												</div>
+								{isTauriShell && (
+									<div className="space-y-5">
+										<div className={generalSettingsRowClass}>
+											<div className={generalSettingsLabelClass}>
+												<h3 className={settingItemTitleClass}>
+													{t("settings:general.menuBarTitle", {
+														defaultValue: "Menu Bar Icon",
+													})}
+												</h3>
+												<p className={settingItemDescriptionClass}>
+													{t("settings:general.menuBarDescription", {
+														defaultValue:
+															"Choose when the desktop tray icon should appear.",
+													})}
+												</p>
+											</div>
+											<div className={generalSettingsControlClass}>
 												<Select
 													value={dashboardSettings.menuBarIconMode}
 													onValueChange={(value: MenuBarIconMode) =>
 														setDashboardSetting("menuBarIconMode", value)
 													}
 												>
-													<SelectTrigger id={menuBarSelectId} className="w-56">
+													<SelectTrigger id={menuBarSelectId} className="w-full">
 														<SelectValue
 															placeholder={t("placeholders.menuBarVisibility", {
 																defaultValue: "Menu bar visibility",
@@ -1857,40 +1824,40 @@ export function SettingsPage() {
 													</SelectContent>
 												</Select>
 											</div>
+										</div>
 
-											<div className="flex items-center justify-between gap-4">
-												<div className="space-y-0.5">
-													<h3 className="text-base font-medium">
-														{t("settings:appearance.dockTitle", {
-															defaultValue: "Dock / Taskbar Icon",
-														})}
-													</h3>
-													<p className="text-sm text-muted-foreground">
-														{t("settings:appearance.dockDescription", {
-															defaultValue:
-																"Show MCPMate in the Dock (macOS), taskbar (Windows/Linux), or run from the tray or menu bar only.",
-														})}
-													</p>
-												</div>
-												<Switch
-													checked={dashboardSettings.showDockIcon}
-													onCheckedChange={(checked) =>
-														setDashboardSetting("showDockIcon", checked)
-													}
-												/>
-											</div>
-
-											{!dashboardSettings.showDockIcon && (
-												<p className="text-sm leading-relaxed text-muted-foreground">
-													{t("settings:appearance.dockHiddenNotice", {
+										<div className={generalSettingsRowClass}>
+											<div className={generalSettingsLabelClass}>
+												<h3 className={settingItemTitleClass}>
+													{t("settings:general.dockTitle", {
+														defaultValue: "Dock / Taskbar Icon",
+													})}
+												</h3>
+												<p className={settingItemDescriptionClass}>
+													{t("settings:general.dockDescription", {
 														defaultValue:
-															"The Dock or taskbar entry is hidden. The tray icon stays visible so you can reopen MCPMate.",
+															"Show MCPMate in the Dock (macOS), taskbar (Windows/Linux), or run from the tray or menu bar only.",
 													})}
 												</p>
-											)}
+											</div>
+											<Switch
+												checked={dashboardSettings.showDockIcon}
+												onCheckedChange={(checked) =>
+													setDashboardSetting("showDockIcon", checked)
+												}
+											/>
 										</div>
-									)}
-								</div>
+
+										{!dashboardSettings.showDockIcon && (
+											<p className="text-sm leading-relaxed text-muted-foreground">
+												{t("settings:general.dockHiddenNotice", {
+													defaultValue:
+														"The Dock or taskbar entry is hidden. The tray icon stays visible so you can reopen MCPMate.",
+												})}
+											</p>
+										)}
+									</div>
+								)}
 							</CardContent>
 						</Card>
 					</TabsContent>


### PR DESCRIPTION
## Summary

- Consolidates the Appearance tab into the General tab, reducing tab count and grouping related settings (layout, theme, language, desktop shell options) in one place
- Replaces the 2-way theme segment + System Preference switch with a single 3-way segment (Light / Auto / Dark), making the system-follow option more discoverable
- Adds icons to the Default View segment (List / Grid) for visual consistency with the theme segment

## Changes

**`board/src/pages/settings/i18n/index.ts`**
- Remove `appearance` tab key and all `appearance.*` translation keys from EN/ZH/JA
- Move theme, menuBar, and dock keys under `general.*`
- Add `options.theme.auto` ("Auto" / "自动" / "自動") in all three locales
- Remove orphaned `notices.dockHidden` key (content was duplicated in `appearance.dockHiddenNotice`)

**`board/src/pages/settings/settings-page.tsx`**
- Remove the entire Appearance `TabsContent` block and its tab trigger
- Inline theme, menuBar, and dock controls into the General tab's `CardContent`
- Add `"system"` option to `THEME_CONFIG` with `Monitor` icon
- Add `List` and `Grid3X3` icons to `DEFAULT_VIEW_CONFIG`
- Extract reusable CSS class constants: `generalSettingsRowClass`, `generalSettingsLabelClass`, `generalSettingsControlClass`
- Fix stale `defaultValue` for `themeDescription` to match i18n ("light, dark, and system theme")

## Test plan

- [ ] Open Settings → General tab: verify Default View, Theme, Language, Menu Bar (on Tauri), and Dock (on Tauri) all render correctly
- [ ] Theme segment: verify Light / Auto / Dark all apply correctly and persist across reload
- [ ] Select "Auto" theme → verify dashboard follows OS preference
- [ ] Verify no "Appearance" tab exists in the tab bar
- [ ] Deep link to `?tab=appearance` → verify fallback to General tab
- [ ] Switch language (EN/ZH/JA) → verify all new keys render correctly, no missing translations
- [ ] Run `bun run build` to verify no TypeScript or build errors