### PR TITLE
fix(docker): add dbus build deps and disable nightly schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,9 +4,11 @@
 name: Nightly
 
 on:
-  # Daily at 18:20 UTC / 02:20 Asia/Singapore.
-  schedule:
-    - cron: "20 18 * * *"
+  workflow_dispatch:
+  # STATUS: DISABLED — schedule trigger is paused.
+  # Re-enable by removing the jobs-level `if` gate on prepare.
+  # schedule:
+  #   - cron: "20 18 * * *"
 
 concurrency:
   group: nightly-${{ github.ref }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ name: Nightly
 on:
   workflow_dispatch:
   # STATUS: DISABLED — schedule trigger is paused.
-  # Re-enable by removing the jobs-level `if` gate on prepare.
+  # Re-enable by uncommenting the schedule trigger below.
   # schedule:
   #   - cron: "20 18 * * *"
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -12,14 +12,15 @@ RUN NODE_OPTIONS=--max-old-space-size=4096 npm run build
 
 FROM ${RUST_IMAGE} AS builder
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 COPY backend ./backend
 
 WORKDIR /workspace/backend
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config \
-    && rm -rf /var/lib/apt/lists/*
 RUN cargo build --release --bin mcpmate --bin bridge
 
 FROM ${RUNTIME_IMAGE} AS runtime

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -17,6 +17,9 @@ WORKDIR /workspace
 COPY backend ./backend
 
 WORKDIR /workspace/backend
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 RUN cargo build --release --bin mcpmate --bin bridge
 
 FROM ${RUNTIME_IMAGE} AS runtime
@@ -27,7 +30,7 @@ LABEL org.opencontainers.image.source="https://github.com/loocor/MCPMate"
 LABEL io.modelcontextprotocol.server.name="io.github.loocor/mcpmate"
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates nginx-light \
+    && apt-get install -y --no-install-recommends ca-certificates libdbus-1-3 nginx-light \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --home-dir /data --shell /usr/sbin/nologin mcpmate
 


### PR DESCRIPTION
## Summary

- Add `libdbus-1-dev` and `pkg-config` to the Docker build stage so `cargo build` can link against dbus
- Add `libdbus-1-3` to the runtime stage for the shared library
- Disable the nightly schedule trigger; retain `workflow_dispatch` for manual runs

## Changes

| File | What |
|------|------|
| `packaging/docker/Dockerfile` | Install `libdbus-1-dev` + `pkg-config` before `cargo build`; add `libdbus-1-3` to runtime image |
| `.github/workflows/nightly.yml` | Comment out `schedule` cron, add `workflow_dispatch`, add disable notice |

## Context

The Docker publish workflow was failing because the Rust build requires dbus headers (`dbus-sys` crate) which weren't available in the builder image. The nightly schedule is being paused until there's a reason to re-enable it.

## Test plan

- [ ] `docker-publish` workflow validate job passes (Dockerfile builds successfully)
- [ ] Nightly workflow is not triggered on schedule
- [ ] Nightly workflow can still be triggered manually via `workflow_dispatch`