### PR TITLE
feat: add bulk MCP config import and profile bulk operations

### DIFF
--- a/board/src/components/bulk-selection/build-bulk-actions.ts
+++ b/board/src/components/bulk-selection/build-bulk-actions.ts
@@ -1,0 +1,138 @@
+import type { TFunction } from "i18next";
+import { Check, CheckCheck, Square, XSquare } from "lucide-react";
+import type { BulkAction, BulkSelectionController } from "./types";
+
+function buildSelectClearBulkActions(
+	bulk: BulkSelectionController,
+	visibleIds: string[],
+	selectAllLabel: string,
+	clearLabel: string,
+): BulkAction[] {
+	return [
+		{
+			id: "select-all",
+			icon: CheckCheck,
+			label: selectAllLabel,
+			variant: "outline",
+			onClick: () => bulk.selectAll(visibleIds),
+		},
+		{
+			id: "clear",
+			icon: XSquare,
+			label: clearLabel,
+			variant: "outline",
+			onClick: () => bulk.clearSelection(),
+		},
+	];
+}
+
+function buildCheckSquarePairBulkActions({
+	bulk,
+	visibleIds,
+	selectAllLabel,
+	clearLabel,
+	positive,
+	negative,
+	disabled = false,
+}: {
+	bulk: BulkSelectionController;
+	visibleIds: string[];
+	selectAllLabel: string;
+	clearLabel: string;
+	positive: { id: string; label: string; onClick: () => void };
+	negative: { id: string; label: string; onClick: () => void };
+	disabled?: boolean;
+}): BulkAction[] {
+	const pairDisabled = disabled || bulk.selectedCount === 0;
+	return [
+		...buildSelectClearBulkActions(bulk, visibleIds, selectAllLabel, clearLabel),
+		{
+			id: positive.id,
+			icon: Check,
+			label: positive.label,
+			disabled: pairDisabled,
+			onClick: positive.onClick,
+		},
+		{
+			id: negative.id,
+			icon: Square,
+			label: negative.label,
+			variant: "secondary",
+			disabled: pairDisabled,
+			onClick: negative.onClick,
+		},
+	];
+}
+
+export function buildEnableDisableBulkActions({
+	bulk,
+	visibleIds,
+	isPending,
+	onEnable,
+	onDisable,
+	t,
+}: {
+	bulk: BulkSelectionController;
+	visibleIds: string[];
+	isPending: boolean;
+	onEnable: () => void;
+	onDisable: () => void;
+	t: TFunction;
+}): BulkAction[] {
+	return buildCheckSquarePairBulkActions({
+		bulk,
+		visibleIds,
+		selectAllLabel: t("profiles:detail.buttons.selectAll", {
+			defaultValue: "Select all",
+		}),
+		clearLabel: t("profiles:detail.buttons.clearSelection", {
+			defaultValue: "Clear",
+		}),
+		disabled: isPending,
+		positive: {
+			id: "enable",
+			label: t("profiles:detail.buttons.enable", { defaultValue: "Enable" }),
+			onClick: onEnable,
+		},
+		negative: {
+			id: "disable",
+			label: t("profiles:detail.buttons.disable", { defaultValue: "Disable" }),
+			onClick: onDisable,
+		},
+	});
+}
+
+export function buildIncludeExcludeBulkActions({
+	bulk,
+	visibleIds,
+	onInclude,
+	onExclude,
+	t,
+}: {
+	bulk: BulkSelectionController;
+	visibleIds: string[];
+	onInclude: () => void;
+	onExclude: () => void;
+	t: TFunction;
+}): BulkAction[] {
+	return buildCheckSquarePairBulkActions({
+		bulk,
+		visibleIds,
+		selectAllLabel: t("manual.bulk.selectAll", { defaultValue: "Select all" }),
+		clearLabel: t("manual.bulk.clearSelection", { defaultValue: "Clear" }),
+		positive: {
+			id: "include",
+			label: t("manual.bulk.includeInImport", {
+				defaultValue: "Add to import",
+			}),
+			onClick: onInclude,
+		},
+		negative: {
+			id: "exclude",
+			label: t("manual.bulk.excludeFromImport", {
+				defaultValue: "Remove from import",
+			}),
+			onClick: onExclude,
+		},
+	});
+}

--- a/board/src/components/bulk-selection/bulk-selection-checkbox.tsx
+++ b/board/src/components/bulk-selection/bulk-selection-checkbox.tsx
@@ -1,0 +1,49 @@
+import { Check } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+type BulkSelectionCheckboxProps = {
+	visible: boolean;
+	checked: boolean;
+	onToggle: () => void;
+	ariaLabel: string;
+	className?: string;
+};
+
+export function BulkSelectionCheckbox({
+	visible,
+	checked,
+	onToggle,
+	ariaLabel,
+	className,
+}: BulkSelectionCheckboxProps) {
+	return (
+		<div
+			className={cn(
+				"shrink-0 overflow-hidden transition-[width,opacity] duration-200",
+				visible ? "w-6 opacity-100" : "w-0 opacity-0",
+				className,
+			)}
+			aria-hidden={!visible}
+		>
+			<button
+				type="button"
+				tabIndex={visible ? 0 : -1}
+				className={cn(
+					"flex h-6 w-6 items-center justify-center rounded-full border text-[0px] transition-all duration-200",
+					checked
+						? "border-primary bg-primary text-white shadow-sm"
+						: "border-slate-300 text-transparent hover:border-primary/50 hover:text-primary/60 dark:border-slate-700 dark:hover:border-primary/50",
+				)}
+				onClick={(event) => {
+					event.stopPropagation();
+					onToggle();
+				}}
+				aria-label={ariaLabel}
+				aria-pressed={checked}
+				disabled={!visible}
+			>
+				<Check className="h-3 w-3" />
+			</button>
+		</div>
+	);
+}

--- a/board/src/components/bulk-selection/bulk-selection-header.tsx
+++ b/board/src/components/bulk-selection/bulk-selection-header.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+import { BulkSelectionToolbar } from "./bulk-selection-toolbar";
+import type { BulkAction } from "./types";
+import { useBulkSelectionLabels } from "./use-bulk-selection-labels";
+
+type BulkSelectionHeaderProps = {
+	title: ReactNode;
+	description: ReactNode;
+	isBulkMode: boolean;
+	onToggleBulkMode: () => void;
+	actions: BulkAction[];
+	trailing?: ReactNode;
+	className?: string;
+};
+
+export function BulkSelectionHeader({
+	title,
+	description,
+	isBulkMode,
+	onToggleBulkMode,
+	actions,
+	trailing,
+	className,
+}: BulkSelectionHeaderProps) {
+	const { modeToggleLabel, modeExitLabel } = useBulkSelectionLabels();
+	return (
+		<div
+			className={cn(
+				"mb-3 flex shrink-0 items-center justify-between gap-3",
+				className,
+			)}
+		>
+			<div className="min-w-0">
+				<div className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+					{title}
+				</div>
+				<div className="text-xs text-slate-500 dark:text-slate-400">
+					{description}
+				</div>
+			</div>
+			<div className="flex shrink-0 items-center gap-2">
+				{trailing}
+				<BulkSelectionToolbar
+					isBulkMode={isBulkMode}
+					onToggleMode={onToggleBulkMode}
+					modeToggleLabel={modeToggleLabel}
+					modeExitLabel={modeExitLabel}
+					actions={actions}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/board/src/components/bulk-selection/bulk-selection-toolbar.tsx
+++ b/board/src/components/bulk-selection/bulk-selection-toolbar.tsx
@@ -1,0 +1,96 @@
+import { ListChecks } from "lucide-react";
+import { Button } from "../ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "../ui/tooltip";
+import { cn } from "../../lib/utils";
+import type { BulkAction } from "./types";
+
+const segmentButtonClassName =
+	"h-8 w-8 shrink-0 rounded-none border-0 shadow-none bg-muted/30 hover:bg-accent hover:text-accent-foreground";
+
+type BulkSelectionToolbarProps = {
+	isBulkMode: boolean;
+	onToggleMode: () => void;
+	modeToggleLabel: string;
+	modeExitLabel: string;
+	actions: BulkAction[];
+	className?: string;
+};
+
+export function BulkSelectionToolbar({
+	isBulkMode,
+	onToggleMode,
+	modeToggleLabel,
+	modeExitLabel,
+	actions,
+	className,
+}: BulkSelectionToolbarProps) {
+	return (
+		<TooltipProvider delayDuration={200}>
+			<div
+				className={cn(
+					"inline-flex shrink-0 items-center",
+					isBulkMode &&
+					"gap-px overflow-hidden rounded-lg border border-input bg-border/80 shadow-sm",
+					className,
+				)}
+			>
+				{isBulkMode
+					? actions.map((action) => (
+						<Tooltip key={action.id}>
+							<TooltipTrigger asChild>
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon"
+									className={cn(
+										segmentButtonClassName,
+										action.variant === "secondary" &&
+										"text-muted-foreground hover:text-foreground",
+										action.variant === "default" &&
+										"bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
+									)}
+									disabled={action.disabled}
+									aria-label={action.label}
+									onClick={action.onClick}
+								>
+									<action.icon className="h-4 w-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">{action.label}</TooltipContent>
+						</Tooltip>
+					))
+					: null}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant={isBulkMode ? "default" : "outline"}
+							size="icon"
+							className={cn(
+								isBulkMode
+									? cn(
+										segmentButtonClassName,
+										"bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
+									)
+									: "h-8 w-8 rounded-md",
+							)}
+							aria-label={isBulkMode ? modeExitLabel : modeToggleLabel}
+							aria-pressed={isBulkMode}
+							onClick={onToggleMode}
+						>
+							<ListChecks className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">
+						{isBulkMode ? modeExitLabel : modeToggleLabel}
+					</TooltipContent>
+				</Tooltip>
+			</div>
+		</TooltipProvider>
+	);
+}

--- a/board/src/components/bulk-selection/index.ts
+++ b/board/src/components/bulk-selection/index.ts
@@ -1,0 +1,15 @@
+export {
+	buildEnableDisableBulkActions,
+	buildIncludeExcludeBulkActions,
+} from "./build-bulk-actions";
+export { BulkSelectionCheckbox } from "./bulk-selection-checkbox";
+export { BulkSelectionHeader } from "./bulk-selection-header";
+export { BulkSelectionToolbar } from "./bulk-selection-toolbar";
+export type {
+	BulkAction,
+	BulkSelectionController,
+	BulkSelectionMode,
+} from "./types";
+export { useBulkSelection } from "./use-bulk-selection";
+export { useBulkSelectionLabels } from "./use-bulk-selection-labels";
+export { useEnableDisableBulkActions } from "./use-enable-disable-bulk-actions";

--- a/board/src/components/bulk-selection/types.ts
+++ b/board/src/components/bulk-selection/types.ts
@@ -1,0 +1,19 @@
+import type { LucideIcon } from "lucide-react";
+
+export type BulkSelectionMode = "browse" | "bulk";
+
+export type BulkAction = {
+	id: string;
+	icon: LucideIcon;
+	label: string;
+	variant?: "default" | "outline" | "secondary" | "destructive" | "ghost";
+	disabled?: boolean;
+	onClick: () => void;
+};
+
+export type BulkSelectionController = {
+	selectedCount: number;
+	selectedIds: string[];
+	selectAll: (ids: string[]) => void;
+	clearSelection: () => void;
+};

--- a/board/src/components/bulk-selection/use-bulk-selection-labels.ts
+++ b/board/src/components/bulk-selection/use-bulk-selection-labels.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 export function useBulkSelectionLabels() {
-	const { t } = useTranslation("common");
+	const { t } = useTranslation();
 
 	return {
 		modeToggleLabel: t("bulkSelection.bulkModeEnter", {

--- a/board/src/components/bulk-selection/use-bulk-selection-labels.ts
+++ b/board/src/components/bulk-selection/use-bulk-selection-labels.ts
@@ -1,0 +1,19 @@
+import { useTranslation } from "react-i18next";
+
+export function useBulkSelectionLabels() {
+	const { t } = useTranslation("common");
+
+	return {
+		modeToggleLabel: t("bulkSelection.bulkModeEnter", {
+			defaultValue: "Bulk select",
+		}),
+		modeExitLabel: t("bulkSelection.bulkModeExit", {
+			defaultValue: "Exit bulk select",
+		}),
+		bulkModeDescription: (count: number) =>
+			t("bulkSelection.bulkModeDescription", {
+				count,
+				defaultValue: "{{count}} selected for bulk actions",
+			}),
+	};
+}

--- a/board/src/components/bulk-selection/use-bulk-selection.ts
+++ b/board/src/components/bulk-selection/use-bulk-selection.ts
@@ -1,0 +1,57 @@
+import { useCallback, useMemo, useState } from "react";
+import type { BulkSelectionMode } from "./types";
+
+export function useBulkSelection<TId extends string>() {
+	const [mode, setMode] = useState<BulkSelectionMode>("browse");
+	const [selectedIds, setSelectedIds] = useState<TId[]>([]);
+
+	const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+	const selectedCount = selectedIds.length;
+	const isBulkMode = mode === "bulk";
+
+	const exitBulkMode = useCallback(() => {
+		setMode("browse");
+		setSelectedIds([]);
+	}, []);
+
+	const toggleMode = useCallback(() => {
+		setMode((current) => {
+			if (current === "bulk") {
+				setSelectedIds([]);
+				return "browse";
+			}
+			return "bulk";
+		});
+	}, []);
+
+	const toggleItem = useCallback((id: TId) => {
+		setSelectedIds((current) =>
+			current.includes(id)
+				? current.filter((item) => item !== id)
+				: [...current, id],
+		);
+	}, []);
+
+	const selectAll = useCallback((ids: TId[]) => {
+		setSelectedIds(ids);
+	}, []);
+
+	const clearSelection = useCallback(() => {
+		setSelectedIds([]);
+	}, []);
+
+	return useMemo(
+		() => ({
+			isBulkMode,
+			selectedIds,
+			selectedIdSet,
+			selectedCount,
+			exitBulkMode,
+			toggleMode,
+			toggleItem,
+			selectAll,
+			clearSelection,
+		}),
+		[isBulkMode, selectedIds, selectedIdSet, selectedCount, exitBulkMode, toggleMode, toggleItem, selectAll, clearSelection],
+	);
+}

--- a/board/src/components/bulk-selection/use-enable-disable-bulk-actions.ts
+++ b/board/src/components/bulk-selection/use-enable-disable-bulk-actions.ts
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { buildEnableDisableBulkActions } from "./build-bulk-actions";
+import type { BulkSelectionController } from "./types";
+
+type EnableDisableBulkMutation = {
+	isPending: boolean;
+	mutate: (args: { enable: boolean; ids: string[] }) => void;
+};
+
+export function useEnableDisableBulkActions(
+	bulk: BulkSelectionController,
+	visibleIds: string[],
+	mutation: EnableDisableBulkMutation,
+) {
+	const { t } = useTranslation();
+	const { isPending, mutate } = mutation;
+
+	return useMemo(
+		() =>
+			buildEnableDisableBulkActions({
+				bulk,
+				visibleIds,
+				isPending,
+				onEnable: () => mutate({ enable: true, ids: bulk.selectedIds }),
+				onDisable: () => mutate({ enable: false, ids: bulk.selectedIds }),
+				t,
+			}),
+		[bulk, visibleIds, isPending, mutate, t],
+	);
+}

--- a/board/src/components/capability-combobox.tsx
+++ b/board/src/components/capability-combobox.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { ReactNode } from "react";
 import { Button } from "./ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import {
@@ -10,6 +11,7 @@ import {
   CommandList,
 } from "./ui/command";
 import { ChevronDown } from "lucide-react";
+import { cn } from "../lib/utils";
 
 export type CapabilityKind = "tool" | "prompt" | "resource" | "template";
 
@@ -26,6 +28,15 @@ export interface CapabilityComboboxProps<T extends CapabilityRecordLike = Capabi
   error?: string | null;
   container?: HTMLElement | null;
   placeholder?: string;
+  triggerClassName?: string;
+  triggerLabelClassName?: string;
+  renderTriggerLeading?: (item: T) => ReactNode;
+  renderTriggerTrailing?: (item: T) => ReactNode;
+  renderItemLeading?: (item: T) => ReactNode;
+  renderItemTrailing?: (item: T) => ReactNode;
+  menuBleed?: boolean;
+  menuGroupClassName?: string;
+  menuItemClassName?: string;
   getKey: (item: T) => string;
   getLabel: (item: T) => string;
   getDescription?: (item: T) => string | undefined;
@@ -40,6 +51,15 @@ export function CapabilityCombobox<T extends CapabilityRecordLike>(props: Capabi
     error,
     container,
     placeholder = "Search...",
+    triggerClassName,
+    triggerLabelClassName,
+    renderTriggerLeading,
+    renderTriggerTrailing,
+    renderItemLeading,
+    renderItemTrailing,
+    menuBleed = true,
+    menuGroupClassName,
+    menuItemClassName,
     getKey,
     getLabel,
     getDescription,
@@ -73,11 +93,13 @@ export function CapabilityCombobox<T extends CapabilityRecordLike>(props: Capabi
     };
   }, [open]);
 
-  const selectedLabel = React.useMemo(() => {
-    if (!value) return "";
-    const found = items.find((it) => getKey(it) === value);
-    return found ? getLabel(found) : "";
-  }, [items, value, getKey, getLabel]);
+  const selectedItem = React.useMemo(() => {
+    if (!value) return undefined;
+    return items.find((it) => getKey(it) === value);
+  }, [items, value, getKey]);
+
+  const selectedLabel = selectedItem ? getLabel(selectedItem) : "";
+  const selectedTrailing = selectedItem ? renderTriggerTrailing?.(selectedItem) : null;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -85,13 +107,26 @@ export function CapabilityCombobox<T extends CapabilityRecordLike>(props: Capabi
         <Button
           ref={triggerRef}
           variant="outline"
-          className="w-full justify-between"
+          className={cn("w-full justify-between", triggerClassName)}
           type="button"
           aria-expanded={open}
         >
-          <span className="truncate text-left font-normal">
-            {selectedLabel || placeholder}
+          <span className="flex min-w-0 flex-1 items-center gap-3 text-left">
+            {selectedItem && renderTriggerLeading
+              ? renderTriggerLeading(selectedItem)
+              : null}
+            <span
+              className={cn(
+                "truncate",
+                triggerLabelClassName ?? "font-normal",
+              )}
+            >
+              {selectedLabel || placeholder}
+            </span>
           </span>
+          {selectedTrailing ? (
+            <span className="ml-2 flex shrink-0 items-center">{selectedTrailing}</span>
+          ) : null}
           <span className="ml-2 flex items-center gap-1 text-slate-500">
             {loading ? (
               <span className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-slate-400 border-t-transparent" />
@@ -103,13 +138,23 @@ export function CapabilityCombobox<T extends CapabilityRecordLike>(props: Capabi
       <PopoverContent
         align="start"
         sideOffset={6}
-        className="p-0"
+        className={cn(
+          "p-0",
+          menuBleed &&
+          "max-w-none overflow-hidden rounded-lg w-[var(--radix-popover-trigger-width)]",
+        )}
         container={container}
-        style={{ width: menuWidth ? `${menuWidth}px` : undefined }}
+        style={menuWidth ? { width: `${menuWidth}px` } : undefined}
       >
-        <Command>
+        <Command className={menuBleed ? "rounded-none" : undefined}>
           <CommandInput placeholder={placeholder} />
-          <CommandList>
+          <CommandList
+            className={
+              menuBleed
+                ? "max-h-[300px] overflow-y-auto overflow-x-hidden p-0 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                : undefined
+            }
+          >
             {error ? (
               <CommandEmpty>
                 <span className="text-red-500 text-xs">{error}</span>
@@ -117,29 +162,53 @@ export function CapabilityCombobox<T extends CapabilityRecordLike>(props: Capabi
             ) : (
               <CommandEmpty>No results found.</CommandEmpty>
             )}
-            <CommandGroup>
+            <CommandGroup
+              className={cn(
+                menuGroupClassName,
+                menuBleed &&
+                "p-0 [&_[cmdk-group-items]]:m-0 [&_[cmdk-group-items]]:w-full [&_[cmdk-group-items]]:p-0",
+              )}
+            >
               {items.map((entry, index) => {
                 const key = getKey(entry) || `index:${index}`;
                 const label = getLabel(entry) || key;
                 const desc = getDescription?.(entry);
+                const trailing = renderItemTrailing?.(entry);
                 return (
                   <CommandItem
                     key={key}
                     value={key}
-                    className="py-2.5 px-4 group"
+                    className={cn(
+                      "group py-2.5",
+                      menuBleed ? "w-full rounded-none px-0" : "px-4",
+                      menuItemClassName,
+                    )}
                     onSelect={(v) => {
                       onChange(v, entry);
                       setOpen(false);
                     }}
                   >
-                    <div className="flex min-w-0 flex-col">
-                      <span className="truncate font-medium text-slate-900 dark:text-slate-100 group-hover:text-accent-foreground group-aria-selected:text-accent-foreground">
-                        {label}
-                      </span>
-                      {desc ? (
-                        <span className="truncate text-xs text-slate-500 dark:text-slate-400" title={desc}>
-                          {desc}
+                    <div
+                      className={cn(
+                        "flex w-full min-w-0 items-center gap-3",
+                        menuBleed && "px-4",
+                      )}
+                    >
+                      {renderItemLeading ? renderItemLeading(entry) : null}
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate font-medium text-slate-900 dark:text-slate-100 group-hover:text-accent-foreground group-aria-selected:text-accent-foreground">
+                          {label}
                         </span>
+                        {desc ? (
+                          <span className="truncate text-xs text-slate-500 dark:text-slate-400" title={desc}>
+                            {desc}
+                          </span>
+                        ) : null}
+                      </div>
+                      {trailing ? (
+                        <div className="ml-auto flex shrink-0 items-center">
+                          {trailing}
+                        </div>
                       ) : null}
                     </div>
                   </CommandItem>

--- a/board/src/components/capability-list-skeleton.tsx
+++ b/board/src/components/capability-list-skeleton.tsx
@@ -1,0 +1,46 @@
+import {
+	CapsuleStripeList,
+	CapsuleStripeListItem,
+} from "./capsule-stripe-list";
+import { cn } from "../lib/utils";
+
+type CapabilityListSkeletonProps = {
+	rows?: number;
+	showSectionLabel?: boolean;
+	className?: string;
+};
+
+export function CapabilityListSkeleton({
+	rows = 5,
+	showSectionLabel = false,
+	className,
+}: CapabilityListSkeletonProps) {
+	return (
+		<div
+			className={cn("p-3", className)}
+			aria-busy="true"
+			aria-live="polite"
+		>
+			{showSectionLabel ? (
+				<div className="mb-3 h-3 w-12 animate-pulse rounded bg-slate-200 dark:bg-slate-800" />
+			) : null}
+			<CapsuleStripeList className="rounded-none border-0 overflow-visible">
+				{Array.from({ length: rows }, (_, index) => (
+					<CapsuleStripeListItem
+						key={`capability-list-skeleton-${index}`}
+						className="items-start"
+					>
+						<div className="flex w-full items-start gap-3">
+							<div className="mt-0.5 h-4 w-4 shrink-0 animate-pulse rounded bg-slate-200 dark:bg-slate-800" />
+							<div className="min-w-0 flex-1 space-y-2 py-0.5">
+								<div className="h-4 max-w-[42%] animate-pulse rounded bg-slate-200 dark:bg-slate-800" />
+								<div className="h-3 w-full animate-pulse rounded bg-slate-200 dark:bg-slate-800" />
+								<div className="h-3 max-w-[88%] animate-pulse rounded bg-slate-200 dark:bg-slate-800" />
+							</div>
+						</div>
+					</CapsuleStripeListItem>
+				))}
+			</CapsuleStripeList>
+		</div>
+	);
+}

--- a/board/src/components/capability-list.tsx
+++ b/board/src/components/capability-list.tsx
@@ -291,6 +291,10 @@ export function CapabilityList<T = CapabilityRecord>({
 		[mappedItems, search],
 	);
 
+	const selectedIdSet = useMemo(
+		() => (selectedIds ? new Set(selectedIds) : null),
+		[selectedIds],
+	);
 	const skeleton = (
 		<div className="space-y-2">
 			{[1, 2, 3].map((i) => (
@@ -305,7 +309,7 @@ export function CapabilityList<T = CapabilityRecord>({
 	const renderedItems = data.map((mapped, idx) => {
 		const item = mapped.raw;
 		const id = getId ? getId(item) : String(idx);
-		const isSelected = !!(selectable && selectedIds?.includes(id));
+		const isSelected = !!(selectable && selectedIdSet?.has(id));
 		const isEnabled = getEnabled ? !!getEnabled(item) : undefined;
 
 		const handleSelect = () => {

--- a/board/src/components/capability-list.tsx
+++ b/board/src/components/capability-list.tsx
@@ -1,4 +1,11 @@
-import { Check } from "lucide-react";
+import {
+	Check,
+	Database,
+	LayoutTemplate,
+	MessageSquare,
+	Wrench,
+	type LucideIcon,
+} from "lucide-react";
 import { type KeyboardEvent, type ReactNode, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../lib/store";
@@ -8,6 +15,7 @@ import type {
 	CapabilityRecord,
 } from "../types/capabilities";
 import type { JsonSchema } from "../types/json";
+import { CapabilityListSkeleton } from "./capability-list-skeleton";
 import { CardListScrollBody } from "./card-list-scroll-body";
 import { JsonCodeBlock } from "./json-code-block";
 import { CachedAvatar } from "./cached-avatar";
@@ -26,6 +34,13 @@ import {
 
 type CapabilityKind = "tools" | "resources" | "prompts" | "templates";
 type ContextType = "server" | "profile";
+
+const CAPABILITY_KIND_ICONS: Record<CapabilityKind, LucideIcon> = {
+	tools: Wrench,
+	resources: Database,
+	prompts: MessageSquare,
+	templates: LayoutTemplate,
+};
 
 export interface CapabilityListProps<T = CapabilityRecord> {
 	title?: string;
@@ -290,12 +305,17 @@ export function CapabilityList<T = CapabilityRecord>({
 			.sort((a, b) => a.title.localeCompare(b.title)),
 		[mappedItems, search],
 	);
-
 	const selectedIdSet = useMemo(
 		() => (selectedIds ? new Set(selectedIds) : null),
 		[selectedIds],
 	);
-	const skeleton = (
+
+	const useStripeSkeleton = context === "profile" || useCapsule;
+	const skeleton = useStripeSkeleton ? (
+		<CapabilityListSkeleton
+			className={scrollContainedBody ? "p-0" : undefined}
+		/>
+	) : (
 		<div className="space-y-2">
 			{[1, 2, 3].map((i) => (
 				<div
@@ -356,14 +376,21 @@ export function CapabilityList<T = CapabilityRecord>({
 				? "font-medium text-primary"
 				: "font-medium";
 
-		const avatarNode = (
-			<CachedAvatar
-				src={mapped.icon}
-				fallback={mapped.title || kind}
-				size="sm"
-				className="border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/40"
-			/>
-		);
+		const KindIcon = CAPABILITY_KIND_ICONS[kind];
+		const leadingNode =
+			context === "server" ? (
+				<KindIcon
+					className="mt-0.5 h-4 w-4 shrink-0 text-slate-500 dark:text-slate-400"
+					aria-hidden
+				/>
+			) : (
+				<CachedAvatar
+					src={mapped.icon}
+					fallback={mapped.title || kind}
+					size="sm"
+					className="border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/40"
+				/>
+			);
 
 		const descriptionBlock = mapped.description ? (
 			<div className="mt-1 whitespace-pre-wrap break-words text-xs text-slate-600 dark:text-slate-300">
@@ -463,7 +490,7 @@ export function CapabilityList<T = CapabilityRecord>({
 		) : null;
 
 		const infoBlock = (
-			<div className="min-w-0 flex-1">
+			<div className="min-w-0 flex-1 select-text">
 				<div className={titleClasses}>
 					{mapped.title}
 					{mapped.subtitle ? (
@@ -485,7 +512,7 @@ export function CapabilityList<T = CapabilityRecord>({
 
 		const leftSection = (
 			<div className="flex flex-1 items-start gap-3">
-				{avatarNode}
+				{leadingNode}
 				{infoBlock}
 			</div>
 		);

--- a/board/src/components/server-install/field-list.tsx
+++ b/board/src/components/server-install/field-list.tsx
@@ -169,7 +169,7 @@ export const FieldList: React.FC<FieldListProps> = ({
 						</div>
 					</div>
 				) : (
-					<div className="flex-1 space-y-0">
+					<div className="flex flex-1 flex-col gap-y-0.5">
 						{fields.map((field, index) => (
 							<div
 								key={field.id}

--- a/board/src/components/server-install/form-fields/meta-fields.tsx
+++ b/board/src/components/server-install/form-fields/meta-fields.tsx
@@ -1,14 +1,17 @@
+import type { FieldErrors, UseFormRegister } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Avatar, AvatarFallback, AvatarImage } from "../../ui/avatar";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
 import { Textarea } from "../../ui/textarea";
-import type { ManualFormStateJson } from "../types";
+import type { ManualFormStateJson, ManualServerFormValues } from "../types";
 
 interface MetaFieldsProps {
 	formStateRef: React.MutableRefObject<ManualFormStateJson>;
-	register: any;
-	errors: any;
+	register: UseFormRegister<ManualServerFormValues>;
+	errors: FieldErrors<ManualServerFormValues>;
+	iconUrl?: string;
+	metaIconUrlId: string;
 	metaDescriptionId: string;
 	metaVersionId: string;
 	metaWebsiteUrlId: string;
@@ -22,6 +25,8 @@ export function MetaFields({
 	formStateRef,
 	register,
 	errors,
+	iconUrl,
+	metaIconUrlId,
 	metaDescriptionId,
 	metaVersionId,
 	metaWebsiteUrlId,
@@ -30,21 +35,21 @@ export function MetaFields({
 	metaRepositorySubfolderId,
 	metaRepositoryId,
 }: MetaFieldsProps) {
-	// Icon preview (read-only)
-	const icon = formStateRef.current.meta.icons?.[0];
 	const fallback = (formStateRef.current.name || "S").slice(0, 1).toUpperCase();
+	const previewIconUrl = (iconUrl ?? formStateRef.current.meta.icons?.[0]?.src ?? "").trim();
 	const { t } = useTranslation("servers");
 
 	return (
-		<>
-			{/* Icon preview (read-only) */}
+		<div className="space-y-4">
 			<div className="flex items-center gap-4">
-				<div className="w-20" />
-				<div className="flex items-center gap-3">
-					<Avatar className="bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200">
-						{icon?.src ? (
+				<Label htmlFor={metaIconUrlId} className="w-20 shrink-0 text-right">
+					{t("manual.fields.meta.icon.label", { defaultValue: "Icon" })}
+				</Label>
+				<div className="flex min-w-0 flex-1 items-center gap-3">
+					<Avatar className="h-10 w-10 shrink-0 bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+						{previewIconUrl ? (
 							<AvatarImage
-								src={icon.src}
+								src={previewIconUrl}
 								alt={t("manual.fields.meta.iconAlt", {
 									defaultValue: "Server icon",
 								})}
@@ -52,11 +57,27 @@ export function MetaFields({
 						) : null}
 						<AvatarFallback>{fallback}</AvatarFallback>
 					</Avatar>
+					<div className="min-w-0 flex-1">
+						<Input
+							id={metaIconUrlId}
+							{...register("meta_icon_url")}
+							placeholder={t("manual.fields.meta.icon.placeholder", {
+								defaultValue: "https://example.com/icon.png",
+							})}
+						/>
+						{errors.meta_icon_url ? (
+							<p className="mt-1 text-xs text-red-500">
+								{t(errors.meta_icon_url.message ?? "", {
+									defaultValue: errors.meta_icon_url.message,
+								})}
+							</p>
+						) : null}
+					</div>
 				</div>
 			</div>
 
 			<div className="flex items-center gap-4">
-				<Label htmlFor={metaVersionId} className="w-20 text-right">
+				<Label htmlFor={metaVersionId} className="w-20 shrink-0 text-right">
 					{t("manual.fields.meta.version.label", { defaultValue: "Version" })}
 				</Label>
 				<div className="flex-1">
@@ -71,7 +92,7 @@ export function MetaFields({
 			</div>
 
 			<div className="flex items-center gap-4">
-				<Label htmlFor={metaWebsiteUrlId} className="w-20 text-right">
+				<Label htmlFor={metaWebsiteUrlId} className="w-20 shrink-0 text-right">
 					{t("manual.fields.meta.website.label", { defaultValue: "Website" })}
 				</Label>
 				<div className="flex-1">
@@ -82,18 +103,18 @@ export function MetaFields({
 							defaultValue: "https://example.com",
 						})}
 					/>
-					{errors.meta_website_url && (
-						<p className="text-xs text-red-500">
+					{errors.meta_website_url ? (
+						<p className="mt-1 text-xs text-red-500">
 							{t(errors.meta_website_url.message ?? "", {
 								defaultValue: errors.meta_website_url.message,
 							})}
 						</p>
-					)}
+					) : null}
 				</div>
 			</div>
 
 			<div className="flex items-center gap-4">
-				<Label htmlFor={metaRepositoryUrlId} className="w-20 text-right">
+				<Label htmlFor={metaRepositoryUrlId} className="w-20 shrink-0 text-right">
 					{t("manual.fields.meta.repo.url.label", {
 						defaultValue: "Repository URL",
 					})}
@@ -106,18 +127,18 @@ export function MetaFields({
 							defaultValue: "https://github.com/org/repo",
 						})}
 					/>
-					{errors.meta_repository_url && (
-						<p className="text-xs text-red-500">
+					{errors.meta_repository_url ? (
+						<p className="mt-1 text-xs text-red-500">
 							{t(errors.meta_repository_url.message ?? "", {
 								defaultValue: errors.meta_repository_url.message,
 							})}
 						</p>
-					)}
+					) : null}
 				</div>
 			</div>
 
 			<div className="flex items-center gap-4">
-				<Label htmlFor={metaRepositorySourceId} className="w-20 text-right">
+				<Label htmlFor={metaRepositorySourceId} className="w-20 shrink-0 text-right">
 					{t("manual.fields.meta.repo.source.label", {
 						defaultValue: "Repository Source",
 					})}
@@ -134,7 +155,7 @@ export function MetaFields({
 			</div>
 
 			<div className="flex items-center gap-4">
-				<Label htmlFor={metaRepositorySubfolderId} className="w-20 text-right">
+				<Label htmlFor={metaRepositorySubfolderId} className="w-20 shrink-0 text-right">
 					{t("manual.fields.meta.repo.subfolder.label", {
 						defaultValue: "Repository Subfolder",
 					})}
@@ -151,7 +172,7 @@ export function MetaFields({
 			</div>
 
 			<div className="flex items-center gap-4">
-				<Label htmlFor={metaRepositoryId} className="w-20 text-right">
+				<Label htmlFor={metaRepositoryId} className="w-20 shrink-0 text-right">
 					{t("manual.fields.meta.repo.id.label", {
 						defaultValue: "Repository Entry ID (Metadata)",
 					})}
@@ -167,9 +188,8 @@ export function MetaFields({
 				</div>
 			</div>
 
-			{/* Description moved to bottom */}
 			<div className="flex items-start gap-4">
-				<Label htmlFor={metaDescriptionId} className="w-20 text-right pt-3">
+				<Label htmlFor={metaDescriptionId} className="w-20 shrink-0 pt-3 text-right">
 					{t("manual.fields.meta.description.label", {
 						defaultValue: "Description",
 					})}
@@ -185,6 +205,6 @@ export function MetaFields({
 					/>
 				</div>
 			</div>
-		</>
+		</div>
 	);
 }

--- a/board/src/components/server-install/form-tab-layout.ts
+++ b/board/src/components/server-install/form-tab-layout.ts
@@ -1,0 +1,24 @@
+import { cn } from "../../lib/utils";
+
+export const FORM_TAB_SHELL_CLASS =
+	"mt-2 flex min-h-0 flex-1 flex-col gap-4 focus-visible:outline-none";
+
+export const FORM_TAB_TOOLBAR_ROW_CLASS = "flex shrink-0 justify-end pt-2";
+
+/** Below tab bar; matches Core toolbar `pt-2` without toggle height or `gap-4`. */
+export const FORM_TAB_PANEL_TOP_INSET_CLASS = "pt-2";
+
+export function formContentScrollClass(isCoreJsonPanel: boolean) {
+	return isCoreJsonPanel
+		? "overflow-hidden"
+		: "overflow-y-auto overscroll-contain";
+}
+
+export function formTabScrollClass(viewMode: "form" | "json") {
+	return cn(
+		"min-h-0 flex-1",
+		viewMode === "json"
+			? "flex flex-col overflow-hidden"
+			: "space-y-4 py-0.5",
+	);
+}

--- a/board/src/components/server-install/hooks/draft-to-form-state.ts
+++ b/board/src/components/server-install/hooks/draft-to-form-state.ts
@@ -1,0 +1,52 @@
+import { normalizeIconList } from "../../../lib/install-normalizer";
+import type { ServerInstallDraft } from "../../../hooks/use-server-install-pipeline";
+import type { ManualFormStateJson } from "../types";
+
+export function draftToFormState(draft: ServerInstallDraft): ManualFormStateJson {
+	const nextState: ManualFormStateJson = {
+		name: draft.name ?? "",
+		kind: draft.kind,
+		meta: {
+			description: draft.meta?.description ?? "",
+			version: draft.meta?.version ?? "",
+			websiteUrl: draft.meta?.websiteUrl ?? "",
+			repository: {
+				url: draft.meta?.repository?.url ?? "",
+				source: draft.meta?.repository?.source ?? "",
+				subfolder: draft.meta?.repository?.subfolder ?? "",
+				id: draft.meta?.repository?.id ?? "",
+			},
+			icons: normalizeIconList(draft.meta?.icons).map((icon) => ({
+			src: icon.src,
+			mimeType: icon.mimeType ?? undefined,
+			sizes: icon.sizes ?? undefined,
+		})),
+		},
+		stdio: { command: "", args: [], env: [] },
+		streamable_http: { url: "", headers: [], urlParams: [] },
+	};
+
+	if (draft.kind === "stdio") {
+		nextState.stdio = {
+			command: draft.command ?? "",
+			args: (draft.args || []).map((value) => ({ value })),
+			env: Object.entries(draft.env || {}).map(([key, value]) => ({
+				key,
+				value,
+			})),
+		};
+	} else {
+		nextState.streamable_http = {
+			url: draft.url ?? "",
+			headers: Object.entries(draft.headers || {}).map(([key, value]) => ({
+				key,
+				value,
+			})),
+			urlParams: Object.entries((draft as any)?.urlParams || {}).map(
+				([key, value]) => ({ key, value: String(value ?? "") }),
+			),
+		};
+	}
+
+	return nextState;
+}

--- a/board/src/components/server-install/hooks/index.ts
+++ b/board/src/components/server-install/hooks/index.ts
@@ -2,6 +2,8 @@ export { useFormState } from "./use-form-state";
 export { useFormSubmission } from "./use-form-submission";
 export { useFormSync } from "./use-form-sync";
 export { useIngest } from "./use-ingest";
+export { useServerTypeOptions } from "./use-server-type-options";
+export { draftToFormState } from "./draft-to-form-state";
 export {
 	buildSecretInsertNextValue,
 	resolveSecretFieldHeaderKey,

--- a/board/src/components/server-install/hooks/use-form-state.ts
+++ b/board/src/components/server-install/hooks/use-form-state.ts
@@ -56,6 +56,7 @@ export function useFormState() {
 				env: [],
 				headers: [],
 				meta_description: commonMeta.description,
+				meta_icon_url: commonMeta.icons?.[0]?.src ?? "",
 				meta_version: commonMeta.version,
 				meta_website_url: commonMeta.websiteUrl,
 				meta_repository_url: commonMeta.repository.url,

--- a/board/src/components/server-install/hooks/use-form-submission.ts
+++ b/board/src/components/server-install/hooks/use-form-submission.ts
@@ -151,6 +151,8 @@ export function useFormSubmission({
 			if (description) meta.description = description;
 			if (version) meta.version = version;
 			if (websiteUrl) meta.websiteUrl = websiteUrl;
+			const iconUrl = trim(values.meta_icon_url);
+			if (iconUrl) meta.icons = [{ src: iconUrl }];
 			if (repository) meta.repository = repository;
 
 			const envForDraft = values.kind === "stdio" ? env : headers;

--- a/board/src/components/server-install/hooks/use-form-sync.ts
+++ b/board/src/components/server-install/hooks/use-form-sync.ts
@@ -8,6 +8,7 @@ interface UseFormSyncProps {
 	kind: ManualServerFormValues["kind"];
 	watchedName: string | undefined;
 	watchedMetaDescription: string | undefined;
+	watchedMetaIconUrl: string | undefined;
 	watchedMetaVersion: string | undefined;
 	watchedMetaWebsite: string | undefined;
 	watchedMetaRepositoryUrl: string | undefined;
@@ -41,6 +42,7 @@ export function useFormSync({
 	kind,
 	watchedName,
 	watchedMetaDescription,
+	watchedMetaIconUrl,
 	watchedMetaVersion,
 	watchedMetaWebsite,
 	watchedMetaRepositoryUrl,
@@ -61,9 +63,19 @@ export function useFormSync({
 		if (isRestoringRef.current) return;
 		formStateRef.current.name = watchedName || "";
 		formStateRef.current.meta.description = watchedMetaDescription || "";
+		const iconUrl = (watchedMetaIconUrl ?? "").trim();
+		formStateRef.current.meta.icons = iconUrl ? [{ src: iconUrl }] : [];
 		formStateRef.current.meta.version = watchedMetaVersion || "";
 		formStateRef.current.meta.websiteUrl = watchedMetaWebsite || "";
-	}, [watchedName, watchedMetaDescription, watchedMetaVersion, watchedMetaWebsite, formStateRef, isRestoringRef]);
+	}, [
+		watchedName,
+		watchedMetaDescription,
+		watchedMetaIconUrl,
+		watchedMetaVersion,
+		watchedMetaWebsite,
+		formStateRef,
+		isRestoringRef,
+	]);
 
 	useEffect(() => {
 		if (isRestoringRef.current) return;

--- a/board/src/components/server-install/hooks/use-ingest.ts
+++ b/board/src/components/server-install/hooks/use-ingest.ts
@@ -4,6 +4,13 @@ import { normalizeIngestResult } from "../../../lib/install-normalizer";
 import { notifyError } from "../../../lib/notify";
 import type { ManualFormStateJson } from "../types";
 import { DEFAULT_INGEST_MESSAGE } from "../types";
+import { draftToFormState } from "./draft-to-form-state";
+
+type IngestPayload = {
+	text?: string;
+	buffer?: ArrayBuffer;
+	fileName?: string;
+};
 
 interface UseIngestProps {
 	ingestEnabled: boolean;
@@ -12,7 +19,6 @@ interface UseIngestProps {
 	buildFormValuesFromState: (state: ManualFormStateJson) => any;
 	reset: (values?: any, options?: any) => void;
 	onSubmitMultiple?: (drafts: ServerInstallDraft[]) => Promise<void> | void;
-	onClose: () => void;
 	messages?: {
 		defaultMessage?: string;
 		parsingDropped?: string;
@@ -33,7 +39,6 @@ export function useIngest({
 	buildFormValuesFromState,
 	reset,
 	onSubmitMultiple,
-	onClose,
 	messages,
 }: UseIngestProps) {
 	const resolvedMessages = {
@@ -71,72 +76,16 @@ export function useIngest({
 		setIngestMessage(resolvedMessages.defaultMessage);
 	}, [ingestEnabled, resolvedMessages.defaultMessage]);
 
+	const markIngestSuccess = useCallback(() => {
+		setIngestError(null);
+		setIsIngestSuccess(true);
+		setIsDropZoneCollapsed(true);
+		setIngestMessage(resolvedMessages.success);
+	}, [resolvedMessages.success]);
+
 	const applySingleDraftToForm = useCallback(
 		(draft: ServerInstallDraft) => {
-			const nextState: ManualFormStateJson = {
-				name: "",
-				kind: "stdio",
-				meta: {
-					description: "",
-					version: "",
-					websiteUrl: "",
-					repository: {
-						url: "",
-						source: "",
-						subfolder: "",
-						id: "",
-					},
-					icons: [],
-				},
-				stdio: { command: "", args: [], env: [] },
-				streamable_http: { url: "", headers: [] },
-			};
-
-			nextState.name = draft.name ?? "";
-			nextState.kind = draft.kind;
-			nextState.meta = {
-				description: draft.meta?.description ?? "",
-				version: draft.meta?.version ?? "",
-				websiteUrl: draft.meta?.websiteUrl ?? "",
-				repository: {
-					url: draft.meta?.repository?.url ?? "",
-					source: draft.meta?.repository?.source ?? "",
-					subfolder: draft.meta?.repository?.subfolder ?? "",
-					id: draft.meta?.repository?.id ?? "",
-				},
-				icons: (draft.meta?.icons || [])
-					.map((it) => ({
-						src: String(
-							(it as any).src ?? (it as any).url ?? (it as any).href ?? "",
-						),
-						mimeType:
-							(it as any).mimeType ?? (it as any).mime_type ?? undefined,
-						sizes: (it as any).sizes ?? (it as any).size ?? undefined,
-					}))
-					.filter((it) => it.src),
-			};
-
-			if (draft.kind === "stdio") {
-				nextState.stdio = {
-					command: draft.command ?? "",
-					args: (draft.args || []).map((value) => ({ value })),
-					env: Object.entries(draft.env || {}).map(([key, value]) => ({
-						key,
-						value,
-					})),
-				};
-			} else {
-				nextState.streamable_http = {
-					url: draft.url ?? "",
-					headers: Object.entries(draft.headers || {}).map(([key, value]) => ({
-						key,
-						value,
-					})),
-					urlParams: Object.entries((draft as any)?.urlParams || {}).map(
-						([key, value]) => ({ key, value: String(value ?? "") }),
-					),
-				};
-			}
+			const nextState = draftToFormState(draft);
 
 			formStateRef.current = nextState;
 			reset(buildFormValuesFromState(nextState), {
@@ -162,23 +111,19 @@ export function useIngest({
 			}
 			if (drafts.length === 1) {
 				applySingleDraftToForm(drafts[0]);
-				setIsIngestSuccess(true);
-				setIsDropZoneCollapsed(true);
-				setIngestMessage(resolvedMessages.success);
-				setIngestError(null);
+				markIngestSuccess();
 				return;
 			}
-			onSubmitMultiple?.(drafts);
-			onClose();
+			markIngestSuccess();
+			await onSubmitMultiple?.(drafts);
 		},
 		[
 			applySingleDraftToForm,
+			markIngestSuccess,
 			onSubmitMultiple,
-			onClose,
 			resolvedMessages.noneDetectedError,
 			resolvedMessages.noneDetectedTitle,
 			resolvedMessages.noneDetectedDescription,
-			resolvedMessages.success,
 		],
 	);
 
@@ -187,12 +132,17 @@ export function useIngest({
 			text?: string;
 			buffer?: ArrayBuffer;
 			fileName?: string;
+			payloads?: IngestPayload[];
 		}) => {
 			if (!canIngestProgrammatically) return;
 			try {
 				setIsIngesting(true);
 				setIngestError(null);
-				const drafts = await normalizeIngestResult(payload);
+				const payloads = payload.payloads ?? [payload];
+				const draftGroups = await Promise.all(
+					payloads.map((item) => normalizeIngestResult(item)),
+				);
+				const drafts = draftGroups.flat();
 				await finalizeIngest(drafts);
 			} catch (error) {
 				const message =
@@ -227,6 +177,7 @@ export function useIngest({
 		setIsDragOver,
 		canIngestProgrammatically,
 		resetIngestState,
+		markIngestSuccess,
 		applySingleDraftToForm,
 		handleIngestPayload,
 	};

--- a/board/src/components/server-install/hooks/use-server-type-options.ts
+++ b/board/src/components/server-install/hooks/use-server-type-options.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { ServerInstallDraft } from "../../../hooks/use-server-install-pipeline";
+import { SERVER_TYPE_OPTIONS } from "../types";
+
+export function useServerTypeOptions() {
+	const { t, i18n } = useTranslation("servers");
+
+	const serverTypeOptions = useMemo(
+		() =>
+			SERVER_TYPE_OPTIONS.map((option) => ({
+				...option,
+				label: t(`manual.fields.type.options.${option.value}`, {
+					defaultValue: option.label,
+				}),
+			})),
+		[t, i18n.language],
+	);
+
+	const transportLabel = useMemo(
+		(): Record<ServerInstallDraft["kind"], string> => ({
+			stdio: t("manual.fields.type.options.stdio", { defaultValue: "Stdio" }),
+			sse: t("manual.fields.type.options.sse", {
+				defaultValue: "SSE (Legacy)",
+			}),
+			streamable_http: t("manual.fields.type.options.streamable_http", {
+				defaultValue: "Streamable HTTP",
+			}),
+		}),
+		[t, i18n.language],
+	);
+
+	return { serverTypeOptions, transportLabel };
+}

--- a/board/src/components/server-install/import-validation-summary.tsx
+++ b/board/src/components/server-install/import-validation-summary.tsx
@@ -1,0 +1,335 @@
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+
+import type { ImportStats } from "../../lib/api";
+import {
+	getSkippedQueryFieldLabel,
+	getSkippedReasonLabel,
+} from "../../lib/server-import-utils";
+import { cn, toTitleCase } from "../../lib/utils";
+import { Badge } from "../ui/badge";
+
+export type ImportValidationStatus = "ready" | "skipped" | "failed";
+
+export type ImportValidationEntry = {
+	name: string;
+	status: ImportValidationStatus;
+	skipReason?: string;
+	detail?: string;
+	incomingQuery?: string | null;
+	existingQuery?: string | null;
+};
+
+type StatusCounts = {
+	ready: number;
+	skipped: number;
+	failed: number;
+};
+
+const BENIGN_SKIP_REASONS = new Set([
+	"duplicate_fingerprint",
+	"duplicate_name",
+]);
+
+const STATUS_BADGE_CLASS: Record<ImportValidationStatus, string> = {
+	ready:
+		"border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800/80 dark:bg-emerald-950/40 dark:text-emerald-300",
+	skipped:
+		"border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800/80 dark:bg-amber-950/40 dark:text-amber-300",
+	failed:
+		"border-red-200 bg-red-50 text-red-700 dark:border-red-800/80 dark:bg-red-950/40 dark:text-red-300",
+};
+
+function countStatuses(items: ImportValidationEntry[]): StatusCounts {
+	return items.reduce<StatusCounts>(
+		(counts, item) => {
+			counts[item.status] += 1;
+			return counts;
+		},
+		{ ready: 0, skipped: 0, failed: 0 },
+	);
+}
+
+export function buildImportValidationItems({
+	selectedNames,
+	stats,
+	hiddenPreviewReady,
+}: {
+	selectedNames: string[];
+	stats: ImportStats | null;
+	hiddenPreviewReady?: boolean;
+}): ImportValidationEntry[] {
+	if (!selectedNames.length) {
+		return [];
+	}
+
+	if (hiddenPreviewReady) {
+		return selectedNames.map((name) => ({ name, status: "ready" }));
+	}
+
+	if (!stats) {
+		return [];
+	}
+
+	const skippedByName = new Map(
+		stats.skippedDetails.map((detail) => [detail.name, detail]),
+	);
+	const failedSet = new Set(stats.failedServers);
+
+	return selectedNames.map((name) => {
+		if (failedSet.has(name)) {
+			return {
+				name,
+				status: "failed",
+				detail: stats.errorDetails?.[name],
+			};
+		}
+
+		const skipped = skippedByName.get(name);
+		if (skipped) {
+			return {
+				name,
+				status: "skipped",
+				skipReason: skipped.reason,
+				incomingQuery: skipped.incoming_query,
+				existingQuery: skipped.existing_query,
+			};
+		}
+
+		return { name, status: "ready" };
+	});
+}
+
+function resolveSummaryCopy(
+	counts: StatusCounts,
+	t: TFunction,
+	options?: { hiddenPreviewReady?: boolean },
+): { title: string; description: string } {
+	if (options?.hiddenPreviewReady) {
+		return {
+			title: t("wizard.result.pendingImportReadyTitle", {
+				defaultValue: "Ready to publish",
+			}),
+			description: t("wizard.result.pendingImportReadyDescription", {
+				defaultValue:
+					"OAuth authorization is complete. Import will publish this server and make it visible in your Servers list.",
+			}),
+		};
+	}
+
+	const { ready, skipped, failed } = counts;
+
+	if (ready > 0 && skipped === 0 && failed === 0) {
+		return {
+			title: t("wizard.result.readyStatusTitle", {
+				defaultValue: "Import Ready",
+			}),
+			description: t("wizard.result.readyStatusDescription", {
+				defaultValue:
+					"The server configuration is ready to be imported. Review the information below and click Import when ready.",
+			}),
+		};
+	}
+
+	if (skipped > 0 && ready === 0 && failed === 0) {
+		return {
+			title: t("wizard.result.alreadyInstalledTitle", {
+				defaultValue: "Already Installed",
+			}),
+			description: t("wizard.result.alreadyInstalledDescription", {
+				defaultValue:
+					"Every selected server already exists. You can use it immediately—no import required.",
+			}),
+		};
+	}
+
+	if (failed > 0 && ready === 0 && skipped === 0) {
+		return {
+			title: t("wizard.result.validationFailedTitle", {
+				defaultValue: "Import Validation Failed",
+			}),
+			description: t("wizard.result.validationFailedDescription", {
+				defaultValue:
+					"Resolve the blocking issues below and run validation again.",
+			}),
+		};
+	}
+
+	if (ready > 0 && skipped > 0 && failed === 0) {
+		return {
+			title: t("wizard.result.validatedWithWarningsTitle", {
+				defaultValue: "Import Validated With Warnings",
+			}),
+			description: t("wizard.result.summary.descriptionReadySkipped", {
+				ready,
+				skipped,
+				defaultValue:
+					"{{ready}} will import and {{skipped}} are already installed and will be skipped.",
+			}),
+		};
+	}
+
+	if (ready > 0 && failed > 0 && skipped === 0) {
+		return {
+			title: t("wizard.result.summary.titleReadyFailed", {
+				defaultValue: "Import Partially Ready",
+			}),
+			description: t("wizard.result.summary.descriptionReadyFailed", {
+				ready,
+				failed,
+				defaultValue:
+					"{{ready}} will import. Resolve validation failures for the remaining {{failed}} before importing.",
+			}),
+		};
+	}
+
+	if (skipped > 0 && failed > 0 && ready === 0) {
+		return {
+			title: t("wizard.result.validationFailedTitle", {
+				defaultValue: "Import Validation Failed",
+			}),
+			description: t("wizard.result.summary.descriptionSkippedFailed", {
+				skipped,
+				failed,
+				defaultValue:
+					"{{skipped}} are already installed and {{failed}} failed validation.",
+			}),
+		};
+	}
+
+	return {
+		title: t("wizard.result.summary.titleMixed", {
+			defaultValue: "Import Review",
+		}),
+		description: t("wizard.result.summary.descriptionReadySkippedFailed", {
+			ready,
+			skipped,
+			failed,
+			defaultValue:
+				"{{ready}} will import, {{skipped}} will be skipped, and {{failed}} failed validation.",
+		}),
+	};
+}
+
+function getEntryDetailText(
+	entry: ImportValidationEntry,
+	t: TFunction,
+): string | undefined {
+	if (entry.status === "failed") {
+		return entry.detail;
+	}
+	if (entry.status === "skipped" && entry.skipReason) {
+		return getSkippedReasonLabel(entry.skipReason, t);
+	}
+	return undefined;
+}
+
+function shouldShowItemDetail(entry: ImportValidationEntry): boolean {
+	if (entry.status === "failed") {
+		return Boolean(entry.detail);
+	}
+	if (entry.status !== "skipped") {
+		return false;
+	}
+	if (!entry.skipReason || BENIGN_SKIP_REASONS.has(entry.skipReason)) {
+		return Boolean(entry.incomingQuery || entry.existingQuery);
+	}
+	return true;
+}
+
+type ImportValidationSummaryProps = {
+	items: ImportValidationEntry[];
+	hiddenPreviewReady?: boolean;
+	className?: string;
+};
+
+export function ImportValidationSummary({
+	items,
+	hiddenPreviewReady = false,
+	className,
+}: ImportValidationSummaryProps) {
+	const { t } = useTranslation("servers");
+
+	if (!items.length) {
+		return null;
+	}
+
+	const counts = countStatuses(items);
+	const { title, description } = resolveSummaryCopy(counts, t, {
+		hiddenPreviewReady,
+	});
+
+	const statusBadgeLabel: Record<ImportValidationStatus, string> = {
+		ready: t("wizard.result.summary.badgeReady", {
+			defaultValue: "Ready",
+		}),
+		skipped: t("wizard.result.summary.badgeSkipped", {
+			defaultValue: "Skipped",
+		}),
+		failed: t("wizard.result.summary.badgeFailed", {
+			defaultValue: "Failed",
+		}),
+	};
+
+	return (
+		<div
+			className={cn(
+				"rounded-md border border-slate-200/80 bg-slate-50/80 px-3 py-3 dark:border-slate-700/80 dark:bg-slate-900/40",
+				className,
+			)}
+		>
+			<p className="text-sm font-medium text-foreground">{title}</p>
+			<p className="mt-1 text-sm text-muted-foreground">{description}</p>
+			<ul className="mt-3 divide-y divide-slate-200/80 dark:divide-slate-700/80">
+				{items.map((entry) => {
+					const queryParts: string[] = [];
+					if (entry.incomingQuery) {
+						queryParts.push(
+							`${getSkippedQueryFieldLabel("incoming", t)}=${entry.incomingQuery}`,
+						);
+					}
+					if (entry.existingQuery) {
+						queryParts.push(
+							`${getSkippedQueryFieldLabel("existing", t)}=${entry.existingQuery}`,
+						);
+					}
+
+					const detailText = getEntryDetailText(entry, t);
+					const showDetail = shouldShowItemDetail(entry);
+
+					return (
+						<li
+							key={entry.name}
+							className="flex items-start justify-between gap-3 py-1.5 first:pt-0 last:pb-0"
+						>
+							<div className="min-w-0">
+								<p className="text-sm font-medium text-foreground">
+									{toTitleCase(entry.name)}
+								</p>
+								{showDetail && detailText ? (
+									<p className="mt-0.5 text-xs text-muted-foreground">
+										{detailText}
+									</p>
+								) : null}
+								{queryParts.length > 0 ? (
+									<p className="mt-0.5 text-xs text-muted-foreground">
+										{queryParts.join(" · ")}
+									</p>
+								) : null}
+							</div>
+							<Badge
+								variant="outline"
+								className={cn(
+									"shrink-0 font-medium",
+									STATUS_BADGE_CLASS[entry.status],
+								)}
+							>
+								{statusBadgeLabel[entry.status]}
+							</Badge>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}

--- a/board/src/components/server-install/server-install-wizard.tsx
+++ b/board/src/components/server-install/server-install-wizard.tsx
@@ -2,14 +2,15 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import {
 	AlertTriangle,
-	ChevronDown,
+	ArrowLeft,
 	ChevronRight,
 	Copy,
 	Loader2,
+	Radar,
 	RefreshCw,
-	Target,
+	RotateCcw,
 } from "lucide-react";
-import type { FocusEvent } from "react";
+import type { FocusEvent, MouseEvent } from "react";
 import {
 	forwardRef,
 	useCallback,
@@ -23,7 +24,7 @@ import {
 import { useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { serversApi } from "../../lib/api";
+import { clientsApi, serversApi } from "../../lib/api";
 import {
 	resolveAutoAddTargetProfileId,
 	useAutoAddTargetProfile,
@@ -38,16 +39,39 @@ import {
 import { readClipboardText, writeClipboardText } from "../../lib/clipboard";
 import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import { notifyError } from "../../lib/notify";
+import { cn, toTitleCase } from "../../lib/utils";
+import { onboardingApi } from "../../lib/onboarding-api";
+import {
+	canIngestFromDataTransfer,
+	extractPayloadFromDataTransfer,
+} from "../../lib/server-uni-import-transfer";
 import {
 	compactKeyValueFields,
 	shouldAppendKeyValueRow,
 } from "../../lib/key-value-fields";
 import { useAppStore } from "../../lib/store";
-import type { MCPServerConfig, SecretOrigin } from "../../lib/types";
+import CapabilityList from "../capability-list";
+import type { ClientInfo, MCPServerConfig, SecretOrigin } from "../../lib/types";
+import type { CapabilityRecord } from "../../types/capabilities";
 import {
 	InlineSecretCreate,
 	useInlineSecretCreateField,
 } from "../secrets";
+import {
+	BulkSelectionCheckbox,
+	BulkSelectionHeader,
+	buildIncludeExcludeBulkActions,
+	useBulkSelectionLabels,
+	useBulkSelection,
+} from "../bulk-selection";
+import CapabilityCombobox from "../capability-combobox";
+import { CachedAvatar } from "../cached-avatar";
+import { CapabilityListSkeleton } from "../capability-list-skeleton";
+import { CardListScrollBody } from "../card-list-scroll-body";
+import {
+	CapsuleStripeList,
+	CapsuleStripeListItem,
+} from "../capsule-stripe-list";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -60,10 +84,18 @@ import {
 	DrawerTitle,
 } from "../ui/drawer";
 import { Input } from "../ui/input";
+import { toolbarSearchInputClassName } from "../ui/page-toolbar";
 import { Label } from "../ui/label";
 import { Segment } from "../ui/segment";
+import { Switch } from "../ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Textarea } from "../ui/textarea";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "../ui/tooltip";
 import {
 	CommandField,
 	HttpHeaders,
@@ -72,13 +104,30 @@ import {
 	UrlParams,
 } from "./form-fields";
 import { ServerAuthSection } from "./server-auth-section";
-import { useFormState, useFormSync, useIngest, useSecretFieldInsert } from "./hooks";
+import {
+	buildImportValidationItems,
+	ImportValidationSummary,
+} from "./import-validation-summary";
+import {
+	draftToFormState,
+	useFormState,
+	useFormSync,
+	useIngest,
+	useSecretFieldInsert,
+	useServerTypeOptions,
+} from "./hooks";
+import {
+	FORM_TAB_PANEL_TOP_INSET_CLASS,
+	FORM_TAB_SHELL_CLASS,
+	FORM_TAB_TOOLBAR_ROW_CLASS,
+	formContentScrollClass,
+	formTabScrollClass,
+} from "./form-tab-layout";
 import {
 	breathingAnimation,
 	DEFAULT_INGEST_MESSAGE,
 	type ManualServerFormValues,
 	manualServerSchema,
-	SERVER_TYPE_OPTIONS,
 	type ServerInstallManualFormHandle,
 } from "./types";
 import { FormViewModeToggle } from "./view-mode-toggle";
@@ -86,6 +135,68 @@ import { FormViewModeToggle } from "./view-mode-toggle";
 // Step definitions
 
 const STEP_ORDER: WizardStep[] = ["form", "preview", "result"];
+
+type BulkDraftView = "list" | "detail";
+
+type PreviewCapabilityKind = "tools" | "resources" | "prompts" | "templates";
+
+function draftEndpointSummary(draft: ServerInstallDraft): string {
+	if (draft.kind === "stdio") {
+		return [draft.command, ...(draft.args ?? [])].filter(Boolean).join(" ");
+	}
+	return draft.url ?? "";
+}
+
+function draftListAvatar(draft: ServerInstallDraft) {
+	const draftIcon = draft.meta?.icons?.[0]?.src;
+	const avatarFallback = (draft.name || "S").slice(0, 1).toUpperCase();
+	return (
+		<CachedAvatar
+			src={draftIcon}
+			alt={draft.name ? `${draft.name} icon` : undefined}
+			fallback={avatarFallback}
+			size="sm"
+			shape="rounded"
+			className="border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/40"
+		/>
+	);
+}
+
+function clientHasScannableConfig(client: ClientInfo): boolean {
+	return Boolean(client.detected && client.config_path?.trim());
+}
+
+function fuzzyTextMatches(value: string, query: string): boolean {
+	const haystack = value.toLowerCase();
+	const needle = query.trim().toLowerCase();
+	if (!needle) return true;
+	if (haystack.includes(needle)) return true;
+	const normalizedHaystack = haystack.replace(/[^a-z0-9]+/g, " ");
+	const tokens = needle.split(/[^a-z0-9]+/).filter(Boolean);
+	if (tokens.length && tokens.every((token) => normalizedHaystack.includes(token))) {
+		return true;
+	}
+	const compactHaystack = haystack.replace(/[^a-z0-9]+/g, "");
+	const compactNeedle = needle.replace(/[^a-z0-9]+/g, "");
+	return Boolean(compactNeedle && compactHaystack.includes(compactNeedle));
+}
+
+function capabilityMatchesSearch(item: Record<string, unknown>, query: string): boolean {
+	if (!query.trim()) return true;
+	const fields = [
+		item.name,
+		item.tool_name,
+		item.prompt_name,
+		item.resource_uri,
+		item.uri,
+		item.uriTemplate,
+		item.uri_template,
+		item.description,
+	]
+		.filter((value): value is string => typeof value === "string")
+		.join(" ");
+	return fuzzyTextMatches(fields, query);
+}
 
 interface ServerInstallWizardProps {
 	isOpen: boolean;
@@ -132,6 +243,24 @@ export const ServerInstallWizard = forwardRef(
 		// Wizard state
 		const [isClosing, setIsClosing] = useState(false);
 		const [uiActiveTab, setUiActiveTab] = useState<"core" | "meta">("core");
+		const [bulkDraftView, setBulkDraftView] = useState<BulkDraftView>("list");
+		const bulkSelection = useBulkSelection<string>();
+		const { bulkModeDescription } = useBulkSelectionLabels();
+		const { serverTypeOptions, transportLabel } = useServerTypeOptions();
+		const [activeDraftName, setActiveDraftName] = useState<string | null>(null);
+		const [activePreviewName, setActivePreviewName] = useState<string | null>(
+			null,
+		);
+		const [isLocalScanLoading, setLocalScanLoading] = useState(false);
+
+		const resetBulkUIState = useCallback(() => {
+			setBulkDraftView("list");
+			bulkSelection.exitBulkMode();
+			setActiveDraftName(null);
+			setActivePreviewName(null);
+		}, [bulkSelection]);
+
+		const [capabilitySearch, setCapabilitySearch] = useState("");
 		const steps = useMemo(
 			() =>
 				STEP_ORDER.map((id) => ({
@@ -304,6 +433,7 @@ export const ServerInstallWizard = forwardRef(
 		const commandId = useId();
 		const urlId = useId();
 		const manualJsonId = useId();
+		const metaIconUrlId = useId();
 		const metaDescriptionId = useId();
 		const metaVersionId = useId();
 		const metaWebsiteUrlId = useId();
@@ -316,11 +446,6 @@ export const ServerInstallWizard = forwardRef(
 		const kind = watch("kind");
 		const isStdio = kind === "stdio";
 
-		// Form interaction handlers
-		const handleFormInteraction = useCallback(() => {
-			// Track form interaction for auto-save or validation
-		}, []);
-
 		const handleModeChange = useCallback(
 			(mode: "form" | "json") => {
 				setViewMode(mode);
@@ -329,13 +454,6 @@ export const ServerInstallWizard = forwardRef(
 		);
 
 		// Type snapshot management (for form state restoration)
-		const saveTypeSnapshot = useCallback((_currentKind: string) => {
-			// Save current form state for restoration
-		}, []);
-
-		const restoreTypeSnapshot = useCallback((_newKind: string) => {
-			// Restore form state based on type
-		}, []);
 
 		// Delete confirmation states
 		const [deleteConfirmStates, setDeleteConfirmStates] = useState<
@@ -369,6 +487,7 @@ export const ServerInstallWizard = forwardRef(
 		// Sync form state with our JSON snapshot and watchers
 		const watchedName = watch("name");
 		const watchedMetaDescription = watch("meta_description");
+		const watchedMetaIconUrl = watch("meta_icon_url");
 		const watchedMetaVersion = watch("meta_version");
 		const watchedMetaWebsite = watch("meta_website_url");
 		const watchedMetaRepositoryUrl = watch("meta_repository_url");
@@ -528,6 +647,8 @@ export const ServerInstallWizard = forwardRef(
 				if (version) meta.version = version;
 				const websiteUrl = trim(values.meta_website_url);
 				if (websiteUrl) meta.websiteUrl = websiteUrl;
+				const iconUrl = trim(values.meta_icon_url);
+				if (iconUrl) meta.icons = [{ src: iconUrl }];
 
 				const repoUrl = trim(values.meta_repository_url);
 				if (repoUrl) repository.url = repoUrl;
@@ -568,6 +689,32 @@ export const ServerInstallWizard = forwardRef(
 			[buildJsonPayloadFromValues, getValues, setJsonError, setJsonText],
 		);
 
+		const formStateFromDraft = useCallback(
+			(draft: ServerInstallDraft) => {
+				return draftToFormState(draft);
+			},
+			[],
+		);
+
+		const loadDraftIntoForm = useCallback(
+			(draft: ServerInstallDraft) => {
+				const nextState = formStateFromDraft(draft);
+				formStateRef.current = nextState;
+				reset(buildFormValuesFromState(nextState));
+				setViewMode("form");
+				setJsonError(null);
+				setUiActiveTab("core");
+			},
+			[
+				buildFormValuesFromState,
+				formStateFromDraft,
+				formStateRef,
+				reset,
+				setJsonError,
+				setViewMode,
+			],
+		);
+
 		useEffect(() => {
 			if (viewMode !== "json") return;
 			updateJsonFromValues();
@@ -605,12 +752,13 @@ export const ServerInstallWizard = forwardRef(
 			[isEditMode, kind, pendingImportServerId, watchedName],
 		);
 
-		useFormSync({
+		const { saveTypeSnapshot, restoreTypeSnapshot } = useFormSync({
 			formStateRef,
 			isRestoringRef,
 			kind,
 			watchedName,
 			watchedMetaDescription,
+			watchedMetaIconUrl,
 			watchedMetaVersion,
 			watchedMetaWebsite,
 			watchedMetaRepositoryUrl,
@@ -631,13 +779,17 @@ export const ServerInstallWizard = forwardRef(
 		const {
 			isIngesting,
 			ingestMessage,
+			setIngestMessage,
 			ingestError,
+			setIngestError,
 			isIngestSuccess,
+			setIsIngestSuccess,
 			isDropZoneCollapsed,
 			isDragOver,
 			setIsDragOver,
 			setIsDropZoneCollapsed,
 			resetIngestState,
+			markIngestSuccess,
 			handleIngestPayload,
 		} = useIngest({
 			ingestEnabled,
@@ -649,54 +801,50 @@ export const ServerInstallWizard = forwardRef(
 				if (onPreview) {
 					onPreview(drafts);
 				} else {
-					installPipeline.begin(drafts, "ingest");
+					installPipeline.setDraftCollection(drafts, "ingest");
+					installPipeline.setCurrentStep("form");
+					resetBulkUIState();
 				}
 			},
-			onClose,
 			messages: ingestMessages,
 		});
 
-		// Drag & drop/paste handlers for the top drop zone (new mode only)
-		const canIngestFromDataTransfer = (dt: DataTransfer | null): boolean => {
-			if (!dt) return false;
-			const types = Array.from(dt.types ?? []);
-			return (
-				types.includes("Files") ||
-				types.includes("text/plain") ||
-				types.includes("text/uri-list")
-			);
-		};
+		const handleResetForm = useCallback(() => {
+			if (initialDraft) {
+				loadDraftIntoForm(initialDraft);
+			} else {
+				const initial = createInitialFormState();
+				formStateRef.current = initial;
+				isRestoringRef.current = true;
+				reset(buildFormValuesFromState(initial));
+				isRestoringRef.current = false;
+				setViewMode("form");
+				setUiActiveTab("core");
+				setJsonError(null);
+			}
 
-		const extractPayloadFromDataTransfer = async (
-			dt: DataTransfer,
-		): Promise<{
-			text?: string;
-			buffer?: ArrayBuffer;
-			fileName?: string;
-		} | null> => {
-			if (dt.files && dt.files.length > 0) {
-				const file = dt.files[0];
-				if (file.name.endsWith(".mcpb") || file.name.endsWith(".dxt")) {
-					return { buffer: await file.arrayBuffer(), fileName: file.name };
-				}
-				return { text: await file.text(), fileName: file.name };
+			resetIngestState();
+			resetBulkUIState();
+
+			if (installPipeline.state.drafts.length > 0) {
+				installPipeline.setDraftCollection([], null);
 			}
-			const plain = dt.getData("text/plain");
-			if (plain) return { text: plain };
-			const uri = dt.getData("text/uri-list");
-			if (uri) return { text: uri };
-			if (dt.items && dt.items.length) {
-				for (const item of Array.from(dt.items)) {
-					if (item.kind === "string") {
-						const v = await new Promise<string | null>((resolve) =>
-							item.getAsString((t) => resolve(t ?? null)),
-						);
-						if (v) return { text: v };
-					}
-				}
-			}
-			return null;
-		};
+			installPipeline.setPreviewState(null);
+			installPipeline.setPreviewError(null);
+		}, [
+			initialDraft,
+			loadDraftIntoForm,
+			createInitialFormState,
+			formStateRef,
+			isRestoringRef,
+			reset,
+			buildFormValuesFromState,
+			setViewMode,
+			setJsonError,
+			resetIngestState,
+			installPipeline,
+			resetBulkUIState,
+		]);
 
 		const ingestClipboardPayload = useCallback(
 			async (initialText?: string | null) => {
@@ -714,20 +862,146 @@ export const ServerInstallWizard = forwardRef(
 			[handleIngestPayload, ingestEnabled, isDropZoneCollapsed, isIngesting],
 		);
 
-		const handleDropZoneActivate = useCallback(() => {
-			if (!ingestEnabled) return;
-			if (isDropZoneCollapsed || ingestError || isIngestSuccess) {
-				resetIngestState();
+		const handleLocalConfigScan = useCallback(async () => {
+			if (
+				!ingestEnabled ||
+				isDropZoneCollapsed ||
+				isLocalScanLoading ||
+				isIngesting
+			) {
+				return;
 			}
-			setIsDropZoneCollapsed(false);
+			try {
+				setLocalScanLoading(true);
+				const clientsResp = await clientsApi.detect(true);
+				const scannableClients = (clientsResp?.client ?? []).filter(
+					clientHasScannableConfig,
+				);
+				if (!scannableClients.length) {
+					notifyError(
+						t("manual.scan.noneTitle", {
+							defaultValue: "No local configs found",
+						}),
+						t("manual.scan.noneDescription", {
+							defaultValue:
+								"No detected MCP clients have a local configuration file to scan.",
+						}),
+					);
+					return;
+				}
+
+				const scanResp = await onboardingApi.scanServers(
+					scannableClients.map((client) => ({
+						identifier: client.identifier,
+						display_name: client.display_name || client.identifier,
+						config_path: client.config_path,
+						config_file_parse:
+							client.config_file_parse_override ??
+							client.config_file_parse_effective ??
+							null,
+					})),
+				);
+				if (!scanResp.success || !scanResp.data) {
+					throw new Error(
+						String(scanResp.error?.message ?? "Local config scan failed"),
+					);
+				}
+
+				const drafts: ServerInstallDraft[] = scanResp.data.candidates.map(
+					(candidate) => ({
+						name: candidate.name,
+						kind:
+							candidate.kind === "sse" ||
+								candidate.kind === "streamable_http"
+								? candidate.kind
+								: "stdio",
+						command:
+							candidate.kind === "stdio"
+								? candidate.command ?? undefined
+								: undefined,
+						args: candidate.args?.length ? candidate.args : undefined,
+						env:
+							candidate.env && Object.keys(candidate.env).length
+								? candidate.env
+								: undefined,
+						url:
+							candidate.kind !== "stdio" && candidate.url
+								? candidate.url
+								: undefined,
+					}),
+				);
+				if (!drafts.length) {
+					notifyError(
+						t("manual.scan.noServersTitle", {
+							defaultValue: "No servers detected",
+						}),
+						t("manual.scan.noServersDescription", {
+							defaultValue:
+								"The local scan did not find importable MCP server entries.",
+						}),
+					);
+					return;
+				}
+
+				if (drafts.length === 1) {
+					loadDraftIntoForm(drafts[0]);
+					installPipeline.setDraftCollection(drafts, "ingest");
+					setBulkDraftView("detail");
+					setActiveDraftName(drafts[0].name);
+					markIngestSuccess();
+					return;
+				}
+
+				installPipeline.setDraftCollection(drafts, "ingest");
+				installPipeline.setCurrentStep("form");
+				resetBulkUIState();
+				markIngestSuccess();
+			} catch (error) {
+				notifyError(
+					t("manual.scan.failedTitle", {
+						defaultValue: "Local scan failed",
+					}),
+					error instanceof Error ? error.message : String(error ?? ""),
+				);
+			} finally {
+				setLocalScanLoading(false);
+			}
 		}, [
 			ingestEnabled,
+			installPipeline,
 			isDropZoneCollapsed,
-			ingestError,
-			isIngestSuccess,
-			resetIngestState,
-			setIsDropZoneCollapsed,
+			isIngesting,
+			isLocalScanLoading,
+			loadDraftIntoForm,
+			markIngestSuccess,
+			resetBulkUIState,
+			t,
 		]);
+
+		const scanActionLabel = t("manual.scan.action", {
+			defaultValue: "Scan local configs",
+		});
+		const scanActionHint = t("manual.scan.actionHint", {
+			defaultValue: "Click to scan local configs",
+		});
+
+		const handleDropZoneClick = useCallback(
+			(event: MouseEvent<HTMLButtonElement>) => {
+				event.stopPropagation();
+				if (!ingestEnabled) return;
+				if (isDropZoneCollapsed || ingestError || isIngestSuccess) {
+					resetIngestState();
+					setIsDropZoneCollapsed(false);
+				}
+			},
+			[ingestEnabled, ingestError, isDropZoneCollapsed, isIngestSuccess, resetIngestState, setIsDropZoneCollapsed],
+		);
+
+		const handleDropZoneFocus = useCallback(() => {
+			if (!ingestEnabled || !isDropZoneCollapsed) return;
+			resetIngestState();
+			setIsDropZoneCollapsed(false);
+		}, [ingestEnabled, isDropZoneCollapsed, resetIngestState, setIsDropZoneCollapsed]);
 
 		const handleContentFocus = useCallback(
 			(event: FocusEvent<HTMLDivElement>) => {
@@ -743,6 +1017,13 @@ export const ServerInstallWizard = forwardRef(
 			[ingestEnabled, isDropZoneCollapsed, setIsDropZoneCollapsed],
 		);
 
+		const handleFormInteraction = useCallback(() => {
+			if (!ingestEnabled) return;
+			if (!isDropZoneCollapsed) {
+				setIsDropZoneCollapsed(true);
+			}
+		}, [ingestEnabled, isDropZoneCollapsed, setIsDropZoneCollapsed]);
+
 		// Step navigation logic
 		const canNavigateToStep = useCallback(
 			(step: WizardStep): boolean => {
@@ -750,6 +1031,9 @@ export const ServerInstallWizard = forwardRef(
 					case "form":
 						return true;
 					case "preview":
+						if (installPipeline.state.drafts.length > 1) {
+							return installPipeline.state.selectedDraftNames.length > 0;
+						}
 						return previewPrereqsMet && !hasBlockingErrors && !jsonError;
 					case "result":
 						// Can navigate to result if preview is completed
@@ -763,6 +1047,8 @@ export const ServerInstallWizard = forwardRef(
 				hasBlockingErrors,
 				jsonError,
 				installPipeline.state.previewState,
+				installPipeline.state.drafts.length,
+				installPipeline.state.selectedDraftNames.length,
 			],
 		);
 
@@ -819,6 +1105,8 @@ export const ServerInstallWizard = forwardRef(
 				if (version) meta.version = version;
 				if (websiteUrl) meta.websiteUrl = websiteUrl;
 				if (repository) meta.repository = repository;
+				const iconUrl = trim(values.meta_icon_url);
+				if (iconUrl) meta.icons = [{ src: iconUrl }];
 
 				return {
 					name: values.name.trim(),
@@ -837,9 +1125,66 @@ export const ServerInstallWizard = forwardRef(
 			[initialDraft?.registryServerId],
 		);
 
+		const persistActiveDraft = useCallback(() => {
+			if (!activeDraftName) return;
+			const nextDraft = toDraftFromValues(getValues());
+			installPipeline.updateDraft(nextDraft, activeDraftName);
+			if (nextDraft.name !== activeDraftName) {
+				setActiveDraftName(nextDraft.name);
+			}
+		}, [activeDraftName, getValues, installPipeline, toDraftFromValues]);
+
 		const handlePreview = useCallback(
 			async (opts?: { shouldFocus?: boolean; skipValidation?: boolean }) => {
 				if (previewInFlightRef.current) return;
+				const isBulkCollection = installPipeline.state.drafts.length > 1;
+				if (isBulkCollection) {
+					const selectedNames = new Set(
+						installPipeline.state.selectedDraftNames,
+					);
+					const activeDraft =
+						activeDraftName && bulkDraftView === "detail"
+							? toDraftFromValues(getValues())
+							: null;
+					if (activeDraft && activeDraftName) {
+						installPipeline.updateDraft(activeDraft, activeDraftName);
+						if (activeDraft.name !== activeDraftName) {
+							setActiveDraftName(activeDraft.name);
+							selectedNames.delete(activeDraftName);
+							selectedNames.add(activeDraft.name);
+						}
+					}
+					const nextDrafts = installPipeline.state.drafts.map((draft) =>
+						activeDraft && draft.name === activeDraftName ? activeDraft : draft,
+					);
+					const selectedDrafts = nextDrafts.filter((draft) =>
+						selectedNames.has(draft.name),
+					);
+					if (!selectedDrafts.length) {
+						notifyError(
+							t("manual.bulk.noSelectionTitle", {
+								defaultValue: "No servers selected",
+							}),
+							t("manual.bulk.noSelectionDescription", {
+								defaultValue: "Select at least one server to preview.",
+							}),
+						);
+						return;
+					}
+					installPipeline.setDraftCollection(nextDrafts, "ingest");
+					installPipeline.setSelectedDraftNames(Array.from(selectedNames));
+					previewInFlightRef.current = true;
+					try {
+						installPipeline.setCurrentStep("preview");
+						setActivePreviewName(selectedDrafts[0]?.name ?? null);
+						await installPipeline.previewDrafts(
+							selectedDrafts[0] ? [selectedDrafts[0]] : [],
+						);
+					} finally {
+						previewInFlightRef.current = false;
+					}
+					return;
+				}
 				if (!opts?.skipValidation) {
 					const isValid = await trigger(undefined, {
 						shouldFocus: opts?.shouldFocus ?? true,
@@ -854,7 +1199,7 @@ export const ServerInstallWizard = forwardRef(
 				const origin = isImportMode
 					? ("market" as InstallSource)
 					: ("manual" as InstallSource);
-				installPipeline.setDrafts(drafts);
+				installPipeline.setDraftCollection(drafts, origin);
 
 				if (currentStep !== "preview") {
 					installPipeline.setCurrentStep("preview");
@@ -919,6 +1264,9 @@ export const ServerInstallWizard = forwardRef(
 				onPreview,
 				currentStep,
 				installPipeline,
+				activeDraftName,
+				bulkDraftView,
+				t,
 			],
 		);
 
@@ -970,8 +1318,9 @@ export const ServerInstallWizard = forwardRef(
 				setIsClosing(false);
 				installPipeline.setCurrentStep("form");
 				installPipeline.reset();
+				resetBulkUIState();
 			}
-		}, [cleanupPendingImportServer, onClose, isClosing, installPipeline]);
+		}, [cleanupPendingImportServer, onClose, isClosing, installPipeline, resetBulkUIState]);
 
 		// Handle import action
 		const handleImport = useCallback(async () => {
@@ -1087,6 +1436,7 @@ export const ServerInstallWizard = forwardRef(
 					// Reset UI state
 					setUiActiveTab("core");
 					setViewMode("form");
+					resetBulkUIState();
 				}, 50);
 			}
 		}, [
@@ -1099,6 +1449,7 @@ export const ServerInstallWizard = forwardRef(
 			buildFormValuesFromState,
 			resetIngestState,
 			setViewMode,
+			resetBulkUIState,
 		]);
 
 		type NextStepAction = "close" | "servers" | "profiles" | "preview" | "none";
@@ -1257,6 +1608,237 @@ export const ServerInstallWizard = forwardRef(
 			},
 		}));
 
+		const selectedDraftNameSet = useMemo(
+			() => new Set(installPipeline.state.selectedDraftNames),
+			[installPipeline.state.selectedDraftNames],
+		);
+
+		const wizardBulkActions = useMemo(
+			() =>
+				buildIncludeExcludeBulkActions({
+					bulk: bulkSelection,
+					visibleIds: installPipeline.state.drafts.map((draft) => draft.name),
+					onInclude: () =>
+						installPipeline.setSelectedDraftNames(
+							Array.from(
+								new Set([
+									...installPipeline.state.selectedDraftNames,
+									...bulkSelection.selectedIds,
+								]),
+							),
+						),
+					onExclude: () =>
+						installPipeline.setSelectedDraftNames(
+							installPipeline.state.selectedDraftNames.filter(
+								(name) => !bulkSelection.selectedIdSet.has(name),
+							),
+						),
+					t,
+				}),
+			[bulkSelection, installPipeline.state.drafts, installPipeline.state.selectedDraftNames, installPipeline.setSelectedDraftNames, t],
+		);
+
+		const toggleDraftSelection = useCallback(
+			(name: string) => {
+				const next = new Set(installPipeline.state.selectedDraftNames);
+				if (next.has(name)) {
+					next.delete(name);
+				} else {
+					next.add(name);
+				}
+				installPipeline.setSelectedDraftNames(Array.from(next));
+			},
+			[installPipeline],
+		);
+
+		const openDraftDetail = useCallback(
+			(draft: ServerInstallDraft) => {
+				if (activeDraftName && bulkDraftView === "detail") {
+					persistActiveDraft();
+				}
+				loadDraftIntoForm(draft);
+				setActiveDraftName(draft.name);
+				setBulkDraftView("detail");
+			},
+			[
+				activeDraftName,
+				bulkDraftView,
+				loadDraftIntoForm,
+				persistActiveDraft,
+			],
+		);
+
+		const returnToBulkList = useCallback(() => {
+			persistActiveDraft();
+			setBulkDraftView("list");
+			setActiveDraftName(null);
+		}, [persistActiveDraft]);
+
+		const previewDraftByName = useCallback(
+			async (name: string) => {
+				const draft = installPipeline.state.drafts.find(
+					(item) => item.name === name,
+				);
+				if (!draft) return;
+				setActivePreviewName(name);
+				await installPipeline.previewDrafts([draft]);
+			},
+			[installPipeline],
+		);
+
+		const renderDraftListItem = (
+			draft: ServerInstallDraft,
+			options: {
+				isActive?: boolean;
+				mode: "configure" | "preview";
+			},
+		) => {
+			const includedForImport = selectedDraftNameSet.has(draft.name);
+			const bulkSelected =
+				options.mode === "configure" &&
+				bulkSelection.isBulkMode &&
+				bulkSelection.selectedIdSet.has(draft.name);
+			const endpoint = draftEndpointSummary(draft);
+			const draftIcon = draft.meta?.icons?.[0]?.src;
+			const draftDescription = draft.meta?.description?.trim();
+			const avatarFallback = (draft.name || "S").slice(0, 1).toUpperCase();
+			const isConfigureBulkMode =
+				options.mode === "configure" && bulkSelection.isBulkMode;
+			const handleRowActivate = () => {
+				if (isConfigureBulkMode) {
+					bulkSelection.toggleItem(draft.name);
+					return;
+				}
+				if (options.mode === "configure") {
+					openDraftDetail(draft);
+					return;
+				}
+				void previewDraftByName(draft.name);
+			};
+			return (
+				<CapsuleStripeListItem
+					key={draft.name}
+					interactive
+					className={cn(
+						"group relative transition-colors",
+						(bulkSelected || options.isActive) &&
+						"bg-primary/10 ring-1 ring-primary/40",
+					)}
+					onClick={handleRowActivate}
+					onKeyDown={(event) => {
+						if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault();
+							handleRowActivate();
+						}
+					}}
+				>
+					<div className="flex w-full items-center justify-between gap-4">
+						<div className="flex min-w-0 flex-1 items-center gap-3">
+							{options.mode === "configure" ? (
+								<BulkSelectionCheckbox
+									visible={bulkSelection.isBulkMode}
+									checked={bulkSelected}
+									onToggle={() => bulkSelection.toggleItem(draft.name)}
+									ariaLabel={t("manual.bulk.selectServer", {
+										name: draft.name,
+										defaultValue: "Select {{name}}",
+									})}
+								/>
+							) : null}
+							<CachedAvatar
+								src={draftIcon}
+								alt={draft.name ? `${draft.name} icon` : undefined}
+								fallback={avatarFallback}
+								size="sm"
+								shape="rounded"
+								className="border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/40"
+							/>
+							<div className="min-w-0">
+								<h3 className="font-medium text-slate-900 dark:text-slate-100">
+									{toTitleCase(draft.name)}
+								</h3>
+								<p className="truncate text-sm text-slate-500">
+									{endpoint ||
+										t("manual.bulk.missingEndpoint", {
+											defaultValue: "Missing command or URL",
+										})}
+								</p>
+								{draftDescription ? (
+									<p className="line-clamp-2 text-xs text-slate-500">
+										{draftDescription}
+									</p>
+								) : null}
+							</div>
+						</div>
+						<div className="ml-auto flex shrink-0 items-center gap-2">
+							{endpoint ? (
+								<Badge variant="secondary">{transportLabel[draft.kind]}</Badge>
+							) : (
+								<Badge variant="outline">
+									{t("manual.bulk.missingEndpoint", {
+										defaultValue: "Missing command or URL",
+									})}
+								</Badge>
+							)}
+							{options.mode === "configure" ? (
+								<Switch
+									checked={includedForImport}
+									onClick={(event) => event.stopPropagation()}
+									onCheckedChange={() => toggleDraftSelection(draft.name)}
+									aria-label={t("manual.bulk.includeForImport", {
+										name: draft.name,
+										defaultValue: "Include {{name}} in import",
+									})}
+								/>
+							) : null}
+							{!isConfigureBulkMode ? (
+								<ChevronRight
+									className="h-4 w-4 shrink-0 text-slate-400 dark:text-slate-500"
+									aria-hidden
+								/>
+							) : null}
+						</div>
+					</div>
+				</CapsuleStripeListItem>
+			);
+		};
+
+		const renderBulkDraftList = () => {
+			const drafts = installPipeline.state.drafts;
+			return (
+				<div
+					className="flex min-h-0 flex-1 flex-col"
+					onClick={handleFormInteraction}
+				>
+					<BulkSelectionHeader
+						title={t("manual.bulk.title", {
+							count: drafts.length,
+							defaultValue: "{{count}} servers detected",
+						})}
+						description={
+							bulkSelection.isBulkMode
+								? bulkModeDescription(bulkSelection.selectedCount)
+								: t("manual.bulk.description", {
+									count: installPipeline.state.selectedDraftNames.length,
+									defaultValue:
+										"Select the servers to preview and import. {{count}} selected.",
+								})
+						}
+						isBulkMode={bulkSelection.isBulkMode}
+						onToggleBulkMode={bulkSelection.toggleMode}
+						actions={wizardBulkActions}
+					/>
+					<CardListScrollBody>
+						<CapsuleStripeList className="rounded-none border-0 overflow-visible">
+							{drafts.map((draft) =>
+								renderDraftListItem(draft, { mode: "configure" }),
+							)}
+						</CapsuleStripeList>
+					</CardListScrollBody>
+				</div>
+			);
+		};
+
 		// Render step content
 		const renderStepContent = () => {
 			switch (currentStep) {
@@ -1272,28 +1854,33 @@ export const ServerInstallWizard = forwardRef(
 		};
 
 		const renderFormStep = () => {
+			const showBulkDraftList =
+				installPipeline.state.drafts.length > 1 && bulkDraftView === "list";
 			const contentPadding = ingestEnabled
 				? "px-4 pb-4 pt-0"
 				: "px-4 pb-4 pt-4";
+			const flexFillClass =
+				"flex min-h-0 flex-1 flex-col overflow-hidden";
+			const isCoreJsonPanel = viewMode === "json" && uiActiveTab === "core";
 			return (
-				<div className="flex flex-col">
+				<div className={flexFillClass}>
 					<form
 						onSubmit={handleSubmit(() =>
 							handlePreview({ skipValidation: true, shouldFocus: false }),
 						)}
-						className="flex flex-col"
-						onClick={handleFormInteraction}
-						onKeyDown={handleFormInteraction}
+						className={flexFillClass}
 					>
 						{/* New-mode drop zone (top) */}
 						{ingestEnabled ? (
-							<div className="px-4 py-4">
+							<div
+								className="relative shrink-0 px-4 py-4"
+								onClick={(event) => event.stopPropagation()}
+							>
 								<button
 									type="button"
 									ref={dropZoneRef}
-									onFocus={handleDropZoneActivate}
-									onClick={handleDropZoneActivate}
-									onMouseDown={handleDropZoneActivate}
+									onFocus={handleDropZoneFocus}
+									onClick={handleDropZoneClick}
 									onDragOver={(e) => {
 										if (!canIngestFromDataTransfer(e.dataTransfer)) return;
 										e.preventDefault();
@@ -1350,20 +1937,51 @@ export const ServerInstallWizard = forwardRef(
 											<Loader2
 												className={`${isDropZoneCollapsed ? "h-4 w-4" : "h-6 w-6"} animate-spin`}
 											/>
-										) : (
-											<Target
-												className={`transition-all duration-300 ${isDropZoneCollapsed ? "h-4 w-4" : "h-12 w-12"
-													} ${isDragOver || isIngesting
-														? "animate-pulse"
-														: "scale-100"
-													} ${isDragOver ? "text-blue-500" : "text-slate-500"}`}
-												style={{
-													animation:
-														ingestError || isDragOver || isIngesting
-															? "breathing 1.5s ease-in-out infinite"
-															: undefined,
-												}}
+										) : isDropZoneCollapsed ? (
+											<Radar
+												className="h-4 w-4 shrink-0 text-slate-500"
+												aria-hidden
 											/>
+										) : (
+											<TooltipProvider delayDuration={200}>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<button
+															type="button"
+															className={cn(
+																"inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-full transition-colors",
+																"hover:bg-slate-200/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:bg-slate-800/60",
+															)}
+															disabled={isLocalScanLoading || isIngesting}
+															aria-label={scanActionLabel}
+															onClick={(event) => {
+																event.stopPropagation();
+																void handleLocalConfigScan();
+															}}
+														>
+															{isLocalScanLoading ? (
+																<Loader2 className="h-6 w-6 animate-spin" />
+															) : (
+																<Radar
+																	className={cn(
+																		"h-12 w-12 scale-100 text-slate-500 transition-all duration-300",
+																		isDragOver && "animate-pulse text-blue-500",
+																	)}
+																	style={{
+																		animation:
+																			ingestError || isDragOver
+																				? "breathing 1.5s ease-in-out infinite"
+																				: undefined,
+																	}}
+																/>
+															)}
+														</button>
+													</TooltipTrigger>
+													<TooltipContent side="bottom">
+														{scanActionHint}
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
 										)}
 										<p
 											className={`text-sm ${ingestError
@@ -1398,359 +2016,389 @@ export const ServerInstallWizard = forwardRef(
 						) : null}
 
 						<div
-							className={`relative z-0 ${contentPadding}`}
+							className={cn(
+								"relative z-0 flex min-h-0 flex-1 flex-col",
+								contentPadding,
+								formContentScrollClass(isCoreJsonPanel),
+							)}
 							onFocusCapture={handleContentFocus}
 						>
-							<Tabs
-								value={uiActiveTab}
-								onValueChange={(v) => setUiActiveTab(v as "core" | "meta")}
-								className="h-full flex flex-col"
-							>
-								<TabsList className="grid w-full grid-cols-2">
-									<TabsTrigger value="core">
-										{t("manual.tabs.core", {
-											defaultValue: "Core configuration",
-										})}
-									</TabsTrigger>
-									<TabsTrigger value="meta">
-										{t("manual.tabs.meta", {
-											defaultValue: "Meta information",
-										})}{" "}
-										<sup>
-											({t("manual.tabs.metaWip", { defaultValue: "WIP" })})
-										</sup>
-									</TabsTrigger>
-								</TabsList>
-
-								<TabsContent
-									value="core"
-									className="space-y-4 flex-1 min-h-0"
-									onClick={handleFormInteraction}
-								>
-									<div className="space-y-4">
-										{/* View Mode Toggle */}
-										<div className="flex justify-end pt-2">
-											<FormViewModeToggle
-												mode={viewMode}
-												onChange={handleModeChange}
-												variant="compact"
-											/>
+							{showBulkDraftList ? (
+								renderBulkDraftList()
+							) : (
+								<>
+									{installPipeline.state.drafts.length > 1 ? (
+										<div className="mb-3 shrink-0">
+											<Button
+												type="button"
+												variant="ghost"
+												size="sm"
+												onClick={returnToBulkList}
+											>
+												<ArrowLeft className="mr-2 h-4 w-4" />
+												{t("manual.bulk.backToList", {
+													defaultValue: "Back to detected servers",
+												})}
+											</Button>
 										</div>
+									) : null}
+									<Tabs
+										value={uiActiveTab}
+										onValueChange={(v) => setUiActiveTab(v as "core" | "meta")}
+										className="flex min-h-0 flex-1 flex-col"
+									>
+										<TabsList className="grid w-full shrink-0 grid-cols-2">
+											<TabsTrigger value="core">
+												{t("manual.tabs.core", {
+													defaultValue: "Core configuration",
+												})}
+											</TabsTrigger>
+											<TabsTrigger value="meta">
+												{t("manual.tabs.meta", {
+													defaultValue: "Meta information",
+												})}{" "}
+												<sup>
+													({t("manual.tabs.metaWip", { defaultValue: "WIP" })})
+												</sup>
+											</TabsTrigger>
+										</TabsList>
 
-										{viewMode === "form" ? (
-											<>
-												<div className="space-y-4">
-													<div className="flex items-center gap-4">
-														<Label htmlFor={nameId} className="w-20 text-right">
-															{t("manual.fields.name.label", {
-																defaultValue: "Name",
-															})}
-														</Label>
-														<div className="flex-1">
-															<Input
-																id={nameId}
-																{...register("name")}
-																placeholder={t(
-																	"manual.fields.name.placeholder",
-																	{
-																		defaultValue: "e.g., local-mcp",
-																	},
-																)}
-																readOnly={isEditMode || Boolean(pendingImportServerId)}
-																aria-readonly={isEditMode || Boolean(pendingImportServerId)}
-																title={
-																	isEditMode || Boolean(pendingImportServerId)
-																		? pendingImportServerId
-																			? t("manual.fields.name.readOnlyTitleAfterOAuth", {
-																				defaultValue:
-																					"Editing server names is disabled after OAuth setup starts",
-																			})
-																			: t("manual.fields.name.readOnlyTitle", {
-																				defaultValue: "Editing server names is disabled",
-																			})
-																		: undefined
-																}
-																className={
-																	isEditMode || Boolean(pendingImportServerId)
-																		? "cursor-not-allowed bg-muted text-muted-foreground"
-																		: undefined
-																}
-															/>
-															{errors.name && (
-																<p className="text-xs text-red-500">
-																	{errors.name.message}
-																</p>
-															)}
-														</div>
-													</div>
-													<div className="flex items-center gap-4">
-														<Label htmlFor={kindId} className="w-20 text-right">
-															{t("manual.fields.type.label", {
-																defaultValue: "Type",
-															})}
-														</Label>
-														<div className="flex-1">
-															<Segment
-																options={SERVER_TYPE_OPTIONS}
-																value={kind}
-																onValueChange={(value) => {
-																	if (pendingImportServerId) {
-																		return;
-																	}
-																	const newKind =
-																		value as ManualServerFormValues["kind"];
-																	if (newKind === kind) {
-																		return;
-																	}
-																	saveTypeSnapshot(kind);
-																	setValue("kind", newKind, {
-																		shouldDirty: true,
-																		shouldTouch: true,
-																	});
-																	restoreTypeSnapshot(newKind);
-																}}
-																showDots={true}
-															/>
-															{errors.kind && (
-																<p className="text-xs text-red-500">
-																	{errors.kind.message}
-																</p>
-															)}
-														</div>
-													</div>
-												</div>
-
-												<CommandField
-													kind={kind}
-													control={control}
-													errors={errors}
-													commandId={commandId}
-													urlId={urlId}
-													viewMode={viewMode}
-													onCreateSecret={onCreateSecret}
-													secretOriginBase={secretOriginBase}
+										<TabsContent
+											value="core"
+											className={FORM_TAB_SHELL_CLASS}
+										>
+											<div className={FORM_TAB_TOOLBAR_ROW_CLASS}>
+												<FormViewModeToggle
+													mode={viewMode}
+													onChange={handleModeChange}
+													variant="compact"
 												/>
+											</div>
 
-												<ServerAuthSection
-													serverId={pendingImportServerId ?? undefined}
-													isStdio={isStdio}
-													viewMode={viewMode}
-													isNewServer={!isEditMode}
-													suggestedAuthMode={suggestedAuthMode}
-													onAuthModeChange={setSelectedAuthMode}
-													onOAuthConnected={(serverId) => {
-														if (isEditMode || pendingImportServerRef.current !== serverId) {
-															return;
-														}
-														void handlePreview({
-															skipValidation: true,
-															shouldFocus: false,
-														});
-													}}
-													onInitiateOAuth={async (config) => {
-														const formValues = getValues();
-														const draft = toDraftFromValues(formValues);
-														if (!draft.name) {
-															throw new Error(
-																t("manual.errors.nameRequired", {
-																	defaultValue: "Name is required",
-																}),
-															);
-														}
+											<div
+												className={formTabScrollClass(viewMode)}
+												onClick={handleFormInteraction}
+											>
+												{viewMode === "form" ? (
+													<>
+														<div className="space-y-4">
+															<div className="flex items-center gap-4">
+																<Label htmlFor={nameId} className="w-20 text-right">
+																	{t("manual.fields.name.label", {
+																		defaultValue: "Name",
+																	})}
+																</Label>
+																<div className="flex-1">
+																	<Input
+																		id={nameId}
+																		{...register("name")}
+																		placeholder={t(
+																			"manual.fields.name.placeholder",
+																			{
+																				defaultValue: "e.g., local-mcp",
+																			},
+																		)}
+																		readOnly={isEditMode || Boolean(pendingImportServerId)}
+																		aria-readonly={isEditMode || Boolean(pendingImportServerId)}
+																		title={
+																			isEditMode || Boolean(pendingImportServerId)
+																				? pendingImportServerId
+																					? t("manual.fields.name.readOnlyTitleAfterOAuth", {
+																						defaultValue:
+																							"Editing server names is disabled after OAuth setup starts",
+																					})
+																					: t("manual.fields.name.readOnlyTitle", {
+																						defaultValue: "Editing server names is disabled",
+																					})
+																				: undefined
+																		}
+																		className={
+																			isEditMode || Boolean(pendingImportServerId)
+																				? "cursor-not-allowed bg-muted text-muted-foreground"
+																				: undefined
+																		}
+																	/>
+																	{errors.name && (
+																		<p className="text-xs text-red-500">
+																			{errors.name.message}
+																		</p>
+																	)}
+																</div>
+															</div>
+															<div className="flex items-center gap-4">
+																<Label htmlFor={kindId} className="w-20 text-right">
+																	{t("manual.fields.type.label", {
+																		defaultValue: "Type",
+																	})}
+																</Label>
+																<div className="flex-1">
+																	<Segment
+																		options={serverTypeOptions}
+																		value={kind}
+																		onValueChange={(value) => {
+																			if (pendingImportServerId) {
+																				return;
+																			}
+																			const newKind =
+																				value as ManualServerFormValues["kind"];
+																			if (newKind === kind) {
+																				return;
+																			}
+																			saveTypeSnapshot(kind);
+																			setValue("kind", newKind, {
+																				shouldDirty: true,
+																				shouldTouch: true,
+																			});
+																			restoreTypeSnapshot(newKind);
+																		}}
+																		showDots={true}
+																	/>
+																	{errors.kind && (
+																		<p className="text-xs text-red-500">
+																			{errors.kind.message}
+																		</p>
+																	)}
+																</div>
+															</div>
+														</div>
 
-														let targetServerId = pendingImportServerRef.current;
-														if (!isEditMode) {
-															if (targetServerId) {
-																await serversApi.updateServer(
-																	targetServerId,
-																	draftToServerConfig(draft, {
-																		pending_import: true,
-																		enabled: false,
-																	}),
-																);
-															} else {
-																const created = await serversApi.createServer(
-																	draftToServerConfig(draft, {
-																		pending_import: true,
-																		enabled: false,
-																	}),
-																);
-																targetServerId = created.data?.id ?? null;
-																if (!targetServerId) {
+														<CommandField
+															kind={kind}
+															control={control}
+															errors={errors}
+															commandId={commandId}
+															urlId={urlId}
+															viewMode={viewMode}
+															onCreateSecret={onCreateSecret}
+															secretOriginBase={secretOriginBase}
+														/>
+
+														<ServerAuthSection
+															serverId={pendingImportServerId ?? undefined}
+															isStdio={isStdio}
+															viewMode={viewMode}
+															isNewServer={!isEditMode}
+															suggestedAuthMode={suggestedAuthMode}
+															onAuthModeChange={setSelectedAuthMode}
+															onOAuthConnected={(serverId) => {
+																if (isEditMode || pendingImportServerRef.current !== serverId) {
+																	return;
+																}
+																void handlePreview({
+																	skipValidation: true,
+																	shouldFocus: false,
+																});
+															}}
+															onInitiateOAuth={async (config) => {
+																const formValues = getValues();
+																const draft = toDraftFromValues(formValues);
+																if (!draft.name) {
 																	throw new Error(
-																		t("manual.errors.oauthDraftServerFailed", {
-																			defaultValue: "Failed to create OAuth draft server",
+																		t("manual.errors.nameRequired", {
+																			defaultValue: "Name is required",
 																		}),
 																	);
 																}
-																pendingImportServerRef.current = targetServerId;
-																setPendingImportServerId(targetServerId);
-															}
-														} else if (!targetServerId) {
-															throw new Error(
-																t("manual.errors.oauthServerIdRequired", {
-																	defaultValue: "Server ID is required to initiate OAuth",
-																}),
-															);
-														}
 
-														await startOAuthAccessFlow(targetServerId, config);
-													}}
-												/>
-
-												<StdioAdvanced
-													viewMode={viewMode}
-													isStdio={isStdio}
-													argFields={argFields.fields}
-													envFields={envFields.fields}
-													removeArg={removeArg}
-													removeEnv={removeEnv}
-													appendArg={appendArg}
-													appendEnv={appendEnv}
-													register={register}
-													control={control}
-													deleteConfirmStates={deleteConfirmStates}
-													onDeleteClick={handleDeleteClick}
-													onGhostClick={handleGhostClick}
-													onCreateSecret={onCreateSecret}
-													secretOriginBase={secretOriginBase}
-													getEnvRowKeyAt={(index) =>
-														watchedEnv?.[index]?.key?.trim() || undefined
-													}
-												/>
-
-												<UrlParams
-													viewMode={viewMode}
-													isStdio={isStdio}
-													urlParamFields={paramFields.fields}
-													removeUrlParam={removeUrlParam}
-													appendUrlParam={appendUrlParam}
-													register={register}
-													control={control}
-													deleteConfirmStates={deleteConfirmStates}
-													onDeleteClick={handleDeleteClick}
-													onGhostClick={handleGhostClick}
-													onCreateSecret={onCreateSecret}
-													secretOriginBase={secretOriginBase}
-													getRowKeyAt={(index) =>
-														watchedUrlParams?.[index]?.key?.trim() || undefined
-													}
-												/>
-
-												{!isStdio && selectedAuthMode === "oauth" ? (
-													<p className="text-xs text-slate-500 dark:text-slate-400">
-														{t("manual.auth.transportHint", {
-															defaultValue:
-																"URL Parameters and HTTP Headers are optional transport extras. They still apply after OAuth if this server needs them.",
-														})}
-													</p>
-												) : null}
-
-												<HttpHeaders
-													viewMode={viewMode}
-													isStdio={isStdio}
-													headerFields={headerFields.fields}
-													removeHeader={removeHeader}
-													appendHeader={appendHeader}
-													register={register}
-													control={control}
-													deleteConfirmStates={deleteConfirmStates}
-													onDeleteClick={handleDeleteClick}
-													onGhostClick={handleGhostClick}
-													onCreateSecret={onCreateSecret}
-													secretOriginBase={secretOriginBase}
-													getRowKeyAt={(index) =>
-														watchedHeaders?.[index]?.key?.trim() || undefined
-													}
-												/>
-											</>
-										) : (
-											<div className="flex flex-col h-full">
-												<div className="flex items-start gap-4 flex-1">
-													<Label
-														htmlFor={manualJsonId}
-														className="w-20 text-right pt-3 flex-shrink-0"
-													>
-														{t("manual.fields.json.label", {
-															defaultValue: "Server JSON",
-														})}
-													</Label>
-													<div className="flex-1 flex flex-col">
-														<div className="group relative flex-1 min-h-[400px] border border-input rounded-md flex flex-col">
-															{jsonText && (
-																<div className="pointer-events-none absolute top-0 right-0 z-10 flex w-full justify-end p-2">
-																	<Button
-																		type="button"
-																		variant="outline"
-																		size="sm"
-																		className="pointer-events-auto h-7 w-7 p-0 bg-white/95 backdrop-blur-sm opacity-0 shadow-sm transition-opacity group-hover:opacity-100 dark:bg-slate-900/95"
-																		onClick={async (event) => {
-																			event.stopPropagation();
-																			await writeClipboardText(jsonText);
-																		}}
-																		title={t("manual.fields.json.copy", {
-																			defaultValue: "Copy JSON",
-																		})}
-																	>
-																		<Copy className="h-3.5 w-3.5" />
-																	</Button>
-																</div>
-															)}
-															<Textarea
-																id={manualJsonId}
-																value={jsonText}
-																onChange={
-																	jsonEditingEnabled
-																		? (event) => setJsonText(event.target.value)
-																		: undefined
+																let targetServerId = pendingImportServerRef.current;
+																if (!isEditMode) {
+																	if (targetServerId) {
+																		await serversApi.updateServer(
+																			targetServerId,
+																			draftToServerConfig(draft, {
+																				pending_import: true,
+																				enabled: false,
+																			}),
+																		);
+																	} else {
+																		const created = await serversApi.createServer(
+																			draftToServerConfig(draft, {
+																				pending_import: true,
+																				enabled: false,
+																			}),
+																		);
+																		targetServerId = created.data?.id ?? null;
+																		if (!targetServerId) {
+																			throw new Error(
+																				t("manual.errors.oauthDraftServerFailed", {
+																					defaultValue: "Failed to create OAuth draft server",
+																				}),
+																			);
+																		}
+																		pendingImportServerRef.current = targetServerId;
+																		setPendingImportServerId(targetServerId);
+																	}
+																} else if (!targetServerId) {
+																	throw new Error(
+																		t("manual.errors.oauthServerIdRequired", {
+																			defaultValue: "Server ID is required to initiate OAuth",
+																		}),
+																	);
 																}
-																readOnly={!jsonEditingEnabled}
-																aria-readonly={!jsonEditingEnabled}
-																className="font-mono text-sm flex-1 border-0 focus:ring-0 focus:outline-none"
-																style={{
-																	background: "transparent",
-																	caretColor: jsonEditingEnabled
-																		? "currentColor"
-																		: "transparent",
-																	minHeight: "400px",
-																	userSelect: "text",
-																	WebkitUserSelect: "text",
-																	MozUserSelect: "text",
-																	msUserSelect: "text",
-																}}
-															/>
-														</div>
-														{jsonError ? (
-															<p className="text-xs text-red-500 mt-2">
-																{jsonError}
+
+																await startOAuthAccessFlow(targetServerId, config);
+															}}
+														/>
+
+														<StdioAdvanced
+															viewMode={viewMode}
+															isStdio={isStdio}
+															argFields={argFields.fields}
+															envFields={envFields.fields}
+															removeArg={removeArg}
+															removeEnv={removeEnv}
+															appendArg={appendArg}
+															appendEnv={appendEnv}
+															register={register}
+															control={control}
+															deleteConfirmStates={deleteConfirmStates}
+															onDeleteClick={handleDeleteClick}
+															onGhostClick={handleGhostClick}
+															onCreateSecret={onCreateSecret}
+															secretOriginBase={secretOriginBase}
+															getEnvRowKeyAt={(index) =>
+																watchedEnv?.[index]?.key?.trim() || undefined
+															}
+														/>
+
+														<UrlParams
+															viewMode={viewMode}
+															isStdio={isStdio}
+															urlParamFields={paramFields.fields}
+															removeUrlParam={removeUrlParam}
+															appendUrlParam={appendUrlParam}
+															register={register}
+															control={control}
+															deleteConfirmStates={deleteConfirmStates}
+															onDeleteClick={handleDeleteClick}
+															onGhostClick={handleGhostClick}
+															onCreateSecret={onCreateSecret}
+															secretOriginBase={secretOriginBase}
+															getRowKeyAt={(index) =>
+																watchedUrlParams?.[index]?.key?.trim() || undefined
+															}
+														/>
+
+														{!isStdio && selectedAuthMode === "oauth" ? (
+															<p className="text-xs text-slate-500 dark:text-slate-400">
+																{t("manual.auth.transportHint", {
+																	defaultValue:
+																		"URL Parameters and HTTP Headers are optional transport extras. They still apply after OAuth if this server needs them.",
+																})}
 															</p>
 														) : null}
-													</div>
-												</div>
-											</div>
-										)}
-									</div>
-								</TabsContent>
 
-								<TabsContent
-									value="meta"
-									className="space-y-4 pt-2"
-									onClick={handleFormInteraction}
-								>
-									<MetaFields
-										formStateRef={formStateRef}
-										register={register}
-										errors={errors}
-										metaDescriptionId={metaDescriptionId}
-										metaVersionId={metaVersionId}
-										metaWebsiteUrlId={metaWebsiteUrlId}
-										metaRepositoryUrlId={metaRepositoryUrlId}
-										metaRepositorySourceId={metaRepositorySourceId}
-										metaRepositorySubfolderId={metaRepositorySubfolderId}
-										metaRepositoryId={metaRepositoryId}
-									/>
-								</TabsContent>
-							</Tabs>
+														<HttpHeaders
+															viewMode={viewMode}
+															isStdio={isStdio}
+															headerFields={headerFields.fields}
+															removeHeader={removeHeader}
+															appendHeader={appendHeader}
+															register={register}
+															control={control}
+															deleteConfirmStates={deleteConfirmStates}
+															onDeleteClick={handleDeleteClick}
+															onGhostClick={handleGhostClick}
+															onCreateSecret={onCreateSecret}
+															secretOriginBase={secretOriginBase}
+															getRowKeyAt={(index) =>
+																watchedHeaders?.[index]?.key?.trim() || undefined
+															}
+														/>
+													</>
+												) : (
+													<div className="flex min-h-0 flex-1 flex-col">
+														<div className="flex min-h-0 flex-1 items-stretch gap-4">
+															<Label
+																htmlFor={manualJsonId}
+																className="w-20 shrink-0 pt-3 text-right"
+															>
+																{t("manual.fields.json.label", {
+																	defaultValue: "Server JSON",
+																})}
+															</Label>
+															<div className="flex min-h-0 flex-1 flex-col">
+																<div className="group relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-input">
+																	{jsonText && (
+																		<div className="pointer-events-none absolute top-0 right-0 z-10 flex w-full justify-end p-2">
+																			<Button
+																				type="button"
+																				variant="outline"
+																				size="sm"
+																				className="pointer-events-auto h-7 w-7 bg-white/95 p-0 opacity-0 shadow-sm backdrop-blur-sm transition-opacity group-hover:opacity-100 dark:bg-slate-900/95"
+																				onClick={async (event) => {
+																					event.stopPropagation();
+																					await writeClipboardText(jsonText);
+																				}}
+																				title={t("manual.fields.json.copy", {
+																					defaultValue: "Copy JSON",
+																				})}
+																			>
+																				<Copy className="h-3.5 w-3.5" />
+																			</Button>
+																		</div>
+																	)}
+																	<Textarea
+																		id={manualJsonId}
+																		value={jsonText}
+																		onChange={
+																			jsonEditingEnabled
+																				? (event) => setJsonText(event.target.value)
+																				: undefined
+																		}
+																		readOnly={!jsonEditingEnabled}
+																		aria-readonly={!jsonEditingEnabled}
+																		className="min-h-0 flex-1 resize-none overflow-y-auto border-0 font-mono text-sm focus:outline-none focus:ring-0"
+																		style={{
+																			background: "transparent",
+																			caretColor: jsonEditingEnabled
+																				? "currentColor"
+																				: "transparent",
+																			userSelect: "text",
+																			WebkitUserSelect: "text",
+																			MozUserSelect: "text",
+																			msUserSelect: "text",
+																		}}
+																	/>
+																</div>
+																{jsonError ? (
+																	<p className="mt-2 shrink-0 text-xs text-red-500">
+																		{jsonError}
+																	</p>
+																) : null}
+															</div>
+														</div>
+													</div>
+												)}
+											</div>
+										</TabsContent>
+
+										<TabsContent
+											value="meta"
+											className={cn(
+												"mt-2 min-h-0 flex-1 focus-visible:outline-none",
+												FORM_TAB_PANEL_TOP_INSET_CLASS,
+											)}
+											onClick={handleFormInteraction}
+										>
+											<MetaFields
+												formStateRef={formStateRef}
+												register={register}
+												errors={errors}
+												iconUrl={watchedMetaIconUrl}
+												metaIconUrlId={metaIconUrlId}
+												metaDescriptionId={metaDescriptionId}
+												metaVersionId={metaVersionId}
+												metaWebsiteUrlId={metaWebsiteUrlId}
+												metaRepositoryUrlId={metaRepositoryUrlId}
+												metaRepositorySourceId={metaRepositorySourceId}
+												metaRepositorySubfolderId={metaRepositorySubfolderId}
+												metaRepositoryId={metaRepositoryId}
+											/>
+										</TabsContent>
+									</Tabs>
+								</>
+							)}
 						</div>
 					</form>
 				</div>
@@ -1782,51 +2430,34 @@ export const ServerInstallWizard = forwardRef(
 			installPipeline.state.previewState.success !== false &&
 			!installPipeline.state.previewError;
 
-		// Expand/collapse details per draft (moved outside render function)
-		const [expanded, setExpanded] = useState<Record<string, boolean>>({});
-		const toggleExpanded = (name: string) =>
-			setExpanded((e) => ({ ...e, [name]: !e[name] }));
-
 		const renderPreviewStep = () => {
 			const { state } = installPipeline;
 			const { drafts, previewState, previewError, isPreviewLoading } = state;
 
 			// Capability rendering helper
 			const renderCapabilitySection = (
-				kind: string,
+				kind: PreviewCapabilityKind,
 				items: Record<string, unknown>[],
 			) => {
 				if (!items.length) return null;
+				const kindLabel = t(`detail.capabilityList.labels.${kind}`, {
+					defaultValue:
+						kind === "templates"
+							? "Resource Templates"
+							: kind.charAt(0).toUpperCase() + kind.slice(1),
+				});
 				return (
 					<div className="space-y-3">
-						<div className="text-xs font-semibold text-slate-700 dark:text-slate-200 uppercase tracking-wide">
-							{kind}
+						<div className="text-xs font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">
+							{kindLabel}
 						</div>
-						<div className="space-y-2.5">
-							{items.map((item, idx) => {
-								const name = String(
-									(item as any).name ??
-									(item as any).title ??
-									`Item ${idx + 1}`,
-								);
-								const description = String(
-									(item as any).description ?? (item as any).summary ?? "",
-								);
-								const uniqueKey = `${kind}-${name}-${idx}`;
-								return (
-									<div key={uniqueKey} className="text-sm leading-relaxed">
-										<div className="font-semibold text-slate-800 dark:text-slate-100">
-											{name}
-										</div>
-										{description && (
-											<div className="text-slate-600 dark:text-slate-400 mt-1 text-xs leading-relaxed">
-												{description}
-											</div>
-										)}
-									</div>
-								);
-							})}
-						</div>
+						<CapabilityList
+							asCard={false}
+							kind={kind}
+							context="server"
+							items={items as CapabilityRecord[]}
+							clickToToggleDetails
+						/>
 					</div>
 				);
 			};
@@ -1843,27 +2474,18 @@ export const ServerInstallWizard = forwardRef(
 			};
 
 			return (
-				<div className="px-4 py-4">
-					<div className="space-y-4">
+				<div className="flex min-h-0 flex-1 flex-col px-4 py-4">
+					<div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
 						{previewError ? (
-							<Alert variant="destructive">
+							<Alert variant="destructive" className="shrink-0">
 								<AlertTriangle className="h-4 w-4" />
 								<AlertTitle>Preview failed</AlertTitle>
 								<AlertDescription>{previewError}</AlertDescription>
 							</Alert>
 						) : null}
 
-						{isPreviewLoading ? (
-							<div className="flex items-center justify-center gap-2 rounded border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
-								<Loader2 className="h-4 w-4 animate-spin" />{" "}
-								{t("wizard.preview.generating", {
-									defaultValue: "Generating capability preview…",
-								})}
-							</div>
-						) : null}
-
 						{previewState?.success === false && previewState?.error ? (
-							<Alert variant="default">
+							<Alert variant="default" className="shrink-0">
 								<AlertTriangle className="h-4 w-4" />
 								<AlertTitle>Preview reported issues</AlertTitle>
 								<AlertDescription>
@@ -1873,8 +2495,8 @@ export const ServerInstallWizard = forwardRef(
 							</Alert>
 						) : null}
 
-						<div className="space-y-3">
-							{drafts.map((draft) => {
+						{(() => {
+							const renderPreviewCard = (draft: ServerInstallDraft) => {
 								const item = previewItemsByName.get(draft.name) as any;
 								const ok = item?.ok !== false;
 								const tools = asRecordList(item?.tools?.items as any);
@@ -1883,83 +2505,186 @@ export const ServerInstallWizard = forwardRef(
 									item?.resource_templates?.items as any,
 								);
 								const prompts = asRecordList(item?.prompts?.items as any);
+								const searchQuery = capabilitySearch.trim();
+								const filteredTools = tools.filter((entry) =>
+									capabilityMatchesSearch(entry, searchQuery),
+								);
+								const filteredResources = resources.filter((entry) =>
+									capabilityMatchesSearch(entry, searchQuery),
+								);
+								const filteredTemplates = templates.filter((entry) =>
+									capabilityMatchesSearch(entry, searchQuery),
+								);
+								const filteredPrompts = prompts.filter((entry) =>
+									capabilityMatchesSearch(entry, searchQuery),
+								);
+								const visibleTools = searchQuery ? filteredTools : tools;
+								const visibleResources = searchQuery
+									? filteredResources
+									: resources;
+								const visibleTemplates = searchQuery
+									? filteredTemplates
+									: templates;
+								const visiblePrompts = searchQuery ? filteredPrompts : prompts;
 								const summaryParts = [] as string[];
-								if (tools.length)
+								if (visibleTools.length)
 									summaryParts.push(
-										`${tools.length} ${tools.length === 1 ? t("wizard.preview.capabilities.tool", { defaultValue: "tool" }) : t("wizard.preview.capabilities.tools", { defaultValue: "tools" })}`,
+										`${visibleTools.length} ${visibleTools.length === 1 ? t("wizard.preview.capabilities.tool", { defaultValue: "tool" }) : t("wizard.preview.capabilities.tools", { defaultValue: "tools" })}`,
 									);
-								if (resources.length)
+								if (visibleResources.length)
 									summaryParts.push(
-										`${resources.length} ${resources.length === 1 ? t("wizard.preview.capabilities.resource", { defaultValue: "resource" }) : t("wizard.preview.capabilities.resources", { defaultValue: "resources" })}`,
+										`${visibleResources.length} ${visibleResources.length === 1 ? t("wizard.preview.capabilities.resource", { defaultValue: "resource" }) : t("wizard.preview.capabilities.resources", { defaultValue: "resources" })}`,
 									);
-								if (templates.length)
+								if (visibleTemplates.length)
 									summaryParts.push(
-										`${templates.length} ${templates.length === 1 ? t("wizard.preview.capabilities.template", { defaultValue: "template" }) : t("wizard.preview.capabilities.templates", { defaultValue: "templates" })}`,
+										`${visibleTemplates.length} ${visibleTemplates.length === 1 ? t("wizard.preview.capabilities.template", { defaultValue: "template" }) : t("wizard.preview.capabilities.templates", { defaultValue: "templates" })}`,
 									);
-								if (prompts.length)
+								if (visiblePrompts.length)
 									summaryParts.push(
-										`${prompts.length} ${prompts.length === 1 ? t("wizard.preview.capabilities.prompt", { defaultValue: "prompt" }) : t("wizard.preview.capabilities.prompts", { defaultValue: "prompts" })}`,
+										`${visiblePrompts.length} ${visiblePrompts.length === 1 ? t("wizard.preview.capabilities.prompt", { defaultValue: "prompt" }) : t("wizard.preview.capabilities.prompts", { defaultValue: "prompts" })}`,
 									);
 								const summaryText = summaryParts.join(" · ");
-								const isOpen = !!expanded[draft.name];
+								const hasCapabilities =
+									tools.length +
+									resources.length +
+									templates.length +
+									prompts.length >
+									0;
+								const capabilitiesHeading = isPreviewLoading
+									? t("wizard.preview.capabilitiesTitle", {
+										defaultValue: "Capabilities",
+									})
+									: summaryText
+										? t("wizard.preview.capabilitiesSummary", {
+											summary: summaryText,
+											defaultValue: "Capabilities · {{summary}}",
+										})
+										: t("wizard.preview.capabilitiesTitle", {
+											defaultValue: "Capabilities",
+										});
 								return (
-									<div key={draft.name} className="rounded border px-4 py-3">
-										<div className="flex items-center justify-between gap-2">
-											<div className="flex items-center gap-2 min-w-0">
-												<button
-													type="button"
-													className="p-0 text-slate-500 hover:text-slate-800 dark:hover:text-slate-200"
-													onClick={() => toggleExpanded(draft.name)}
-													onKeyDown={(e) => {
-														if (e.key === "Enter" || e.key === " ") {
-															e.preventDefault();
-															toggleExpanded(draft.name);
-														}
-													}}
-													aria-label={isOpen ? "Collapse" : "Expand"}
-												>
-													{isOpen ? (
-														<ChevronDown className="h-4 w-4" />
-													) : (
-														<ChevronRight className="h-4 w-4" />
-													)}
-												</button>
-												<div
-													className="font-medium text-sm truncate"
-													title={draft.name}
-												>
-													{draft.name}
-													{summaryText ? (
-														<span className="ml-2 text-xs text-slate-500">
-															{summaryText}
-														</span>
-													) : null}
-												</div>
+									<CardListScrollBody key={draft.name}>
+										<div className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-slate-200/80 bg-background/95 px-4 py-3 backdrop-blur-sm dark:border-slate-700/80">
+											<div
+												className="min-w-0 truncate font-medium text-sm"
+												title={capabilitiesHeading}
+											>
+												{capabilitiesHeading}
 											</div>
-											<Badge variant="secondary" className="text-xs">
-												{draft.kind}
-											</Badge>
+											<div className="shrink-0">
+												<Input
+													type="search"
+													value={capabilitySearch}
+													onChange={(event) =>
+														setCapabilitySearch(event.target.value)
+													}
+													placeholder={t("wizard.preview.filterCapabilities", {
+														defaultValue: "Filter capabilities...",
+													})}
+													className={cn(toolbarSearchInputClassName, "h-8 w-48")}
+												/>
+											</div>
 										</div>
 
-										{!ok && item?.error ? (
-											<div className="mt-2 text-xs text-red-500 break-words overflow-hidden">
+										{isPreviewLoading ? (
+											<CapabilityListSkeleton showSectionLabel />
+										) : !ok && item?.error ? (
+											<div className="overflow-hidden break-words px-4 py-3 text-xs text-red-500">
 												{String(item.error)}
 											</div>
-										) : null}
-
-										{/* Details */}
-										{isOpen ? (
-											<div className="mt-4 pt-3 border-t space-y-5">
-												{renderCapabilitySection("tools", tools)}
-												{renderCapabilitySection("resources", resources)}
-												{renderCapabilitySection("templates", templates)}
-												{renderCapabilitySection("prompts", prompts)}
+										) : !item ? (
+											<div className="px-4 py-3 text-xs text-slate-500">
+												{t("wizard.preview.selectServerHint", {
+													defaultValue:
+														"Select this server from the list to generate its capability preview.",
+												})}
 											</div>
-										) : null}
-									</div>
+										) : !hasCapabilities ? (
+											<div className="px-4 py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+												{t("wizard.preview.emptyCapabilities", {
+													defaultValue:
+														"No capabilities discovered for this server.",
+												})}
+											</div>
+										) : searchQuery &&
+											visibleTools.length +
+											visibleResources.length +
+											visibleTemplates.length +
+											visiblePrompts.length ===
+											0 ? (
+											<div className="px-4 py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+												{t("wizard.preview.emptyCapabilitySearch", {
+													defaultValue:
+														"No capabilities match this search.",
+												})}
+											</div>
+										) : (
+											<div className="p-3">
+												<div className="space-y-5">
+													{renderCapabilitySection("tools", visibleTools)}
+													{renderCapabilitySection("resources", visibleResources)}
+													{renderCapabilitySection("templates", visibleTemplates)}
+													{renderCapabilitySection("prompts", visiblePrompts)}
+												</div>
+											</div>
+										)}
+									</CardListScrollBody>
 								);
-							})}
-						</div>
+							};
+
+							const selectedDrafts = drafts.filter((draft) =>
+								selectedDraftNameSet.has(draft.name),
+							);
+							if (!selectedDrafts.length) {
+								return null;
+							}
+
+							const activeName =
+								activePreviewName ??
+								selectedDrafts[0]?.name ??
+								null;
+							const activeDraft =
+								selectedDrafts.find((draft) => draft.name === activeName) ??
+								selectedDrafts[0] ??
+								null;
+
+							return (
+								<div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+									<div className="shrink-0">
+										<CapabilityCombobox
+											kind="tool"
+											items={selectedDrafts}
+											value={activeName ?? undefined}
+											onChange={(name) => {
+												void previewDraftByName(name);
+											}}
+											placeholder={t("wizard.preview.selectServer", {
+												defaultValue: "Select server",
+											})}
+											triggerClassName="h-10 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-0 shadow-none transition-all duration-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-900/40"
+											triggerLabelClassName="font-semibold text-slate-900 dark:text-slate-100"
+											renderItemLeading={draftListAvatar}
+											renderTriggerTrailing={(draft) => (
+												<Badge variant="secondary" className="shrink-0 text-xs">
+													{transportLabel[draft.kind]}
+												</Badge>
+											)}
+											renderItemTrailing={(draft) => (
+												<Badge variant="secondary" className="shrink-0 text-xs">
+													{transportLabel[draft.kind]}
+												</Badge>
+											)}
+											getKey={(draft) => draft.name}
+											getLabel={(draft) => toTitleCase(draft.name)}
+											getDescription={(draft) =>
+												draftEndpointSummary(draft) || undefined
+											}
+										/>
+									</div>
+									{activeDraft ? renderPreviewCard(activeDraft) : null}
+								</div>
+							);
+						})()}
 					</div>
 				</div>
 			);
@@ -1973,8 +2698,9 @@ export const ServerInstallWizard = forwardRef(
 				dryRunResult,
 				isDryRunLoading,
 				dryRunError,
-				dryRunStats,
 				dryRunWarning,
+				dryRunStats,
+				selectedDraftNames,
 			} = state;
 			const summary = importResult?.summary as
 				| { imported_count?: number | null; skipped_count?: number | null }
@@ -1996,9 +2722,8 @@ export const ServerInstallWizard = forwardRef(
 			// Determine if we can proceed with import based on dry-run
 			const dryRunImportableCount = dryRunStats?.importedCount ?? 0;
 			const dryRunSkippedCount = dryRunStats?.skippedCount ?? 0;
-			const dryRunFailedCount = dryRunStats?.failedCount ?? 0;
 			const effectiveImportableCount = hiddenPreviewReady
-				? Math.max(dryRunImportableCount, state.drafts.length || 1)
+				? Math.max(dryRunImportableCount, state.selectedDrafts.length || 1)
 				: dryRunImportableCount;
 			const effectiveSkippedCount = hiddenPreviewReady ? 0 : dryRunSkippedCount;
 			const canProceedWithImport =
@@ -2007,35 +2732,6 @@ export const ServerInstallWizard = forwardRef(
 				!dryRunError &&
 				dryRunResult &&
 				dryRunImportableCount > 0;
-			const validationOverviewItems = [
-				{
-					label: t("wizard.result.validation.ready", {
-						defaultValue: "Ready to import",
-					}),
-					value: effectiveImportableCount,
-					accent:
-						effectiveImportableCount > 0
-							? "text-green-600"
-							: "text-muted-foreground",
-				},
-				{
-					label: t("wizard.result.validation.skipped", {
-						defaultValue: "Will be skipped",
-					}),
-					value: effectiveSkippedCount,
-					accent:
-						effectiveSkippedCount > 0 ? "text-amber-600" : "text-muted-foreground",
-				},
-				{
-					label: t("wizard.result.validation.failed", {
-						defaultValue: "Failed validation",
-					}),
-					value: dryRunFailedCount,
-					accent:
-						dryRunFailedCount > 0 ? "text-red-600" : "text-muted-foreground",
-				},
-			];
-
 			const successSteps: Array<{ label: string; action: NextStepAction }> =
 				selectedProfileName
 					? [
@@ -2186,126 +2882,74 @@ export const ServerInstallWizard = forwardRef(
 									})}
 								</div>
 							) : (
-								<div className="rounded-lg border p-4 space-y-4">
-									{(() => {
-										let statusTitle = t("wizard.result.validatedTitle", {
-											defaultValue: "Import Validated",
-										});
-										let detailMessage: string | null = null;
-										let detailTone: "error" | "warning" | "muted" = "muted";
-										if (hiddenPreviewReady) {
-											statusTitle = t("wizard.result.pendingImportReadyTitle", {
-												defaultValue: "Ready to publish",
-											});
-											detailMessage = t("wizard.result.pendingImportReadyDescription", {
-												defaultValue:
-													"OAuth authorization is complete. Import will publish this server and make it visible in your Servers list.",
-											});
-										} else if (dryRunError) {
-											statusTitle = t("wizard.result.validationFailedTitle", {
-												defaultValue: "Import Validation Failed",
-											});
-											detailMessage = dryRunError;
-											detailTone = "error";
-										} else if (canProceedWithImport) {
-											if (dryRunWarning) {
-												statusTitle = t(
-													"wizard.result.validatedWithWarningsTitle",
+								(() => {
+									const validationItems = buildImportValidationItems({
+										selectedNames: selectedDraftNames,
+										stats: dryRunStats,
+										hiddenPreviewReady,
+									});
+									const hasPerServerBreakdown =
+										validationItems.length > 0 &&
+										(hiddenPreviewReady || dryRunStats !== null);
+									const showValidationSummary =
+										!dryRunError || (dryRunStats?.failedCount ?? 0) > 0;
+
+									const skippedOnly =
+										!dryRunError &&
+										!hiddenPreviewReady &&
+										!canProceedWithImport &&
+										effectiveSkippedCount > 0;
+
+									const nextSteps = dryRunError
+										? failureSteps
+										: canProceedWithImport
+											? readySteps
+											: skippedOnly
+												? [
 													{
-														defaultValue: "Import Validated With Warnings",
+														label: t(
+															"wizard.result.skipSteps.useExisting",
+															{
+																defaultValue:
+																	"Close this drawer and start using the existing server.",
+															},
+														),
+														action: "close" as NextStepAction,
 													},
-												);
-												detailMessage = dryRunWarning;
-												detailTone = "warning";
-											}
-										} else {
-											statusTitle = t("wizard.result.alreadyInstalledTitle", {
-												defaultValue: "Already Installed",
-											});
-											detailMessage = dryRunWarning;
-											detailTone = "warning";
-										}
+													{
+														label: t(
+															"wizard.result.skipSteps.chooseAnother",
+															{
+																defaultValue:
+																	"Go back to the previous step to choose a different server if needed.",
+															},
+														),
+														action: "preview" as NextStepAction,
+													},
+												]
+												: readySteps;
 
-										const detailClass =
-											detailTone === "error"
-												? "text-sm text-red-600"
-												: detailTone === "warning"
-													? "text-sm text-amber-600"
-													: "text-sm text-muted-foreground";
-
-										const skippedOnly =
-											!dryRunError &&
-											!hiddenPreviewReady &&
-											!canProceedWithImport &&
-											effectiveSkippedCount > 0;
-
-										const nextSteps = dryRunError
-											? failureSteps
-											: canProceedWithImport
-												? readySteps
-												: skippedOnly
-													? [
-														{
-															label: t(
-																"wizard.result.skipSteps.useExisting",
-																{
-																	defaultValue:
-																		"Close this drawer and start using the existing server.",
-																},
-															),
-															action: "close" as NextStepAction,
-														},
-														{
-															label: t(
-																"wizard.result.skipSteps.chooseAnother",
-																{
-																	defaultValue:
-																		"Go back to the previous step to choose a different server if needed.",
-																},
-															),
-															action: "preview" as NextStepAction,
-														},
-													]
-													: readySteps;
-
-										return (
-											<>
-												<div className="flex items-center gap-2">
-													<span
-														className={`font-medium ${detailTone === "warning" && !dryRunError ? "text-amber-600" : detailTone === "error" ? "text-red-600" : "text-green-600"}`}
-													>
-														{statusTitle}
-													</span>
-												</div>
-												<div className="space-y-3">
-													<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-														{validationOverviewItems.map(
-															({ label, value, accent }) => (
-																<div
-																	key={label}
-																	className="rounded-md border p-3"
-																>
-																	<div className="text-xs font-semibold uppercase text-muted-foreground">
-																		{label}
-																	</div>
-																	<div
-																		className={`text-2xl font-bold ${accent}`}
-																	>
-																		{value}
-																	</div>
-																</div>
-															),
-														)}
-													</div>
-													{detailMessage ? (
-														<p className={detailClass}>{detailMessage}</p>
-													) : null}
-													{renderNextSteps(nextSteps)}
-												</div>
-											</>
-										);
-									})()}
-								</div>
+									return (
+										<div className="flex flex-col gap-20">
+											<div className="space-y-3">
+												{dryRunWarning && !dryRunError ? (
+													<p className="text-sm text-amber-700 dark:text-amber-300">
+														{dryRunWarning}
+													</p>
+												) : null}
+												{hasPerServerBreakdown && showValidationSummary ? (
+													<ImportValidationSummary
+														items={validationItems}
+														hiddenPreviewReady={hiddenPreviewReady}
+													/>
+												) : dryRunError ? (
+													<p className="text-sm text-red-600">{dryRunError}</p>
+												) : null}
+											</div>
+											{renderNextSteps(nextSteps)}
+										</div>
+									);
+								})()
 							)
 						) : isImporting ? (
 							<div className="flex items-center justify-center gap-2 rounded border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
@@ -2432,9 +3076,11 @@ export const ServerInstallWizard = forwardRef(
 									</div>
 								)}
 
-								{renderNextSteps(
-									importResult.success !== false ? successSteps : failureSteps,
-								)}
+								<div className="pt-20">
+									{renderNextSteps(
+										importResult.success !== false ? successSteps : failureSteps,
+									)}
+								</div>
 							</div>
 						) : (
 							<div className="flex items-center justify-center h-full">
@@ -2458,35 +3104,153 @@ export const ServerInstallWizard = forwardRef(
 			);
 		};
 
+		const isFlexFillStep =
+			currentStep === "form" || currentStep === "preview";
+		const detectedServerCount = installPipeline.state.drafts.length;
+		const headerPluralCount = detectedServerCount > 1 ? detectedServerCount : 1;
+
 		return (
 			<>
 				<Drawer
 					open={isOpen}
 					onOpenChange={(open) => !open && handleOverlayClose()}
 				>
-					<DrawerContent className="h-full flex flex-col">
-						<DrawerHeader>
-							<DrawerTitle className="flex items-center gap-2">
-								{isEditMode
-									? t("wizard.header.editTitle", { defaultValue: "Edit Server" })
-									: t("wizard.header.addTitle", {
-										defaultValue: "Add MCP Server",
-									})}
-							</DrawerTitle>
-							<DrawerDescription>
-								{isEditMode
-									? t("wizard.header.editDescription", {
-										defaultValue: "Update server configuration",
-									})
-									: t("wizard.header.addDescription", {
-										defaultValue: "Configure and install a new MCP server",
-									})}
-							</DrawerDescription>
+					<DrawerContent className="flex h-full flex-col overflow-hidden">
+						<DrawerHeader className="shrink-0">
+							<div className="flex items-start justify-between gap-3">
+								<div className="min-w-0 flex-1 space-y-1 text-left">
+									<DrawerTitle className="flex items-center gap-2">
+										{isEditMode
+											? t("wizard.header.editTitle", { defaultValue: "Edit Server" })
+											: t("wizard.header.addTitle", {
+												count: headerPluralCount,
+												defaultValue:
+													detectedServerCount > 1
+														? "Add MCP Servers"
+														: "Add MCP Server",
+											})}
+									</DrawerTitle>
+									<DrawerDescription>
+										{isEditMode
+											? t("wizard.header.editDescription", {
+												defaultValue: "Update server configuration",
+											})
+											: t("wizard.header.addDescription", {
+												count: headerPluralCount,
+												defaultValue:
+													detectedServerCount > 1
+														? `Review and install ${detectedServerCount} detected MCP servers`
+														: "Configure and install a new MCP server",
+											})}
+									</DrawerDescription>
+								</div>
+								{currentStep === "form" ? (
+									<TooltipProvider delayDuration={200}>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Button
+													type="button"
+													variant="ghost"
+													size="icon"
+													className="-mr-1 -mt-1 h-5 w-5 shrink-0 rounded-md border-0 bg-transparent p-0 text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground focus-visible:ring-1 focus-visible:ring-offset-0"
+													disabled={isSubmitting}
+													onClick={handleResetForm}
+													aria-label={t("wizard.buttons.reset", {
+														defaultValue: "Reset form",
+													})}
+												>
+													<RotateCcw className="h-4 w-4" />
+												</Button>
+											</TooltipTrigger>
+											<TooltipContent side="bottom" align="end" className="max-w-xs">
+												<p className="font-medium">
+													{t("wizard.buttons.reset", {
+														defaultValue: "Reset form",
+													})}
+												</p>
+												<p className="mt-1 text-background/80">
+													{t("wizard.buttons.resetDescription", {
+														defaultValue:
+															"Clear all fields and restore the initial configuration.",
+													})}
+												</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								) : currentStep === "preview" &&
+									(installPipeline.state.previewState !== null ||
+										installPipeline.state.isPreviewLoading) ? (
+									<TooltipProvider delayDuration={200}>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Button
+													type="button"
+													variant="ghost"
+													size="icon"
+													className="-mr-1 -mt-1 h-5 w-5 shrink-0 rounded-md border-0 bg-transparent p-0 text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground focus-visible:ring-1 focus-visible:ring-offset-0"
+													disabled={
+														installPipeline.state.isImporting ||
+														installPipeline.state.isPreviewLoading
+													}
+													aria-label={
+														installPipeline.state.isPreviewLoading
+															? t("wizard.buttons.previewing", {
+																defaultValue: "Previewing...",
+															})
+															: t("wizard.preview.retry", {
+																defaultValue: "Retry preview",
+															})
+													}
+													onClick={() => {
+														installPipeline.setPreviewState(null);
+														if (
+															installPipeline.state.drafts.length > 1 &&
+															activePreviewName
+														) {
+															void previewDraftByName(activePreviewName);
+														} else {
+															void handlePreview({
+																skipValidation: true,
+																shouldFocus: false,
+															});
+														}
+													}}
+												>
+													<RefreshCw
+														className={cn(
+															"h-4 w-4",
+															installPipeline.state.isPreviewLoading &&
+															"animate-spin",
+														)}
+													/>
+												</Button>
+											</TooltipTrigger>
+											<TooltipContent side="bottom" align="end" className="max-w-xs">
+												<p className="font-medium">
+													{installPipeline.state.isPreviewLoading
+														? t("wizard.buttons.previewing", {
+															defaultValue: "Previewing...",
+														})
+														: t("wizard.preview.retry", {
+															defaultValue: "Retry preview",
+														})}
+												</p>
+												<p className="mt-1 text-background/80">
+													{t("wizard.preview.retryDescription", {
+														defaultValue:
+															"Regenerate capability preview for the selected server.",
+													})}
+												</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								) : null}
+							</div>
 						</DrawerHeader>
 
 						{/* Step Navigation */}
-						<div className="relative z-10 p-4 pb-0 bg-background">
-							<div className="flex items-center justify-between gap-2">
+						<div className="relative z-10 shrink-0 bg-background p-4 pb-0">
+							<div className="flex items-center gap-2">
 								<div className="flex items-center gap-2">
 									{steps.map((step, index) => {
 										const isActive = currentStep === step.id;
@@ -2534,44 +3298,23 @@ export const ServerInstallWizard = forwardRef(
 										);
 									})}
 								</div>
-								{/* Refresh button for preview step - visible during and after preview */}
-								{currentStep === "preview" &&
-									(installPipeline.state.previewState !== null || installPipeline.state.isPreviewLoading) && (
-										<Button
-											variant="ghost"
-											className="h-9 w-9 p-0"
-											aria-label={
-												installPipeline.state.isPreviewLoading
-													? t("wizard.buttons.previewing", { defaultValue: "Previewing..." })
-													: t("wizard.preview.retry", { defaultValue: "Retry preview" })
-											}
-											title={
-												installPipeline.state.isPreviewLoading
-													? t("wizard.buttons.previewing", { defaultValue: "Previewing..." })
-													: t("wizard.preview.retry", { defaultValue: "Retry preview" })
-											}
-											disabled={installPipeline.state.isImporting || installPipeline.state.isPreviewLoading}
-											onClick={() => {
-												installPipeline.setPreviewState(null);
-												void handlePreview({
-													skipValidation: true,
-													shouldFocus: false,
-												});
-											}}
-										>
-											<RefreshCw className={`h-4 w-4 ${installPipeline.state.isPreviewLoading ? "animate-spin" : ""}`} />
-										</Button>
-									)}
 							</div>
 						</div>
 
 						{/* Step Content - with spacing and bottom padding to avoid footer overlap */}
-						<div className="flex-1 min-h-0 overflow-y-auto py-2 pb-20">
+						<div
+							className={cn(
+								"flex-1 min-h-0 py-2",
+								isFlexFillStep
+									? "flex flex-col overflow-hidden"
+									: "overflow-y-auto",
+							)}
+						>
 							{renderStepContent()}
 						</div>
 
 						{/* Footer - fixed at bottom with subtle shadow for separation */}
-						<DrawerFooter className="absolute bottom-0 left-0 right-0 z-10 border-t p-4 bg-background">
+						<DrawerFooter className="shrink-0 border-t bg-background p-4">
 							<div className="flex w-full items-center justify-between gap-3">
 								{currentStep === "result" &&
 									installPipeline.state.importResult ? (

--- a/board/src/components/server-install/server-install-wizard.tsx
+++ b/board/src/components/server-install/server-install-wizard.tsx
@@ -426,7 +426,7 @@ export const ServerInstallWizard = forwardRef(
 		);
 
 		// Form refs
-		const dropZoneRef = useRef<HTMLButtonElement | null>(null);
+		const dropZoneRef = useRef<HTMLDivElement | null>(null);
 		// Form field IDs
 		const nameId = useId();
 		const kindId = useId();
@@ -986,7 +986,7 @@ export const ServerInstallWizard = forwardRef(
 		});
 
 		const handleDropZoneClick = useCallback(
-			(event: MouseEvent<HTMLButtonElement>) => {
+			(event: MouseEvent<HTMLDivElement>) => {
 				event.stopPropagation();
 				if (!ingestEnabled) return;
 				if (isDropZoneCollapsed || ingestError || isIngestSuccess) {
@@ -1876,11 +1876,18 @@ export const ServerInstallWizard = forwardRef(
 								className="relative shrink-0 px-4 py-4"
 								onClick={(event) => event.stopPropagation()}
 							>
-								<button
-									type="button"
+								<div
+									role="button"
+									tabIndex={0}
 									ref={dropZoneRef}
 									onFocus={handleDropZoneFocus}
 									onClick={handleDropZoneClick}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" || e.key === " ") {
+											e.preventDefault();
+											handleDropZoneClick(e as unknown as MouseEvent<HTMLDivElement>);
+										}
+									}}
 									onDragOver={(e) => {
 										if (!canIngestFromDataTransfer(e.dataTransfer)) return;
 										e.preventDefault();
@@ -2011,7 +2018,7 @@ export const ServerInstallWizard = forwardRef(
 											</p>
 										)}
 									</div>
-								</button>
+								</div>
 							</div>
 						) : null}
 

--- a/board/src/components/server-install/server-install-wizard.tsx
+++ b/board/src/components/server-install/server-install-wizard.tsx
@@ -1147,6 +1147,8 @@ export const ServerInstallWizard = forwardRef(
 							? toDraftFromValues(getValues())
 							: null;
 					if (activeDraft && activeDraftName) {
+						const isValid = await trigger(undefined, { shouldFocus: true });
+						if (!isValid) return;
 						installPipeline.updateDraft(activeDraft, activeDraftName);
 						if (activeDraft.name !== activeDraftName) {
 							setActiveDraftName(activeDraft.name);

--- a/board/src/components/server-install/types.ts
+++ b/board/src/components/server-install/types.ts
@@ -5,7 +5,7 @@ import type { SegmentOption } from "../ui/segment";
 
 // Constants
 export const DEFAULT_INGEST_MESSAGE =
-	"Drop JSON/TOML/Text or MCP bundles (WIP) to begin";
+	"Drop or paste JSON, TOML, or text, or click the icon to scan local configs";
 
 export const GHOST_INPUT_CLASS =
 	"border-dashed border-slate-300 bg-slate-50 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:hover:bg-slate-700 cursor-pointer";
@@ -13,7 +13,7 @@ export const GHOST_INPUT_CLASS =
 // Server type options for Segment component
 export const SERVER_TYPE_OPTIONS: SegmentOption[] = [
 	{ value: "stdio", label: "Stdio" },
-	{ value: "sse", label: "SSE" },
+	{ value: "sse", label: "SSE (Legacy)" },
 	{ value: "streamable_http", label: "Streamable HTTP" },
 ];
 
@@ -66,6 +66,11 @@ export const manualServerSchema = z
 		headers: z.array(headerSchema).optional(),
 		urlParams: z.array(urlParamSchema).optional(),
 		meta_description: z.string().optional(),
+		meta_icon_url: z
+			.string()
+			.url("manual.errors.urlInvalid")
+			.optional()
+			.or(z.literal("")),
 		meta_version: z.string().optional(),
 		meta_website_url: z
 			.string()
@@ -163,6 +168,11 @@ export interface ServerInstallManualFormHandle {
 		text?: string;
 		buffer?: ArrayBuffer;
 		fileName?: string;
+		payloads?: Array<{
+			text?: string;
+			buffer?: ArrayBuffer;
+			fileName?: string;
+		}>;
 	}) => Promise<void>;
 	loadDraft: (draft: ServerInstallDraft) => Promise<void> | void;
 	getCurrentDraft: () => ServerInstallDraft | null;

--- a/board/src/components/server-install/uni-import.tsx
+++ b/board/src/components/server-install/uni-import.tsx
@@ -59,13 +59,17 @@ import {
 	useFormSync,
 	useIngest,
 	useSecretFieldInsert,
+	useServerTypeOptions,
 } from "./hooks";
+import {
+	FORM_TAB_PANEL_TOP_INSET_CLASS,
+	FORM_TAB_TOOLBAR_ROW_CLASS,
+} from "./form-tab-layout";
 import {
 	breathingAnimation,
 	DEFAULT_INGEST_MESSAGE,
 	type ManualServerFormValues,
 	manualServerSchema,
-	SERVER_TYPE_OPTIONS,
 	type ServerInstallManualFormHandle,
 	type ServerInstallManualFormProps,
 } from "./types";
@@ -96,6 +100,7 @@ export const ServerInstallManualForm = forwardRef<
 	) => {
 		usePageTranslations("servers");
 		const { t } = useTranslation("servers");
+		const { serverTypeOptions } = useServerTypeOptions();
 		const isEditMode = mode === "edit";
 		const isMarketMode = mode === "market";
 		const jsonEditingEnabled = allowJsonEditing ?? !isEditMode;
@@ -140,6 +145,7 @@ export const ServerInstallManualForm = forwardRef<
 				headers: [],
 				urlParams: [],
 				meta_description: "",
+				meta_icon_url: "",
 				meta_version: "",
 				meta_website_url: "",
 				meta_repository_url: "",
@@ -254,22 +260,12 @@ export const ServerInstallManualForm = forwardRef<
 		// Watched values
 		const kind = watch("kind");
 		const isStdio = kind === "stdio";
-		const serverTypeOptions = useMemo(
-			() =>
-				SERVER_TYPE_OPTIONS.map((option) => ({
-					...option,
-					label: t(`manual.fields.type.options.${option.value}`, {
-						defaultValue:
-							option.value === "stdio" ? "Stdio" : "Streamable HTTP",
-					}),
-				})),
-			[t],
-		);
 		const watchedName = useWatch({ control, name: "name" });
 		const watchedMetaDescription = useWatch({
 			control,
 			name: "meta_description",
 		});
+		const watchedMetaIconUrl = useWatch({ control, name: "meta_icon_url" });
 		const watchedMetaVersion = useWatch({ control, name: "meta_version" });
 		const watchedMetaWebsite = useWatch({ control, name: "meta_website_url" });
 		const watchedMetaRepositoryUrl = useWatch({
@@ -396,6 +392,7 @@ export const ServerInstallManualForm = forwardRef<
 			kind,
 			watchedName,
 			watchedMetaDescription,
+			watchedMetaIconUrl,
 			watchedMetaVersion,
 			watchedMetaWebsite,
 			watchedMetaRepositoryUrl,
@@ -436,7 +433,6 @@ export const ServerInstallManualForm = forwardRef<
 			buildFormValuesFromState,
 			reset,
 			onSubmitMultiple,
-			onClose,
 			messages: ingestMessages,
 		});
 
@@ -531,6 +527,7 @@ export const ServerInstallManualForm = forwardRef<
 		const kindId = useId();
 		const commandId = useId();
 		const urlId = useId();
+		const metaIconUrlId = useId();
 		const metaDescriptionId = useId();
 		const metaVersionId = useId();
 		const metaWebsiteUrlId = useId();
@@ -1077,7 +1074,7 @@ export const ServerInstallManualForm = forwardRef<
 								<Tabs
 									value={activeTab}
 									onValueChange={setActiveTab}
-									className="space-y-4"
+									className="flex flex-col"
 								>
 									<TabsList className={`grid w-full ${extraTab ? "grid-cols-3" : "grid-cols-2"}`}>
 										<TabsTrigger value="core">{tabsCoreLabel}</TabsTrigger>
@@ -1091,11 +1088,10 @@ export const ServerInstallManualForm = forwardRef<
 
 									<TabsContent
 										value="core"
-										className={`space-y-4 ${viewMode === "json" ? "flex flex-col h-full" : ""
-											}`}
+										className={`flex flex-col gap-4 ${viewMode === "json" ? "h-full" : ""}`}
 										onClick={handleFormInteraction}
 									>
-										<div className="flex items-center justify-end pt-2">
+										<div className={FORM_TAB_TOOLBAR_ROW_CLASS}>
 											<FormViewModeToggle
 												mode={viewMode}
 												onChange={handleModeChange}
@@ -1295,7 +1291,7 @@ export const ServerInstallManualForm = forwardRef<
 									{extraTab && (
 										<TabsContent
 											value={extraTab.value}
-											className="space-y-4 pt-4"
+											className={FORM_TAB_PANEL_TOP_INSET_CLASS}
 											onClick={handleFormInteraction}
 										>
 											{extraTab.content}
@@ -1303,14 +1299,15 @@ export const ServerInstallManualForm = forwardRef<
 									)}
 									<TabsContent
 										value="meta"
-
-										className="space-y-4 pt-4"
+										className={FORM_TAB_PANEL_TOP_INSET_CLASS}
 										onClick={handleFormInteraction}
 									>
 										<MetaFields
 											formStateRef={formStateRef}
 											register={register}
 											errors={errors}
+											iconUrl={watchedMetaIconUrl}
+											metaIconUrlId={metaIconUrlId}
 											metaDescriptionId={metaDescriptionId}
 											metaVersionId={metaVersionId}
 											metaWebsiteUrlId={metaWebsiteUrlId}

--- a/board/src/components/ui/tabs.tsx
+++ b/board/src/components/ui/tabs.tsx
@@ -43,6 +43,8 @@ const TabsContent = React.forwardRef<
 		ref={ref}
 		className={cn(
 			"mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:ring-offset-slate-950 dark:focus-visible:ring-ring",
+			// Tailwind `flex` utilities override the native [hidden] attribute; keep inactive panels out of layout.
+			"data-[state=inactive]:hidden",
 			className,
 		)}
 		{...props}

--- a/board/src/hooks/use-server-install-pipeline.ts
+++ b/board/src/hooks/use-server-install-pipeline.ts
@@ -72,6 +72,8 @@ export function useServerInstallPipeline(
 	const previewGenerationRef = useRef(0);
 
 	const clearResults = useCallback(() => {
+		previewGenerationRef.current++;
+		setPreviewLoading(false);
 		setPreviewState(null);
 		setPreviewError(null);
 		setImportResult(null);

--- a/board/src/hooks/use-server-install-pipeline.ts
+++ b/board/src/hooks/use-server-install-pipeline.ts
@@ -1,8 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	extractImportStats,
 	serversApi,
+	type ServersImportResponse,
+	type ServersPreviewResponse,
 } from "../lib/api";
 import {
 	buildDraftServersImportRequest,
@@ -34,12 +36,6 @@ interface UseServerInstallPipelineOptions {
 	onImported?: () => void;
 }
 
-interface PreviewState {
-	success: boolean;
-	data?: any;
-	error?: unknown;
-}
-
 function hasEntries(
 	value?: Record<string, string>,
 ): value is Record<string, string> {
@@ -49,38 +45,91 @@ function hasEntries(
 export function useServerInstallPipeline(
 	opts: UseServerInstallPipelineOptions = {},
 ) {
-	const { t, i18n } = useTranslation("servers");
+	const { t } = useTranslation("servers");
 	const [isDrawerOpen, setDrawerOpen] = useState(false);
 	const [drafts, setDrafts] = useState<ServerInstallDraft[]>([]);
+	const [selectedDraftNames, setSelectedDraftNames] = useState<string[]>([]);
 	const [source, setSource] = useState<InstallSource | null>(null);
 	const [isPreviewLoading, setPreviewLoading] = useState(false);
-	const [previewState, setPreviewState] = useState<PreviewState | null>(null);
+	const [previewState, setPreviewState] = useState<ServersPreviewResponse | null>(
+		null,
+	);
 	const [previewError, setPreviewError] = useState<string | null>(null);
 	const [isImporting, setImporting] = useState(false);
 	const [currentStep, setCurrentStep] = useState<WizardStep>("form");
-	const [importResult, setImportResult] = useState<any>(null);
+	const [importResult, setImportResult] = useState<ServersImportResponse | null>(
+		null,
+	);
 	const [targetProfileId, setTargetProfileId] = useState<string | null>(null);
-	const [dryRunResult, setDryRunResult] = useState<any>(null);
+	const [dryRunResult, setDryRunResult] = useState<ServersImportResponse | null>(
+		null,
+	);
 	const [dryRunStats, setDryRunStats] = useState<ImportStats | null>(null);
 	const [dryRunWarning, setDryRunWarning] = useState<string | null>(null);
 	const [isDryRunLoading, setDryRunLoading] = useState(false);
 	const [dryRunError, setDryRunError] = useState<string | null>(null);
 
-	const reset = useCallback(() => {
-		setDrawerOpen(false);
-		setDrafts([]);
-		setSource(null);
+	const previewGenerationRef = useRef(0);
+
+	const clearResults = useCallback(() => {
 		setPreviewState(null);
 		setPreviewError(null);
-		setPreviewLoading(false);
-		setImporting(false);
-		setCurrentStep("form");
 		setImportResult(null);
-		setTargetProfileId(null);
 		setDryRunResult(null);
 		setDryRunStats(null);
 		setDryRunWarning(null);
+		setDryRunError(null);
+	}, []);
+
+	const reset = useCallback(() => {
+		setDrawerOpen(false);
+		setDrafts([]);
+		setSelectedDraftNames([]);
+		setSource(null);
+		clearResults();
+		setPreviewLoading(false);
+		setImporting(false);
+		setCurrentStep("form");
+		setTargetProfileId(null);
 		setDryRunLoading(false);
+	}, [clearResults]);
+
+	const selectedDraftNameSet = useMemo(
+		() => new Set(selectedDraftNames),
+		[selectedDraftNames],
+	);
+	const selectedDrafts = useMemo(
+		() => drafts.filter((draft) => selectedDraftNameSet.has(draft.name)),
+		[drafts, selectedDraftNameSet],
+	);
+
+	const setDraftCollection = useCallback(
+		(items: ServerInstallDraft[], origin: InstallSource | null) => {
+			setDrafts(items);
+			setSelectedDraftNames(items.map((item) => item.name));
+			setSource(origin);
+			clearResults();
+		},
+		[clearResults],
+	);
+
+	const updateDraft = useCallback((draft: ServerInstallDraft, previousName?: string) => {
+		const matchName = previousName ?? draft.name;
+		setDrafts((current) =>
+			current.map((item) => (item.name === matchName ? draft : item)),
+		);
+		setSelectedDraftNames((current) =>
+			current.map((name) => (name === matchName ? draft.name : name)),
+		);
+		clearResults();
+	}, [clearResults]);
+
+	const updateSelectedDraftNames = useCallback((names: string[]) => {
+		setSelectedDraftNames(names);
+		setImportResult(null);
+		setDryRunResult(null);
+		setDryRunStats(null);
+		setDryRunWarning(null);
 		setDryRunError(null);
 	}, []);
 
@@ -108,6 +157,44 @@ export function useServerInstallPipeline(
 		};
 	}, []);
 
+	const previewDrafts = useCallback(
+		async (items: ServerInstallDraft[]) => {
+			if (!items.length) {
+				notifyError(
+					"No servers selected",
+					"Select at least one server to preview.",
+				);
+				return;
+			}
+
+			const gen = ++previewGenerationRef.current;
+			setPreviewState(null);
+			setPreviewError(null);
+			setPreviewLoading(true);
+
+			try {
+				const payload = buildPreviewPayload(items);
+				const result = await serversApi.previewServers({
+					...payload,
+					timeout_ms: 30000,
+				});
+				if (gen !== previewGenerationRef.current) return;
+				setPreviewState(result);
+			} catch (error) {
+				if (gen !== previewGenerationRef.current) return;
+				const message =
+					error instanceof Error ? error.message : "Preview request failed";
+				setPreviewError(message);
+				notifyError("Preview failed", message);
+			} finally {
+				if (gen === previewGenerationRef.current) {
+					setPreviewLoading(false);
+				}
+			}
+		},
+		[buildPreviewPayload],
+	);
+
 	const begin = useCallback(
 		async (items: ServerInstallDraft[], origin: InstallSource) => {
 			if (!items.length) {
@@ -118,40 +205,23 @@ export function useServerInstallPipeline(
 				return;
 			}
 
-			setDrafts(items);
-			setSource(origin);
-			setPreviewState(null);
-			setPreviewError(null);
+			setDraftCollection(items, origin);
 			setDrawerOpen(true);
 			setCurrentStep("preview");
-			setPreviewLoading(true);
-
-			try {
-				const payload = buildPreviewPayload(items);
-				const result = await serversApi.previewServers({
-					...payload,
-					timeout_ms: 30000, // 30 seconds for stdio servers that need to install dependencies
-					// TODO: Implement intelligent timeout handling for server preview
-					// - Add user-friendly timeout management UI
-					// - Show dependency download progress indication
-					// - Allow users to temporarily increase timeout time
-					// - Implement smart timeout detection based on server type and dependency requirements
-				});
-				setPreviewState(result);
-			} catch (error) {
-				const message =
-					error instanceof Error ? error.message : "Preview request failed";
-				setPreviewError(message);
-				notifyError("Preview failed", message);
-			} finally {
-				setPreviewLoading(false);
-			}
+			await previewDrafts(items);
 		},
-		[buildPreviewPayload],
+		[previewDrafts, setDraftCollection],
 	);
 
 	const performDryRun = useCallback(async () => {
-		if (!drafts.length) return;
+		if (!selectedDrafts.length) {
+			setDryRunError(
+				t("wizard.result.validationNoSelection", {
+					defaultValue: "Select at least one server to validate.",
+				}),
+			);
+			return;
+		}
 		try {
 			setDryRunLoading(true);
 			setDryRunError(null);
@@ -159,6 +229,7 @@ export function useServerInstallPipeline(
 			setDryRunWarning(null);
 			const requestBody = buildDraftServersImportRequest({
 				drafts,
+				selectedDraftNames,
 				targetProfileId,
 				dryRun: true,
 			});
@@ -217,11 +288,23 @@ export function useServerInstallPipeline(
 		} finally {
 			setDryRunLoading(false);
 		}
-	}, [drafts, targetProfileId, t, i18n.language]);
+	}, [
+		drafts,
+		selectedDraftNames,
+		selectedDrafts.length,
+		targetProfileId,
+		t,
+	]);
 
 	const confirmImport = useCallback(
 		async (overrideTargetProfileId?: string | null) => {
-			if (!drafts.length) return false;
+			if (!selectedDrafts.length) {
+				notifyError(
+					"No servers selected",
+					"Select at least one server before importing.",
+				);
+				return false;
+			}
 			// Allow callers (e.g., the install wizard's `handleImport`) to
 			// provide a freshly resolved target profile id — useful when
 			// auto-add is enabled but the pipeline state has not been updated
@@ -236,6 +319,7 @@ export function useServerInstallPipeline(
 				setCurrentStep("result");
 				const requestBody = buildDraftServersImportRequest({
 					drafts,
+					selectedDraftNames,
 					targetProfileId: effectiveTargetProfileId,
 				});
 				const result = await serversApi.importServers(requestBody);
@@ -301,12 +385,21 @@ export function useServerInstallPipeline(
 				setImporting(false);
 			}
 		},
-		[drafts, targetProfileId, t, i18n.language, opts],
+		[
+			drafts,
+			selectedDraftNames,
+			selectedDrafts.length,
+			targetProfileId,
+			t,
+			opts,
+		],
 	);
 
 	const state = useMemo(
 		() => ({
 			drafts,
+			selectedDraftNames,
+			selectedDrafts,
 			source,
 			previewState,
 			previewError,
@@ -324,6 +417,8 @@ export function useServerInstallPipeline(
 		}),
 		[
 			drafts,
+			selectedDraftNames,
+			selectedDrafts,
 			source,
 			previewState,
 			previewError,
@@ -349,12 +444,16 @@ export function useServerInstallPipeline(
 			close: reset,
 			reset,
 			setDrafts,
+			setDraftCollection,
+			updateDraft,
+			setSelectedDraftNames: updateSelectedDraftNames,
 			setImportResult,
 			setPreviewState,
 			setPreviewError,
 			setPreviewLoading,
 			setCurrentStep,
 			setTargetProfileId,
+			previewDrafts,
 			performDryRun,
 		}),
 		[
@@ -362,6 +461,9 @@ export function useServerInstallPipeline(
 			begin,
 			confirmImport,
 			reset,
+			setDraftCollection,
+			updateDraft,
+			updateSelectedDraftNames,
 			setDrafts,
 			setImportResult,
 			setPreviewState,
@@ -369,6 +471,7 @@ export function useServerInstallPipeline(
 			setPreviewLoading,
 			setCurrentStep,
 			setTargetProfileId,
+			previewDrafts,
 			performDryRun,
 		],
 	);

--- a/board/src/hooks/use-server-install-pipeline.ts
+++ b/board/src/hooks/use-server-install-pipeline.ts
@@ -45,7 +45,7 @@ function hasEntries(
 export function useServerInstallPipeline(
 	opts: UseServerInstallPipelineOptions = {},
 ) {
-	const { t } = useTranslation("servers");
+	const { t, i18n } = useTranslation("servers");
 	const [isDrawerOpen, setDrawerOpen] = useState(false);
 	const [drafts, setDrafts] = useState<ServerInstallDraft[]>([]);
 	const [selectedDraftNames, setSelectedDraftNames] = useState<string[]>([]);
@@ -296,6 +296,7 @@ export function useServerInstallPipeline(
 		selectedDrafts.length,
 		targetProfileId,
 		t,
+		i18n.language,
 	]);
 
 	const confirmImport = useCallback(
@@ -393,6 +394,7 @@ export function useServerInstallPipeline(
 			selectedDrafts.length,
 			targetProfileId,
 			t,
+			i18n.language,
 			opts,
 		],
 	);

--- a/board/src/lib/api.ts
+++ b/board/src/lib/api.ts
@@ -1419,16 +1419,22 @@ export const serversApi = {
 			env?: Record<string, string> | null;
 			url?: string | null;
 		}>;
-	}): Promise<{
-		success: boolean;
-		data?: { items: unknown[] } | null;
-		error?: unknown | null;
-	}> => {
+	}): Promise<ServersPreviewResponse> => {
 		return await fetchApi(`/api/mcp/servers/preview`, {
 			method: "POST",
 			body: JSON.stringify(payload),
 		});
 	},
+};
+
+export type ServersImportResponse = Awaited<
+	ReturnType<typeof serversApi.importServers>
+>;
+
+export type ServersPreviewResponse = {
+	success: boolean;
+	data?: { items: unknown[] } | null;
+	error?: unknown | null;
 };
 
 export interface ImportStats {

--- a/board/src/lib/i18n/common.ts
+++ b/board/src/lib/i18n/common.ts
@@ -43,8 +43,8 @@ export const commonTranslations = {
 				incoming: "Incoming query",
 			},
 			skippedReasons: {
-				duplicateName: "Duplicate name",
-				duplicateFingerprint: "Duplicate fingerprint",
+				duplicateName: "Name already in use",
+				duplicateFingerprint: "Already installed",
 				urlQueryMismatch: "URL query mismatch",
 				configUnrecognized: "Unrecognized config entry",
 				configInvalidEntry: "Invalid config entry",
@@ -76,6 +76,11 @@ export const commonTranslations = {
 			pageSuffix: "",
 			ofTotal: "of {{total}}",
 			goToPage: "Go to page",
+		},
+		bulkSelection: {
+			bulkModeEnter: "Bulk select",
+			bulkModeExit: "Exit bulk select",
+			bulkModeDescription: "{{count}} selected for bulk actions",
 		},
 		lock: {
 			title: "MCPMate",
@@ -139,8 +144,8 @@ export const commonTranslations = {
 				incoming: "传入查询参数",
 			},
 			skippedReasons: {
-				duplicateName: "名称重复",
-				duplicateFingerprint: "指纹重复",
+				duplicateName: "名称已被占用",
+				duplicateFingerprint: "已安装",
 				urlQueryMismatch: "URL 查询参数不匹配",
 				configUnrecognized: "未识别的配置项",
 				configInvalidEntry: "无效的配置项",
@@ -172,6 +177,11 @@ export const commonTranslations = {
 			pageSuffix: "页",
 			ofTotal: "，共 {{total}} 页",
 			goToPage: "跳转到页码",
+		},
+		bulkSelection: {
+			bulkModeEnter: "批量选择",
+			bulkModeExit: "退出批量选择",
+			bulkModeDescription: "已选择 {{count}} 项，可进行批量操作",
 		},
 		lock: {
 			title: "MCPMate",
@@ -234,8 +244,8 @@ export const commonTranslations = {
 				incoming: "入力クエリ",
 			},
 			skippedReasons: {
-				duplicateName: "名前の重複",
-				duplicateFingerprint: "フィンガープリントの重複",
+				duplicateName: "名前が既に使用中",
+				duplicateFingerprint: "インストール済み",
 				urlQueryMismatch: "URL クエリ不一致",
 				configUnrecognized: "未識別の設定項目",
 				configInvalidEntry: "無効な設定項目",
@@ -267,6 +277,11 @@ export const commonTranslations = {
 			pageSuffix: "",
 			ofTotal: "/ {{total}} ページ",
 			goToPage: "ページへ移動",
+		},
+		bulkSelection: {
+			bulkModeEnter: "一括選択",
+			bulkModeExit: "一括選択を終了",
+			bulkModeDescription: "一括操作の対象 {{count}} 件",
 		},
 		lock: {
 			title: "MCPMate",

--- a/board/src/lib/install-normalizer.ts
+++ b/board/src/lib/install-normalizer.ts
@@ -97,7 +97,7 @@ const normalizeServerIcon = (icon: unknown): ServerIcon | null => {
 	return normalized;
 };
 
-const normalizeIconList = (value: unknown): ServerIcon[] => {
+export const normalizeIconList = (value: unknown): ServerIcon[] => {
 	if (!value) return [];
 	const array = Array.isArray(value) ? value : [value];
 	return array

--- a/board/src/lib/server-import-payload.test.ts
+++ b/board/src/lib/server-import-payload.test.ts
@@ -26,4 +26,32 @@ describe("server import payload", () => {
 			},
 		});
 	});
+
+	test("filters draft imports to the selected server names", () => {
+		const body = buildMcpServersImportBodyFromDrafts(
+			[
+				{
+					name: "alpha",
+					kind: "stdio",
+					command: "node",
+					args: ["alpha.js"],
+				},
+				{
+					name: "beta",
+					kind: "streamable_http",
+					url: "https://beta.example.com/mcp",
+				},
+			],
+			new Set(["beta"]),
+		);
+
+		expect(body).toEqual({
+			mcpServers: {
+				beta: {
+					type: "streamable_http",
+					url: "https://beta.example.com/mcp",
+				},
+			},
+		});
+	});
 });

--- a/board/src/lib/server-import-payload.ts
+++ b/board/src/lib/server-import-payload.ts
@@ -32,9 +32,19 @@ export function buildClientServersImportRequest(init: {
 /** Build `mcpServers` map from install wizard drafts (preview/import). */
 export function buildMcpServersImportBodyFromDrafts(
 	items: ServerInstallDraft[],
+	selectedNames?: Set<string> | string[],
 ): Pick<ServersImportRequestBody, "mcpServers"> {
 	const payload: Record<string, unknown> = {};
+	const selected =
+		selectedNames instanceof Set
+			? selectedNames
+			: Array.isArray(selectedNames)
+				? new Set(selectedNames)
+				: null;
 	for (const item of items) {
+		if (selected && !selected.has(item.name)) {
+			continue;
+		}
 		const metaPayload = serializeMetaForApi(item.meta);
 		const entry: Record<string, unknown> = {
 			type: item.kind,
@@ -69,11 +79,13 @@ export function buildMcpServersImportBodyFromDrafts(
 
 export function buildDraftServersImportRequest(init: {
 	drafts: ServerInstallDraft[];
+	selectedDraftNames?: Set<string> | string[];
 	targetProfileId?: string | null;
 	dryRun?: boolean;
 }): ServersImportRequestBody {
 	const body: ServersImportRequestBody = buildMcpServersImportBodyFromDrafts(
 		init.drafts,
+		init.selectedDraftNames,
 	);
 	if (init.targetProfileId) {
 		body.target_profile_id = init.targetProfileId;

--- a/board/src/lib/server-import-utils.ts
+++ b/board/src/lib/server-import-utils.ts
@@ -10,11 +10,11 @@ const SKIPPED_REASON_LABELS: Record<
 > = {
   duplicate_name: {
     key: "serverImport.skippedReasons.duplicateName",
-    defaultValue: "Duplicate name",
+    defaultValue: "Name already in use",
   },
   duplicate_fingerprint: {
     key: "serverImport.skippedReasons.duplicateFingerprint",
-    defaultValue: "Duplicate fingerprint",
+    defaultValue: "Already installed",
   },
   url_query_mismatch: {
     key: "serverImport.skippedReasons.urlQueryMismatch",

--- a/board/src/lib/server-uni-import-transfer.ts
+++ b/board/src/lib/server-uni-import-transfer.ts
@@ -2,6 +2,11 @@ export type ServerUniImportTransferPayload = {
 	text?: string;
 	buffer?: ArrayBuffer;
 	fileName?: string;
+	payloads?: Array<{
+		text?: string;
+		buffer?: ArrayBuffer;
+		fileName?: string;
+	}>;
 };
 
 export function canIngestFromDataTransfer(dataTransfer: DataTransfer | null): boolean {
@@ -18,11 +23,18 @@ export async function extractPayloadFromDataTransfer(
 	dataTransfer: DataTransfer,
 ): Promise<ServerUniImportTransferPayload | null> {
 	if (dataTransfer.files && dataTransfer.files.length > 0) {
-		const file = dataTransfer.files[0];
-		if (file.name.endsWith(".mcpb") || file.name.endsWith(".dxt")) {
-			return { buffer: await file.arrayBuffer(), fileName: file.name };
+		const payloads = await Promise.all(
+			Array.from(dataTransfer.files).map(async (file) => {
+				if (file.name.endsWith(".mcpb") || file.name.endsWith(".dxt")) {
+					return { buffer: await file.arrayBuffer(), fileName: file.name };
+				}
+				return { text: await file.text(), fileName: file.name };
+			}),
+		);
+		if (payloads.length === 1) {
+			return payloads[0];
 		}
-		return { text: await file.text(), fileName: file.name };
+		return { payloads };
 	}
 
 	const plainText = dataTransfer.getData("text/plain");

--- a/board/src/lib/utils.ts
+++ b/board/src/lib/utils.ts
@@ -162,3 +162,16 @@ export function truncate(str: string | undefined | null, length: number): string
 	if (str.length <= length) return str;
 	return `${str.slice(0, length)}...`;
 }
+
+export function toTitleCase(value?: string | null): string {
+	return (
+		(value ?? "")
+			.trim()
+			.split(/[\s_-]+/)
+			.filter(Boolean)
+			.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+			.join(" ") ||
+		value ||
+		""
+	);
+}

--- a/board/src/pages/profile/profile-detail-page.tsx
+++ b/board/src/pages/profile/profile-detail-page.tsx
@@ -17,6 +17,13 @@ import { useUrlTab } from "../../lib/hooks/use-url-state";
 import { CachedAvatar } from "../../components/cached-avatar";
 import { CardListScrollBody } from "../../components/card-list-scroll-body";
 import { AuditLogsPanel } from "../../components/audit-logs-panel";
+import {
+	BulkSelectionCheckbox,
+	BulkSelectionHeader,
+	useBulkSelection,
+	useBulkSelectionLabels,
+	useEnableDisableBulkActions,
+} from "../../components/bulk-selection";
 import CapabilityList from "../../components/capability-list";
 import {
 	CapsuleStripeList,
@@ -65,22 +72,13 @@ import { auditApi, configSuitsApi, serversApi, useProfileTokenChartSource } from
 import { DEFAULT_ANCHOR_ROLE } from "../../lib/default-profile";
 import { notifyError, notifySuccess } from "../../lib/notify";
 import { useAppStore } from "../../lib/store";
+import { toTitleCase } from "../../lib/utils";
 import type {
 	ConfigSuitPrompt,
 	ConfigSuitResource,
 	ConfigSuitServer,
 	ConfigSuitTool,
 } from "../../lib/types";
-
-const toTitleCase = (value?: string | null) =>
-	(value ?? "")
-		.trim()
-		.split(/[\s_-]+/)
-		.filter(Boolean)
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-		.join(" ") ||
-	value ||
-	"";
 
 const formatProfileTypeLabel = (value?: string | null) =>
 	value
@@ -183,12 +181,12 @@ export function ProfileDetailPage() {
 		"all" | "enabled" | "disabled"
 	>("all");
 	const [promptServer, setPromptServer] = useState<string>("all");
-	// Bulk selection states for lists
-	const [selectedServerIds, setSelectedServerIds] = useState<string[]>([]);
-	const [selectedToolIds, setSelectedToolIds] = useState<string[]>([]);
-	const [selectedResourceIds, setSelectedResourceIds] = useState<string[]>([]);
-	const [selectedPromptIds, setSelectedPromptIds] = useState<string[]>([]);
-	const [selectedTemplateIds, setSelectedTemplateIds] = useState<string[]>([]);
+	const { bulkModeDescription } = useBulkSelectionLabels();
+	const serverBulk = useBulkSelection<string>();
+	const toolBulk = useBulkSelection<string>();
+	const resourceBulk = useBulkSelection<string>();
+	const promptBulk = useBulkSelection<string>();
+	const templateBulk = useBulkSelection<string>();
 	const [logFilter, setLogFilter] = useState("");
 	const [logPageSize, setLogPageSize] = useState<number>(10);
 	const [logPageCursors, setLogPageCursors] = useState<string[]>([]);
@@ -290,14 +288,15 @@ export function ProfileDetailPage() {
 
 	// Bulk mutations using server-side batch manage to improve reliability
 	const bulkToolsM = useMutation({
-		mutationFn: ({ enable }: { enable: boolean }) =>
+		mutationFn: ({ enable, ids }: { enable: boolean; ids: string[] }) =>
 			configSuitsApi.bulkTools(
 				profileId!,
-				selectedToolIds,
+				ids,
 				enable ? "enable" : "disable",
 			),
 		onSuccess: () => {
-			setSelectedToolIds([]);
+			toolBulk.clearSelection();
+			toolBulk.exitBulkMode();
 			refetchTools();
 			notifySuccess(
 				t("profiles:detail.messages.toolsUpdated", { defaultValue: "Tools updated" }),
@@ -310,14 +309,15 @@ export function ProfileDetailPage() {
 		),
 	});
 	const bulkResourcesM = useMutation({
-		mutationFn: ({ enable }: { enable: boolean }) =>
+		mutationFn: ({ enable, ids }: { enable: boolean; ids: string[] }) =>
 			configSuitsApi.bulkResources(
 				profileId!,
-				selectedResourceIds,
+				ids,
 				enable ? "enable" : "disable",
 			),
 		onSuccess: () => {
-			setSelectedResourceIds([]);
+			resourceBulk.clearSelection();
+			resourceBulk.exitBulkMode();
 			refetchResources();
 			notifySuccess(
 				t("profiles:detail.messages.resourcesUpdated", { defaultValue: "Resources updated" }),
@@ -330,14 +330,15 @@ export function ProfileDetailPage() {
 		),
 	});
 	const bulkPromptsM = useMutation({
-		mutationFn: ({ enable }: { enable: boolean }) =>
+		mutationFn: ({ enable, ids }: { enable: boolean; ids: string[] }) =>
 			configSuitsApi.bulkPrompts(
 				profileId!,
-				selectedPromptIds,
+				ids,
 				enable ? "enable" : "disable",
 			),
 		onSuccess: () => {
-			setSelectedPromptIds([]);
+			promptBulk.clearSelection();
+			promptBulk.exitBulkMode();
 			refetchPrompts();
 			notifySuccess(
 				t("profiles:detail.messages.promptsUpdated", { defaultValue: "Prompts updated" }),
@@ -351,14 +352,15 @@ export function ProfileDetailPage() {
 	});
 
 	const bulkTemplatesM = useMutation({
-		mutationFn: ({ enable }: { enable: boolean }) =>
+		mutationFn: ({ enable, ids }: { enable: boolean; ids: string[] }) =>
 			configSuitsApi.bulkResourceTemplates(
 				profileId!,
-				selectedTemplateIds,
+				ids,
 				enable ? "enable" : "disable",
 			),
 		onSuccess: () => {
-			setSelectedTemplateIds([]);
+			templateBulk.clearSelection();
+			templateBulk.exitBulkMode();
 			refetchTemplates();
 			notifySuccess(
 				t("profiles:detail.messages.templatesUpdated", { defaultValue: "Templates updated" }),
@@ -372,14 +374,15 @@ export function ProfileDetailPage() {
 	});
 
 	const bulkServersM = useMutation({
-		mutationFn: ({ enable }: { enable: boolean }) =>
+		mutationFn: ({ enable, ids }: { enable: boolean; ids: string[] }) =>
 			configSuitsApi.bulkServers(
 				profileId!,
-				selectedServerIds,
+				ids,
 				enable ? "enable" : "disable",
 			),
 		onSuccess: () => {
-			setSelectedServerIds([]);
+			serverBulk.clearSelection();
+			serverBulk.exitBulkMode();
 			invalidateProfileCapabilityLedger();
 			refetchServers();
 			notifySuccess(
@@ -859,6 +862,32 @@ export function ProfileDetailPage() {
 		return queryPass && statusPass && serverPass;
 	});
 
+	const serverBulkActions = useEnableDisableBulkActions(
+		serverBulk,
+		visibleServers.map((server) => server.id),
+		bulkServersM,
+	);
+	const toolBulkActions = useEnableDisableBulkActions(
+		toolBulk,
+		visibleTools.map((tool) => tool.id),
+		bulkToolsM,
+	);
+	const promptBulkActions = useEnableDisableBulkActions(
+		promptBulk,
+		visiblePrompts.map((prompt) => prompt.id),
+		bulkPromptsM,
+	);
+	const resourceBulkActions = useEnableDisableBulkActions(
+		resourceBulk,
+		visibleResources.map((resource) => resource.id),
+		bulkResourcesM,
+	);
+	const templateBulkActions = useEnableDisableBulkActions(
+		templateBulk,
+		visibleTemplates.map((template) => template.id),
+		bulkTemplatesM,
+	);
+
 	// Template toggle mutations
 	const templateToggleMutation = useMutation({
 		mutationFn: ({ templateId, enable }: { templateId: string; enable: boolean }) =>
@@ -1240,7 +1269,7 @@ export function ProfileDetailPage() {
 					<TabsContent value="servers" className={DETAIL_TAB_CONTENT_CLASS}>
 						<Card className="flex min-h-0 flex-1 flex-col overflow-hidden">
 							<CardHeader className="shrink-0">
-								<div className="flex items-center justify-between gap-2">
+								{isLoadingServers ? (
 									<div>
 										<CardTitle>
 											{t("profiles:detail.labels.servers", { defaultValue: "Servers" })}
@@ -1251,87 +1280,74 @@ export function ProfileDetailPage() {
 											})}
 										</CardDescription>
 									</div>
-									{!isLoadingServers && (
-										<div className="flex flex-wrap items-center gap-2">
-											<Input
-												placeholder={t("profiles:detail.placeholders.searchServers", {
-													defaultValue: "Search servers...",
-												})}
-												value={serverQuery}
-												onChange={(e) => setServerQuery(e.target.value)}
-												className="w-48 h-9"
-											/>
-											<div className="hidden xl:block">
-												<Select
-													value={serverStatus}
-													onValueChange={(v) =>
-														setServerStatus(v as "all" | "enabled" | "disabled")
-													}
-												>
-													<SelectTrigger className="w-36 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.status", { defaultValue: "Status" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">
-															{t("profiles:detail.filters.status.all", { defaultValue: "All" })}
-														</SelectItem>
-														<SelectItem value="enabled">
-															{t("profiles:detail.filters.status.enabled", { defaultValue: "Enabled" })}
-														</SelectItem>
-														<SelectItem value="disabled">
-															{t("profiles:detail.filters.status.disabled", { defaultValue: "Disabled" })}
-														</SelectItem>
-													</SelectContent>
-												</Select>
+								) : (
+									<BulkSelectionHeader
+										className="mb-0"
+										title={t("profiles:detail.labels.servers", {
+											defaultValue: "Servers",
+										})}
+										description={
+											serverBulk.isBulkMode
+												? bulkModeDescription(serverBulk.selectedCount)
+												: t("profiles:detail.descriptions.servers", {
+													defaultValue:
+														"Manage servers included in this profile",
+												})
+										}
+										isBulkMode={serverBulk.isBulkMode}
+										onToggleBulkMode={serverBulk.toggleMode}
+										actions={serverBulkActions}
+										trailing={
+											<div className="flex flex-wrap items-center gap-2">
+												<Input
+													placeholder={t(
+														"profiles:detail.placeholders.searchServers",
+														{ defaultValue: "Search servers..." },
+													)}
+													value={serverQuery}
+													onChange={(e) => setServerQuery(e.target.value)}
+													className="h-9 w-48"
+												/>
+												<div className="hidden xl:block">
+													<Select
+														value={serverStatus}
+														onValueChange={(v) =>
+															setServerStatus(
+																v as "all" | "enabled" | "disabled",
+															)
+														}
+													>
+														<SelectTrigger className="h-9 w-36">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.status",
+																	{ defaultValue: "Status" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.status.all", {
+																	defaultValue: "All",
+																})}
+															</SelectItem>
+															<SelectItem value="enabled">
+																{t("profiles:detail.filters.status.enabled", {
+																	defaultValue: "Enabled",
+																})}
+															</SelectItem>
+															<SelectItem value="disabled">
+																{t("profiles:detail.filters.status.disabled", {
+																	defaultValue: "Disabled",
+																})}
+															</SelectItem>
+														</SelectContent>
+													</Select>
+												</div>
 											</div>
-											<ButtonGroup className="hidden md:flex ml-2">
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() =>
-														setSelectedServerIds(
-															visibleServers.map((s: any) => s.id),
-														)
-													}
-												>
-													{t("profiles:detail.buttons.selectAll", {
-														defaultValue: "Select all",
-													})}
-												</Button>
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() => setSelectedServerIds([])}
-												>
-													{t("profiles:detail.buttons.clearSelection", {
-														defaultValue: "Clear",
-													})}
-												</Button>
-												<Button
-													size="sm"
-													disabled={
-														bulkServersM.isPending ||
-														selectedServerIds.length === 0
-													}
-													onClick={() => bulkServersM.mutate({ enable: true })}
-												>
-													{t("profiles:detail.buttons.enable", { defaultValue: "Enable" })}
-												</Button>
-												<Button
-													size="sm"
-													variant="secondary"
-													disabled={
-														bulkServersM.isPending ||
-														selectedServerIds.length === 0
-													}
-													onClick={() => bulkServersM.mutate({ enable: false })}
-												>
-													{t("profiles:detail.buttons.disable", { defaultValue: "Disable" })}
-												</Button>
-											</ButtonGroup>
-										</div>
-									)}
-								</div>
+										}
+									/>
+								)}
 							</CardHeader>
 							<CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-4 pt-2">
 								<CardListScrollBody>
@@ -1362,43 +1378,51 @@ export function ProfileDetailPage() {
 												const iconAlt = global?.name || server.name || server.id;
 												const globalDescription =
 													global?.meta?.description?.trim();
-												const selected = selectedServerIds.includes(server.id);
+												const bulkSelected =
+													serverBulk.isBulkMode &&
+													serverBulk.selectedIdSet.has(server.id);
+												const handleServerRowActivate = () => {
+													if (serverBulk.isBulkMode) {
+														serverBulk.toggleItem(server.id);
+													}
+												};
 												return (
 													<CapsuleStripeListItem
 														key={server.id}
-														interactive
-														className={`group relative transition-colors ${selected
+														interactive={serverBulk.isBulkMode}
+														className={`group relative transition-colors ${bulkSelected
 															? "bg-primary/10 ring-1 ring-primary/40"
 															: ""
 															}`}
-														onClick={() =>
-															setSelectedServerIds((prev) =>
-																prev.includes(server.id)
-																	? prev.filter((x) => x !== server.id)
-																	: [...prev, server.id],
-															)
+														onClick={
+															serverBulk.isBulkMode
+																? handleServerRowActivate
+																: undefined
 														}
 														onKeyDown={(e) => {
+															if (!serverBulk.isBulkMode) return;
 															if (e.key === "Enter" || e.key === " ") {
 																e.preventDefault();
-																setSelectedServerIds((prev) =>
-																	prev.includes(server.id)
-																		? prev.filter((x) => x !== server.id)
-																		: [...prev, server.id],
-																);
+																handleServerRowActivate();
 															}
 														}}
 													>
 														<div className="flex w-full items-center justify-between gap-4">
 															<div className="flex flex-1 items-center gap-3">
-																<div
-																	className={`flex h-6 w-6 items-center justify-center rounded-full border text-[0px] transition-all duration-200 ${selected
-																		? "border-primary bg-primary text-white shadow-sm"
-																		: "border-slate-300 text-transparent group-hover:border-primary/50 group-hover:text-primary/60 dark:border-slate-700 dark:group-hover:border-primary/50"
-																		}`}
-																>
-																	<Check className="h-3 w-3" />
-																</div>
+																<BulkSelectionCheckbox
+																	visible={serverBulk.isBulkMode}
+																	checked={bulkSelected}
+																	onToggle={() =>
+																		serverBulk.toggleItem(server.id)
+																	}
+																	ariaLabel={t(
+																		"profiles:detail.bulk.selectItem",
+																		{
+																			name: server.name,
+																			defaultValue: "Select {{name}}",
+																		},
+																	)}
+																/>
 																<CachedAvatar
 																	src={globalIcon}
 																	alt={iconAlt ? `${iconAlt} icon` : undefined}
@@ -1506,7 +1530,7 @@ export function ProfileDetailPage() {
 					<TabsContent value="tools" className={DETAIL_TAB_CONTENT_CLASS}>
 						<Card className="flex min-h-0 flex-1 flex-col overflow-hidden">
 							<CardHeader className="shrink-0">
-								<div className="flex items-center justify-between gap-2">
+								{isLoadingTools ? (
 									<div>
 										<CardTitle>
 											{t("profiles:detail.labels.tools", { defaultValue: "Tools" })}
@@ -1517,107 +1541,101 @@ export function ProfileDetailPage() {
 											})}
 										</CardDescription>
 									</div>
-									{!isLoadingTools && (
-										<div className="flex flex-wrap items-center gap-2">
-											<Input
-												placeholder={t("profiles:detail.placeholders.searchTools", {
-													defaultValue: "Search tools...",
-												})}
-												value={toolQuery}
-												onChange={(e) => setToolQuery(e.target.value)}
-												className="w-48 h-9"
-											/>
-											<div className="hidden xl:block">
-												<Select
-													value={toolStatus}
-													onValueChange={(v) =>
-														setToolStatus(v as "all" | "enabled" | "disabled")
-													}
-												>
-													<SelectTrigger className="w-36 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.status", { defaultValue: "Status" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">
-															{t("profiles:detail.filters.status.all", { defaultValue: "All" })}
-														</SelectItem>
-														<SelectItem value="enabled">
-															{t("profiles:detail.filters.status.enabled", { defaultValue: "Enabled" })}
-														</SelectItem>
-														<SelectItem value="disabled">
-															{t("profiles:detail.filters.status.disabled", { defaultValue: "Disabled" })}
-														</SelectItem>
-													</SelectContent>
-												</Select>
-											</div>
-											<div className="hidden xl:block">
-												<Select
-													value={toolServer}
-													onValueChange={(v) => setToolServer(v)}
-												>
-													<SelectTrigger className="w-40 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.server", { defaultValue: "Server" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">
-															{t("profiles:detail.filters.server.all", {
-																defaultValue: "All Servers",
-															})}
-														</SelectItem>
-														{serverNameOptions.map((name) => (
-															<SelectItem key={`tool-sel-${name}`} value={name}>
-																{name}
+								) : (
+									<BulkSelectionHeader
+										className="mb-0"
+										title={t("profiles:detail.labels.tools", {
+											defaultValue: "Tools",
+										})}
+										description={
+											toolBulk.isBulkMode
+												? bulkModeDescription(toolBulk.selectedCount)
+												: t("profiles:detail.descriptions.tools", {
+													defaultValue:
+														"Manage tools included in this profile",
+												})
+										}
+										isBulkMode={toolBulk.isBulkMode}
+										onToggleBulkMode={toolBulk.toggleMode}
+										actions={toolBulkActions}
+										trailing={
+											<div className="flex flex-wrap items-center gap-2">
+												<Input
+													placeholder={t(
+														"profiles:detail.placeholders.searchTools",
+														{ defaultValue: "Search tools..." },
+													)}
+													value={toolQuery}
+													onChange={(e) => setToolQuery(e.target.value)}
+													className="h-9 w-48"
+												/>
+												<div className="hidden xl:block">
+													<Select
+														value={toolStatus}
+														onValueChange={(v) =>
+															setToolStatus(
+																v as "all" | "enabled" | "disabled",
+															)
+														}
+													>
+														<SelectTrigger className="h-9 w-36">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.status",
+																	{ defaultValue: "Status" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.status.all", {
+																	defaultValue: "All",
+																})}
 															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
+															<SelectItem value="enabled">
+																{t("profiles:detail.filters.status.enabled", {
+																	defaultValue: "Enabled",
+																})}
+															</SelectItem>
+															<SelectItem value="disabled">
+																{t("profiles:detail.filters.status.disabled", {
+																	defaultValue: "Disabled",
+																})}
+															</SelectItem>
+														</SelectContent>
+													</Select>
+												</div>
+												<div className="hidden xl:block">
+													<Select
+														value={toolServer}
+														onValueChange={(v) => setToolServer(v)}
+													>
+														<SelectTrigger className="h-9 w-40">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.server",
+																	{ defaultValue: "Server" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.server.all", {
+																	defaultValue: "All Servers",
+																})}
+															</SelectItem>
+															{serverNameOptions.map((name) => (
+																<SelectItem key={`tool-sel-${name}`} value={name}>
+																	{name}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</div>
 											</div>
-											<ButtonGroup className="hidden md:flex ml-2">
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() =>
-														setSelectedToolIds(
-															visibleTools.map((t: any) => t.id),
-														)
-													}
-												>
-													{t("profiles:detail.buttons.selectAll", {
-														defaultValue: "Select all",
-													})}
-												</Button>
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() => setSelectedToolIds([])}
-												>
-													{t("profiles:detail.buttons.clearSelection", {
-														defaultValue: "Clear",
-													})}
-												</Button>
-												<Button
-													size="sm"
-													disabled={
-														bulkToolsM.isPending || selectedToolIds.length === 0
-													}
-													onClick={() => bulkToolsM.mutate({ enable: true })}
-												>
-													{t("profiles:detail.buttons.enable", { defaultValue: "Enable" })}
-												</Button>
-												<Button
-													size="sm"
-													variant="secondary"
-													disabled={
-														bulkToolsM.isPending || selectedToolIds.length === 0
-													}
-													onClick={() => bulkToolsM.mutate({ enable: false })}
-												>
-													{t("profiles:detail.buttons.disable", { defaultValue: "Disable" })}
-												</Button>
-											</ButtonGroup>
-										</div>
-									)}
-								</div>
+										}
+									/>
+								)}
 							</CardHeader>
 							<CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-4 pt-2">
 								<CapabilityList
@@ -1636,15 +1654,9 @@ export function ProfileDetailPage() {
 									}
 									emptyText={t("profiles:detail.emptyStates.noTools", { defaultValue: "No tools found in this profile" })}
 									filterText={toolQuery}
-									selectable
-									selectedIds={selectedToolIds}
-									onSelectToggle={(id) => {
-										setSelectedToolIds((prev) =>
-											prev.includes(id)
-												? prev.filter((x) => x !== id)
-												: [...prev, id],
-										);
-									}}
+									selectable={toolBulk.isBulkMode}
+									selectedIds={toolBulk.selectedIds}
+									onSelectToggle={(id) => toolBulk.toggleItem(id)}
 									renderAction={undefined}
 								/>
 							</CardContent>
@@ -1654,7 +1666,7 @@ export function ProfileDetailPage() {
 					<TabsContent value="prompts" className={DETAIL_TAB_CONTENT_CLASS}>
 						<Card className="flex min-h-0 flex-1 flex-col overflow-hidden">
 							<CardHeader className="shrink-0">
-								<div className="flex items-center justify-between gap-2">
+								{isLoadingPrompts ? (
 									<div>
 										<CardTitle>
 											{t("profiles:detail.labels.prompts", { defaultValue: "Prompts" })}
@@ -1665,109 +1677,101 @@ export function ProfileDetailPage() {
 											})}
 										</CardDescription>
 									</div>
-									{!isLoadingPrompts && (
-										<div className="flex flex-wrap items-center gap-2">
-											<Input
-												placeholder={t("profiles:detail.placeholders.searchPrompts", {
-													defaultValue: "Search prompts...",
-												})}
-												value={promptQuery}
-												onChange={(e) => setPromptQuery(e.target.value)}
-												className="w-48 h-9"
-											/>
-											<div className="hidden xl:block">
-												<Select
-													value={promptStatus}
-													onValueChange={(v) =>
-														setPromptStatus(v as "all" | "enabled" | "disabled")
-													}
-												>
-													<SelectTrigger className="w-36 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.status", { defaultValue: "Status" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">
-															{t("profiles:detail.filters.status.all", { defaultValue: "All" })}
-														</SelectItem>
-														<SelectItem value="enabled">
-															{t("profiles:detail.filters.status.enabled", { defaultValue: "Enabled" })}
-														</SelectItem>
-														<SelectItem value="disabled">
-															{t("profiles:detail.filters.status.disabled", { defaultValue: "Disabled" })}
-														</SelectItem>
-													</SelectContent>
-												</Select>
-											</div>
-											<div className="hidden xl:block">
-												<Select
-													value={promptServer}
-													onValueChange={(v) => setPromptServer(v)}
-												>
-													<SelectTrigger className="w-40 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.server", { defaultValue: "Server" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">
-															{t("profiles:detail.filters.server.all", {
-																defaultValue: "All Servers",
-															})}
-														</SelectItem>
-														{serverNameOptions.map((name) => (
-															<SelectItem key={`prm-sel-${name}`} value={name}>
-																{name}
+								) : (
+									<BulkSelectionHeader
+										className="mb-0"
+										title={t("profiles:detail.labels.prompts", {
+											defaultValue: "Prompts",
+										})}
+										description={
+											promptBulk.isBulkMode
+												? bulkModeDescription(promptBulk.selectedCount)
+												: t("profiles:detail.descriptions.prompts", {
+													defaultValue:
+														"Manage prompts included in this profile",
+												})
+										}
+										isBulkMode={promptBulk.isBulkMode}
+										onToggleBulkMode={promptBulk.toggleMode}
+										actions={promptBulkActions}
+										trailing={
+											<div className="flex flex-wrap items-center gap-2">
+												<Input
+													placeholder={t(
+														"profiles:detail.placeholders.searchPrompts",
+														{ defaultValue: "Search prompts..." },
+													)}
+													value={promptQuery}
+													onChange={(e) => setPromptQuery(e.target.value)}
+													className="h-9 w-48"
+												/>
+												<div className="hidden xl:block">
+													<Select
+														value={promptStatus}
+														onValueChange={(v) =>
+															setPromptStatus(
+																v as "all" | "enabled" | "disabled",
+															)
+														}
+													>
+														<SelectTrigger className="h-9 w-36">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.status",
+																	{ defaultValue: "Status" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.status.all", {
+																	defaultValue: "All",
+																})}
 															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
+															<SelectItem value="enabled">
+																{t("profiles:detail.filters.status.enabled", {
+																	defaultValue: "Enabled",
+																})}
+															</SelectItem>
+															<SelectItem value="disabled">
+																{t("profiles:detail.filters.status.disabled", {
+																	defaultValue: "Disabled",
+																})}
+															</SelectItem>
+														</SelectContent>
+													</Select>
+												</div>
+												<div className="hidden xl:block">
+													<Select
+														value={promptServer}
+														onValueChange={(v) => setPromptServer(v)}
+													>
+														<SelectTrigger className="h-9 w-40">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.server",
+																	{ defaultValue: "Server" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.server.all", {
+																	defaultValue: "All Servers",
+																})}
+															</SelectItem>
+															{serverNameOptions.map((name) => (
+																<SelectItem key={`prm-sel-${name}`} value={name}>
+																	{name}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</div>
 											</div>
-											<ButtonGroup className="hidden md:flex ml-2">
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() =>
-														setSelectedPromptIds(
-															visiblePrompts.map((p: any) => p.id),
-														)
-													}
-												>
-													{t("profiles:detail.buttons.selectAll", {
-														defaultValue: "Select all",
-													})}
-												</Button>
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() => setSelectedPromptIds([])}
-												>
-													{t("profiles:detail.buttons.clearSelection", {
-														defaultValue: "Clear",
-													})}
-												</Button>
-												<Button
-													size="sm"
-													disabled={
-														bulkPromptsM.isPending ||
-														selectedPromptIds.length === 0
-													}
-													onClick={() => bulkPromptsM.mutate({ enable: true })}
-												>
-													{t("profiles:detail.buttons.enable", { defaultValue: "Enable" })}
-												</Button>
-												<Button
-													size="sm"
-													variant="secondary"
-													disabled={
-														bulkPromptsM.isPending ||
-														selectedPromptIds.length === 0
-													}
-													onClick={() => bulkPromptsM.mutate({ enable: false })}
-												>
-													{t("profiles:detail.buttons.disable", { defaultValue: "Disable" })}
-												</Button>
-											</ButtonGroup>
-										</div>
-									)}
-								</div>
+										}
+									/>
+								)}
 							</CardHeader>
 							<CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-4 pt-2">
 								<CapabilityList
@@ -1786,15 +1790,9 @@ export function ProfileDetailPage() {
 									}
 									emptyText={t("profiles:detail.emptyStates.noPrompts", { defaultValue: "No prompts found in this profile" })}
 									filterText={promptQuery}
-									selectable
-									selectedIds={selectedPromptIds}
-									onSelectToggle={(id) => {
-										setSelectedPromptIds((prev) =>
-											prev.includes(id)
-												? prev.filter((x) => x !== id)
-												: [...prev, id],
-										);
-									}}
+									selectable={promptBulk.isBulkMode}
+									selectedIds={promptBulk.selectedIds}
+									onSelectToggle={(id) => promptBulk.toggleItem(id)}
 									renderAction={undefined}
 								/>
 							</CardContent>
@@ -1804,7 +1802,7 @@ export function ProfileDetailPage() {
 					<TabsContent value="resources" className={DETAIL_TAB_CONTENT_CLASS}>
 						<Card className="flex min-h-0 flex-1 flex-col overflow-hidden">
 							<CardHeader className="shrink-0">
-								<div className="flex items-center justify-between gap-2">
+								{isLoadingResources ? (
 									<div>
 										<CardTitle>
 											{t("profiles:detail.labels.resources", { defaultValue: "Resources" })}
@@ -1815,115 +1813,101 @@ export function ProfileDetailPage() {
 											})}
 										</CardDescription>
 									</div>
-									{!isLoadingResources && (
-										<div className="flex flex-wrap items-center gap-2">
-											<Input
-												placeholder={t("profiles:detail.placeholders.searchResources", {
-													defaultValue: "Search resources...",
-												})}
-												value={resourceQuery}
-												onChange={(e) => setResourceQuery(e.target.value)}
-												className="w-48 h-9"
-											/>
-											<div className="hidden xl:block">
-												<Select
-													value={resourceStatus}
-													onValueChange={(v) =>
-														setResourceStatus(
-															v as "all" | "enabled" | "disabled",
-														)
-													}
-												>
-													<SelectTrigger className="w-36 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.status", { defaultValue: "Status" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">
-															{t("profiles:detail.filters.status.all", { defaultValue: "All" })}
-														</SelectItem>
-														<SelectItem value="enabled">
-															{t("profiles:detail.filters.status.enabled", { defaultValue: "Enabled" })}
-														</SelectItem>
-														<SelectItem value="disabled">
-															{t("profiles:detail.filters.status.disabled", { defaultValue: "Disabled" })}
-														</SelectItem>
-													</SelectContent>
-												</Select>
-											</div>
-											<div className="hidden xl:block">
-												<Select
-													value={resourceServer}
-													onValueChange={(v) => setResourceServer(v)}
-												>
-													<SelectTrigger className="w-40 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.server", { defaultValue: "Server" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">
-															{t("profiles:detail.filters.server.all", {
-																defaultValue: "All Servers",
-															})}
-														</SelectItem>
-														{serverNameOptions.map((name) => (
-															<SelectItem key={`res-sel-${name}`} value={name}>
-																{name}
+								) : (
+									<BulkSelectionHeader
+										className="mb-0"
+										title={t("profiles:detail.labels.resources", {
+											defaultValue: "Resources",
+										})}
+										description={
+											resourceBulk.isBulkMode
+												? bulkModeDescription(resourceBulk.selectedCount)
+												: t("profiles:detail.descriptions.resources", {
+													defaultValue:
+														"Manage resources included in this profile",
+												})
+										}
+										isBulkMode={resourceBulk.isBulkMode}
+										onToggleBulkMode={resourceBulk.toggleMode}
+										actions={resourceBulkActions}
+										trailing={
+											<div className="flex flex-wrap items-center gap-2">
+												<Input
+													placeholder={t(
+														"profiles:detail.placeholders.searchResources",
+														{ defaultValue: "Search resources..." },
+													)}
+													value={resourceQuery}
+													onChange={(e) => setResourceQuery(e.target.value)}
+													className="h-9 w-48"
+												/>
+												<div className="hidden xl:block">
+													<Select
+														value={resourceStatus}
+														onValueChange={(v) =>
+															setResourceStatus(
+																v as "all" | "enabled" | "disabled",
+															)
+														}
+													>
+														<SelectTrigger className="h-9 w-36">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.status",
+																	{ defaultValue: "Status" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.status.all", {
+																	defaultValue: "All",
+																})}
 															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
+															<SelectItem value="enabled">
+																{t("profiles:detail.filters.status.enabled", {
+																	defaultValue: "Enabled",
+																})}
+															</SelectItem>
+															<SelectItem value="disabled">
+																{t("profiles:detail.filters.status.disabled", {
+																	defaultValue: "Disabled",
+																})}
+															</SelectItem>
+														</SelectContent>
+													</Select>
+												</div>
+												<div className="hidden xl:block">
+													<Select
+														value={resourceServer}
+														onValueChange={(v) => setResourceServer(v)}
+													>
+														<SelectTrigger className="h-9 w-40">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.server",
+																	{ defaultValue: "Server" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.server.all", {
+																	defaultValue: "All Servers",
+																})}
+															</SelectItem>
+															{serverNameOptions.map((name) => (
+																<SelectItem key={`res-sel-${name}`} value={name}>
+																	{name}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</div>
 											</div>
-											<ButtonGroup className="hidden md:flex ml-2">
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() =>
-														setSelectedResourceIds(
-															visibleResources.map((r: any) => r.id),
-														)
-													}
-												>
-													{t("profiles:detail.buttons.selectAll", {
-														defaultValue: "Select all",
-													})}
-												</Button>
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() => setSelectedResourceIds([])}
-												>
-													{t("profiles:detail.buttons.clearSelection", {
-														defaultValue: "Clear",
-													})}
-												</Button>
-												<Button
-													size="sm"
-													disabled={
-														bulkResourcesM.isPending ||
-														selectedResourceIds.length === 0
-													}
-													onClick={() =>
-														bulkResourcesM.mutate({ enable: true })
-													}
-												>
-													{t("profiles:detail.buttons.enable", { defaultValue: "Enable" })}
-												</Button>
-												<Button
-													size="sm"
-													variant="secondary"
-													disabled={
-														bulkResourcesM.isPending ||
-														selectedResourceIds.length === 0
-													}
-													onClick={() =>
-														bulkResourcesM.mutate({ enable: false })
-													}
-												>
-													{t("profiles:detail.buttons.disable", { defaultValue: "Disable" })}
-												</Button>
-											</ButtonGroup>
-										</div>
-									)}
-								</div>
+										}
+									/>
+								)}
 							</CardHeader>
 							<CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-4 pt-2">
 								<CapabilityList
@@ -1945,15 +1929,9 @@ export function ProfileDetailPage() {
 									}
 									emptyText={t("profiles:detail.emptyStates.noResources", { defaultValue: "No resources found in this profile" })}
 									filterText={resourceQuery}
-									selectable
-									selectedIds={selectedResourceIds}
-									onSelectToggle={(id) => {
-										setSelectedResourceIds((prev) =>
-											prev.includes(id)
-												? prev.filter((x) => x !== id)
-												: [...prev, id],
-										);
-									}}
+									selectable={resourceBulk.isBulkMode}
+									selectedIds={resourceBulk.selectedIds}
+									onSelectToggle={(id) => resourceBulk.toggleItem(id)}
 									renderAction={undefined}
 								/>
 							</CardContent>
@@ -1963,72 +1941,113 @@ export function ProfileDetailPage() {
 					<TabsContent value="templates" className={DETAIL_TAB_CONTENT_CLASS}>
 						<Card className="flex min-h-0 flex-1 flex-col overflow-hidden">
 							<CardHeader className="shrink-0">
-								<div className="flex items-center justify-between gap-2">
+								{isLoadingTemplates ? (
 									<div>
 										<CardTitle>
 											{t("profiles:detail.labels.templates", { defaultValue: "Templates" })}
 										</CardTitle>
 										<CardDescription>
 											{t("profiles:detail.descriptions.templates", {
-												defaultValue: "Manage resource templates included in this profile",
+												defaultValue:
+													"Manage resource templates included in this profile",
 											})}
 										</CardDescription>
 									</div>
-									{!isLoadingTemplates && (
-										<div className="flex flex-wrap items-center gap-2">
-											<Input
-												placeholder={t("profiles:detail.placeholders.searchTemplates", { defaultValue: "Search templates..." })}
-												value={templateQuery}
-												onChange={(e) => setTemplateQuery(e.target.value)}
-												className="w-48 h-9"
-											/>
-											<div className="hidden xl:block">
-												<Select
-													value={templateStatus}
-													onValueChange={(v) => setTemplateStatus(v as "all" | "enabled" | "disabled")}
-												>
-													<SelectTrigger className="w-36 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.status", { defaultValue: "Status" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">{t("profiles:detail.filters.status.all", { defaultValue: "All" })}</SelectItem>
-														<SelectItem value="enabled">{t("profiles:detail.filters.status.enabled", { defaultValue: "Enabled" })}</SelectItem>
-														<SelectItem value="disabled">{t("profiles:detail.filters.status.disabled", { defaultValue: "Disabled" })}</SelectItem>
-													</SelectContent>
-												</Select>
-											</div>
-											<div className="hidden xl:block">
-												<Select value={templateServer} onValueChange={(v) => setTemplateServer(v)}>
-													<SelectTrigger className="w-40 h-9">
-														<SelectValue placeholder={t("profiles:detail.placeholders.server", { defaultValue: "Server" })} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="all">{t("profiles:detail.filters.server.all", { defaultValue: "All Servers" })}</SelectItem>
-														{serverNameOptions.map((name) => (
-															<SelectItem key={`tpl-sel-${name}`} value={name}>
-																{name}
+								) : (
+									<BulkSelectionHeader
+										className="mb-0"
+										title={t("profiles:detail.labels.templates", {
+											defaultValue: "Templates",
+										})}
+										description={
+											templateBulk.isBulkMode
+												? bulkModeDescription(templateBulk.selectedCount)
+												: t("profiles:detail.descriptions.templates", {
+													defaultValue:
+														"Manage resource templates included in this profile",
+												})
+										}
+										isBulkMode={templateBulk.isBulkMode}
+										onToggleBulkMode={templateBulk.toggleMode}
+										actions={templateBulkActions}
+										trailing={
+											<div className="flex flex-wrap items-center gap-2">
+												<Input
+													placeholder={t(
+														"profiles:detail.placeholders.searchTemplates",
+														{ defaultValue: "Search templates..." },
+													)}
+													value={templateQuery}
+													onChange={(e) => setTemplateQuery(e.target.value)}
+													className="h-9 w-48"
+												/>
+												<div className="hidden xl:block">
+													<Select
+														value={templateStatus}
+														onValueChange={(v) =>
+															setTemplateStatus(
+																v as "all" | "enabled" | "disabled",
+															)
+														}
+													>
+														<SelectTrigger className="h-9 w-36">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.status",
+																	{ defaultValue: "Status" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.status.all", {
+																	defaultValue: "All",
+																})}
 															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
+															<SelectItem value="enabled">
+																{t("profiles:detail.filters.status.enabled", {
+																	defaultValue: "Enabled",
+																})}
+															</SelectItem>
+															<SelectItem value="disabled">
+																{t("profiles:detail.filters.status.disabled", {
+																	defaultValue: "Disabled",
+																})}
+															</SelectItem>
+														</SelectContent>
+													</Select>
+												</div>
+												<div className="hidden xl:block">
+													<Select
+														value={templateServer}
+														onValueChange={(v) => setTemplateServer(v)}
+													>
+														<SelectTrigger className="h-9 w-40">
+															<SelectValue
+																placeholder={t(
+																	"profiles:detail.placeholders.server",
+																	{ defaultValue: "Server" },
+																)}
+															/>
+														</SelectTrigger>
+														<SelectContent>
+															<SelectItem value="all">
+																{t("profiles:detail.filters.server.all", {
+																	defaultValue: "All Servers",
+																})}
+															</SelectItem>
+															{serverNameOptions.map((name) => (
+																<SelectItem key={`tpl-sel-${name}`} value={name}>
+																	{name}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</div>
 											</div>
-											<ButtonGroup className="hidden md:flex ml-2">
-												<Button variant="outline" size="sm" onClick={() => setSelectedTemplateIds(visibleTemplates.map((p: any) => p.id))}>
-													{t("profiles:detail.buttons.selectAll", { defaultValue: "Select all" })}
-												</Button>
-												<Button variant="outline" size="sm" onClick={() => setSelectedTemplateIds([])}>
-													{t("profiles:detail.buttons.clearSelection", { defaultValue: "Clear" })}
-												</Button>
-												<Button size="sm" disabled={bulkTemplatesM.isPending || selectedTemplateIds.length === 0} onClick={() => bulkTemplatesM.mutate({ enable: true })}>
-													{t("profiles:detail.buttons.enable", { defaultValue: "Enable" })}
-												</Button>
-												<Button size="sm" variant="secondary" disabled={bulkTemplatesM.isPending || selectedTemplateIds.length === 0} onClick={() => bulkTemplatesM.mutate({ enable: false })}>
-													{t("profiles:detail.buttons.disable", { defaultValue: "Disable" })}
-												</Button>
-											</ButtonGroup>
-										</div>
-									)}
-								</div>
+										}
+									/>
+								)}
 							</CardHeader>
 							<CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-4 pt-2">
 								<CapabilityList
@@ -2045,9 +2064,9 @@ export function ProfileDetailPage() {
 									onToggle={(id, next) => templateToggleMutation.mutate({ templateId: id, enable: next })}
 									emptyText={t("profiles:detail.emptyStates.noTemplates", { defaultValue: "No templates found in this profile" })}
 									filterText={templateQuery}
-									selectable
-									selectedIds={selectedTemplateIds}
-									onSelectToggle={(id) => setSelectedTemplateIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))}
+									selectable={templateBulk.isBulkMode}
+									selectedIds={templateBulk.selectedIds}
+									onSelectToggle={(id) => templateBulk.toggleItem(id)}
 									renderAction={undefined}
 								/>
 							</CardContent>

--- a/board/src/pages/servers/i18n/index.ts
+++ b/board/src/pages/servers/i18n/index.ts
@@ -415,7 +415,8 @@ export const serversTranslations = {
 		},
 		manual: {
 			ingest: {
-				default: "Drop JSON/TOML/Text or MCP bundles (WIP) to begin",
+				default:
+					"Drop or paste JSON, TOML, or text, or click the icon to scan local configs",
 				parsingDropped: "Parsing dropped text",
 				parsingPasted: "Parsing pasted content",
 				success: "Server configuration loaded successfully",
@@ -472,6 +473,38 @@ export const serversTranslations = {
 				saving: "Saving...",
 				importing: "Importing...",
 				processing: "Processing...",
+			},
+			bulk: {
+				title: "{{count}} servers detected",
+				description:
+					"Select the servers to preview and import. {{count}} selected.",
+				selectAll: "Select all",
+				clearSelection: "Clear",
+				enable: "Enable",
+				disable: "Disable",
+				bulkModeEnter: "Bulk select",
+				bulkModeExit: "Exit bulk select",
+				bulkModeDescription: "{{count}} selected for bulk actions",
+				includeInImport: "Add to import",
+				excludeFromImport: "Remove from import",
+				selectServer: "Select {{name}}",
+				includeForImport: "Include {{name}} in import",
+				missingEndpoint: "Missing command or URL",
+				backToList: "Back to detected servers",
+				noSelectionTitle: "No servers selected",
+				noSelectionDescription:
+					"Select at least one server to continue with preview and import.",
+			},
+			scan: {
+				action: "Scan local configs",
+				actionHint: "Click to scan local configs",
+				noneTitle: "No local configs found",
+				noneDescription:
+					"No detected MCP clients have a local configuration file to scan.",
+				noServersTitle: "No servers detected",
+				noServersDescription:
+					"The local scan did not find importable MCP server entries.",
+				failedTitle: "Local scan failed",
 			},
 			fields: {
 				name: {
@@ -684,14 +717,25 @@ export const serversTranslations = {
 				result: { label: "Import & Profile", hint: "Complete" },
 			},
 			header: {
-				addTitle: "Add MCP Server",
-				addDescription: "Configure and install a new MCP server",
+				addTitle_one: "Add MCP Server",
+				addTitle_other: "Add MCP Servers",
+				addDescription_one: "Configure and install a new MCP server",
+				addDescription_other:
+					"Review and install {{count}} detected MCP servers",
 				editTitle: "Edit Server",
 				editDescription: "Update server configuration",
 			},
 			preview: {
 				retry: "Retry preview",
+				retryDescription:
+					"Regenerate capability preview for the selected server.",
 				generating: "Generating capability preview…",
+				serverPickerLabel: "Server",
+				selectServer: "Select server",
+				capabilitiesTitle: "Capabilities",
+				capabilitiesSummary: "Capabilities · {{summary}}",
+				emptyCapabilities:
+					"No capabilities discovered for this server.",
 				capabilities: {
 					tool: "tool",
 					tools: "tools",
@@ -713,6 +757,9 @@ export const serversTranslations = {
 				importing: "Importing...",
 				validating: "Validating...",
 				done: "Done",
+				reset: "Reset form",
+				resetDescription:
+					"Clear all fields and restore the initial configuration.",
 			},
 			result: {
 				validation: {
@@ -744,6 +791,30 @@ export const serversTranslations = {
 					baseMultiple: "Skipped {{count}} servers",
 					withDetail: "{{base}}: {{detail}}",
 					suffixAlreadyInstalled: "Already installed—no new import required.",
+				},
+				skipNotice: {
+					titlePartial: "{{count}} servers will be skipped",
+					descriptionAlreadyInstalled:
+						"These servers are already in your library and won't be imported again.",
+					descriptionDuplicateName:
+						"These servers use names that are already taken and won't be imported again.",
+					descriptionMixed:
+						"These servers won't be imported. Review the reason for each item below.",
+				},
+				summary: {
+					badgeReady: "Ready",
+					badgeSkipped: "Skipped",
+					badgeFailed: "Failed",
+					titleMixed: "Import Review",
+					titleReadyFailed: "Import Partially Ready",
+					descriptionReadySkipped:
+						"{{ready}} will import and {{skipped}} are already installed and will be skipped.",
+					descriptionReadyFailed:
+						"{{ready}} will import. Resolve validation failures for the remaining {{failed}} before importing.",
+					descriptionSkippedFailed:
+						"{{skipped}} are already installed and {{failed}} failed validation.",
+					descriptionReadySkippedFailed:
+						"{{ready}} will import, {{skipped}} will be skipped, and {{failed}} failed validation.",
 				},
 				readyStatusTitle: "Import Ready",
 				readyStatusDescription:
@@ -1221,7 +1292,8 @@ export const serversTranslations = {
 		},
 		manual: {
 			ingest: {
-				default: "拖拽 JSON/TOML/文本或 MCP 安装包（即将支持）即可开始",
+				default:
+					"拖放或粘贴 JSON、TOML 或文本，或点击图标扫描本地配置",
 				parsingDropped: "正在解析拖入的文本",
 				parsingPasted: "正在解析粘贴的内容",
 				success: "服务器配置已成功载入",
@@ -1276,6 +1348,34 @@ export const serversTranslations = {
 				saving: "正在保存...",
 				importing: "正在导入...",
 				processing: "正在处理...",
+			},
+			bulk: {
+				title: "检测到 {{count}} 个服务器",
+				description: "选择要预览和导入的服务器。已选 {{count}} 个。",
+				selectAll: "全选",
+				clearSelection: "清空",
+				enable: "启用",
+				disable: "禁用",
+				bulkModeEnter: "批量选择",
+				bulkModeExit: "退出批量选择",
+				bulkModeDescription: "已选 {{count}} 项用于批量操作",
+				includeInImport: "纳入导入",
+				excludeFromImport: "移出导入",
+				selectServer: "选择 {{name}}",
+				includeForImport: "将 {{name}} 纳入导入",
+				missingEndpoint: "缺少命令或 URL",
+				backToList: "返回检测到的服务器",
+				noSelectionTitle: "未选择服务器",
+				noSelectionDescription: "请至少选择一个服务器后再继续预览和导入。",
+			},
+			scan: {
+				action: "扫描本地配置",
+				actionHint: "点击扫描本地配置",
+				noneTitle: "未找到本地配置",
+				noneDescription: "未检测到带有可扫描本地配置文件的 MCP 客户端。",
+				noServersTitle: "未检测到服务器",
+				noServersDescription: "本地扫描未发现可导入的 MCP 服务器条目。",
+				failedTitle: "本地扫描失败",
 			},
 			fields: {
 				name: {
@@ -1482,14 +1582,22 @@ export const serversTranslations = {
 				result: { label: "导入", hint: "完成" },
 			},
 			header: {
-				addTitle: "新增服务器",
-				addDescription: "配置并安装新的 MCP 服务器",
+				addTitle_one: "新增 MCP 服务器",
+				addTitle_other: "新增 MCP 服务器",
+				addDescription_one: "配置并安装新的 MCP 服务器",
+				addDescription_other: "查看并安装检测到的 {{count}} 个 MCP 服务器",
 				editTitle: "编辑服务器",
 				editDescription: "更新 MCP 服务器配置",
 			},
 			preview: {
 				retry: "重新预览",
+				retryDescription: "为当前选中的服务器重新生成能力预览。",
 				generating: "正在生成能力预览…",
+				serverPickerLabel: "服务器",
+				selectServer: "选择服务器",
+				capabilitiesTitle: "能力",
+				capabilitiesSummary: "能力 · {{summary}}",
+				emptyCapabilities: "未发现该服务器的能力。",
 				capabilities: {
 					tool: "工具",
 					tools: "工具",
@@ -1511,6 +1619,8 @@ export const serversTranslations = {
 				importing: "正在导入...",
 				validating: "正在校验...",
 				done: "完成",
+				reset: "重置表单",
+				resetDescription: "清空所有字段并恢复初始配置。",
 			},
 			result: {
 				validation: {
@@ -1538,6 +1648,29 @@ export const serversTranslations = {
 					baseMultiple: "已跳过 {{count}} 个服务器",
 					withDetail: "{{base}}：{{detail}}",
 					suffixAlreadyInstalled: "已存在可直接使用，无需重新导入。",
+				},
+				skipNotice: {
+					titlePartial: "将跳过 {{count}} 个服务器",
+					descriptionAlreadyInstalled:
+						"这些服务器已在库中，不会再次导入。",
+					descriptionDuplicateName:
+						"这些服务器名称已被占用，不会再次导入。",
+					descriptionMixed: "以下服务器不会导入，请查看各项原因。",
+				},
+				summary: {
+					badgeReady: "可导入",
+					badgeSkipped: "跳过",
+					badgeFailed: "失败",
+					titleMixed: "导入预览",
+					titleReadyFailed: "部分可导入",
+					descriptionReadySkipped:
+						"{{ready}} 个将导入，{{skipped}} 个已安装并将跳过。",
+					descriptionReadyFailed:
+						"{{ready}} 个将导入，请先解决其余 {{failed}} 个的校验问题。",
+					descriptionSkippedFailed:
+						"{{skipped}} 个已安装，{{failed}} 个校验失败。",
+					descriptionReadySkippedFailed:
+						"{{ready}} 个将导入，{{skipped}} 个将跳过，{{failed}} 个校验失败。",
 				},
 				readyStatusTitle: "可执行导入",
 				readyStatusDescription: "配置已就绪，请确认信息后点击“导入”。",
@@ -2009,7 +2142,7 @@ export const serversTranslations = {
 		manual: {
 			ingest: {
 				default:
-					"JSON/TOML/テキストまたは MCP バンドル（プレビュー）をドロップして開始",
+					"JSON、TOML、またはテキストをドロップ／貼り付け、またはアイコンをクリックしてローカル設定をスキャン",
 				parsingDropped: "ドロップしたテキストを解析しています",
 				parsingPasted: "貼り付けた内容を解析しています",
 				success: "サーバー構成を読み込みました",
@@ -2065,6 +2198,38 @@ export const serversTranslations = {
 				saving: "保存中...",
 				importing: "インポート中...",
 				processing: "処理中...",
+			},
+			bulk: {
+				title: "{{count}} 件のサーバーを検出",
+				description:
+					"プレビューとインポートするサーバーを選択してください。{{count}} 件選択中。",
+				selectAll: "すべて選択",
+				clearSelection: "クリア",
+				enable: "有効化",
+				disable: "無効化",
+				bulkModeEnter: "一括選択",
+				bulkModeExit: "一括選択を終了",
+				bulkModeDescription: "一括操作の対象 {{count}} 件",
+				includeInImport: "インポートに追加",
+				excludeFromImport: "インポートから除外",
+				selectServer: "{{name}} を選択",
+				includeForImport: "{{name}} をインポート対象に含める",
+				missingEndpoint: "コマンドまたは URL がありません",
+				backToList: "検出されたサーバーに戻る",
+				noSelectionTitle: "サーバーが選択されていません",
+				noSelectionDescription:
+					"プレビューとインポートを続行するには、少なくとも 1 件のサーバーを選択してください。",
+			},
+			scan: {
+				action: "ローカル設定をスキャン",
+				actionHint: "クリックしてローカル設定をスキャン",
+				noneTitle: "ローカル設定が見つかりません",
+				noneDescription:
+					"スキャン可能なローカル設定ファイルを持つ MCP クライアントが検出されませんでした。",
+				noServersTitle: "サーバーが検出されませんでした",
+				noServersDescription:
+					"ローカルスキャンでインポート可能な MCP サーバー項目は見つかりませんでした。",
+				failedTitle: "ローカルスキャンに失敗しました",
 			},
 			fields: {
 				name: {
@@ -2276,14 +2441,25 @@ export const serversTranslations = {
 				result: { label: "インポートと割り当て", hint: "完了" },
 			},
 			header: {
-				addTitle: "MCP サーバーを追加",
-				addDescription: "新しい MCP サーバーを設定してインストールします",
+				addTitle_one: "MCP サーバーを追加",
+				addTitle_other: "MCP サーバーを追加",
+				addDescription_one: "新しい MCP サーバーを設定してインストールします",
+				addDescription_other:
+					"検出した {{count}} 件の MCP サーバーを確認してインストールします",
 				editTitle: "サーバーを編集",
 				editDescription: "サーバー設定を更新します",
 			},
 			preview: {
 				retry: "プレビューを再実行",
+				retryDescription:
+					"選択中のサーバーの機能プレビューを再生成します。",
 				generating: "機能プレビューを生成中…",
+				serverPickerLabel: "サーバー",
+				selectServer: "サーバーを選択",
+				capabilitiesTitle: "機能",
+				capabilitiesSummary: "機能 · {{summary}}",
+				emptyCapabilities:
+					"このサーバーでは機能が見つかりませんでした。",
 				capabilities: {
 					tool: "ツール",
 					tools: "ツール",
@@ -2305,6 +2481,8 @@ export const serversTranslations = {
 				importing: "インポート中...",
 				validating: "検証中...",
 				done: "完了",
+				reset: "フォームをリセット",
+				resetDescription: "すべてのフィールドをクリアし、初期設定に戻します。",
 			},
 			result: {
 				validation: {
@@ -2337,6 +2515,30 @@ export const serversTranslations = {
 					withDetail: "{{base}}：{{detail}}",
 					suffixAlreadyInstalled:
 						"既に利用可能なため、再インポートは不要です。",
+				},
+				skipNotice: {
+					titlePartial: "{{count}} 件のサーバーはスキップされます",
+					descriptionAlreadyInstalled:
+						"これらのサーバーは既にライブラリにあり、再インポートされません。",
+					descriptionDuplicateName:
+						"これらのサーバー名は既に使用されているため、インポートされません。",
+					descriptionMixed:
+						"以下のサーバーはインポートされません。各項目の理由を確認してください。",
+				},
+				summary: {
+					badgeReady: "準備完了",
+					badgeSkipped: "スキップ",
+					badgeFailed: "失敗",
+					titleMixed: "インポート確認",
+					titleReadyFailed: "一部のみインポート可能",
+					descriptionReadySkipped:
+						"{{ready}} 件はインポートされ、{{skipped}} 件は既にインストール済みのためスキップされます。",
+					descriptionReadyFailed:
+						"{{ready}} 件はインポート可能です。残り {{failed}} 件の検証エラーを解消してください。",
+					descriptionSkippedFailed:
+						"{{skipped}} 件は既にインストール済み、{{failed}} 件は検証に失敗しました。",
+					descriptionReadySkippedFailed:
+						"{{ready}} 件はインポート、{{skipped}} 件はスキップ、{{failed}} 件は検証失敗です。",
 				},
 				readyStatusTitle: "インポート可能",
 				readyStatusDescription:


### PR DESCRIPTION
## Summary

Closes #109

- Add a reusable `bulk-selection` component module (checkbox, header, toolbar, actions factory)
- Refactor the server-install wizard to support multi-draft bulk import with preview, dry-run, and validation
- Add bulk enable/disable/edit operations to the profile detail page across all 5 capability types (servers, tools, resources, prompts, templates)

Implements the batch import workflow requested in #109: users can now drag-and-drop or paste an `mcp-servers.json` file (or any multi-server config) directly into the server install wizard. The wizard detects all server entries, presents them as a selectable draft list, and supports per-draft preview, dry-run validation, and batch import in one flow. Local config scanning is also supported for discovering MCP configurations already on disk.

## Changes

### Bulk Selection Module (`board/src/components/bulk-selection/`)
- `useBulkSelection` hook — mode toggle, select all, clear, memoized return value
- `useEnableDisableBulkActions` — context-aware bulk action config builder
- `BulkSelectionHeader` / `BulkSelectionToolbar` / `BulkSelectionCheckbox` — UI components
- `buildBulkActions` factory — declarative action construction with include/exclude semantics

### Server Install Wizard (`board/src/components/server-install/`)
- Multi-draft bulk import flow: local config scan → draft collection → per-draft preview → dry-run → import
- `import-validation-summary` component for per-server dry-run result display
- `draftToFormState` shared utility eliminating duplicate draft-to-form mapping between wizard and `useIngest`
- `clearResults` helper in pipeline hook to reduce state-reset duplication across 3 callbacks
- `capabilityMatchesSearch` performance fix: removed `JSON.stringify` fallback
- Concurrency fixes: `previewInFlightRef` guard for bulk path, generation counter for `previewDrafts`
- `useFormSync` return value fix: save/restore now works on transport-type toggle
- `dryRunWarning` rendering restored in result step
- Dead `onClose` parameter removed from `useIngest` interface

### Profile Detail Page (`board/src/pages/profile/`)
- Bulk mode toggle per capability tab with select-all / per-item checkbox
- `BulkSelectionHeader` with context-aware include/exclude toolbar
- Bulk enable/disable mutations for all 5 capability types
- Capability kind icons and stripe-style skeleton for profile context

## Test plan

- [ ] Server install wizard: drag-and-drop multi-server JSON → verify draft list renders all entries
- [ ] Server install wizard: paste multi-server config → verify all entries detected
- [ ] Server install wizard: scan local config → verify multi-draft list renders
- [ ] Server install wizard: select drafts → preview → verify capabilities display
- [ ] Server install wizard: dry-run → verify validation summary shows per-server status
- [ ] Server install wizard: import → verify success result with next-step actions
- [ ] Server install wizard: switch transport type → verify form data preserved
- [ ] Profile page: toggle bulk mode → select items → verify toolbar appears
- [ ] Profile page: include/exclude → verify API calls fire with correct IDs
- [ ] Profile page: capability kind icons display correctly in list