### PR TITLE
fix(desktop): block Tauri WebView drop-navigation, harden uni-import transfer layer

### DIFF
--- a/board/bun.lock
+++ b/board/bun.lock
@@ -36,7 +36,6 @@
         "i18next": "^25.5.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "json5": "^2.2.3",
-        "jszip": "^3.10.1",
         "lucide-react": "^0.344.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
@@ -547,8 +546,6 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "core-util-is": ["core-util-is@1.0.3", "https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.3.tgz", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
-
     "cross-spawn": ["cross-spawn@7.0.3", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": "bin/cssesc" }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
@@ -705,13 +702,9 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "immediate": ["immediate@3.0.6", "https://registry.npmmirror.com/immediate/-/immediate-3.0.6.tgz", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
-
     "import-fresh": ["import-fresh@3.3.0", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
-
-    "inherits": ["inherits@2.0.4", "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -739,8 +732,6 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
-    "isarray": ["isarray@1.0.0", "https://registry.npmmirror.com/isarray/-/isarray-1.0.0.tgz", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
-
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
@@ -761,13 +752,9 @@
 
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "jszip": ["jszip@3.10.1", "https://registry.npmmirror.com/jszip/-/jszip-3.10.1.tgz", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
-
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
-
-    "lie": ["lie@3.3.0", "https://registry.npmmirror.com/lie/-/lie-3.3.0.tgz", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
@@ -909,8 +896,6 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
-    "pako": ["pako@1.0.11", "https://registry.npmmirror.com/pako/-/pako-1.0.11.tgz", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
-
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -953,8 +938,6 @@
 
     "prism-react-renderer": ["prism-react-renderer@2.4.1", "", { "dependencies": { "@types/prismjs": "^1.26.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": ">=16.0.0" } }, "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig=="],
 
-    "process-nextick-args": ["process-nextick-args@2.0.1", "https://registry.npmmirror.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
-
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
@@ -993,8 +976,6 @@
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
-    "readable-stream": ["readable-stream@2.3.8", "https://registry.npmmirror.com/readable-stream/-/readable-stream-2.3.8.tgz", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
-
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "recharts": ["recharts@2.15.3", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ=="],
@@ -1021,13 +1002,9 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.1.2.tgz", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "setimmediate": ["setimmediate@1.0.5", "https://registry.npmmirror.com/setimmediate/-/setimmediate-1.0.5.tgz", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1042,8 +1019,6 @@
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "string_decoder": ["string_decoder@1.1.1", "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.1.1.tgz", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 

--- a/board/package-lock.json
+++ b/board/package-lock.json
@@ -39,7 +39,6 @@
 				"i18next": "^25.5.3",
 				"i18next-browser-languagedetector": "^8.2.0",
 				"json5": "^2.2.3",
-				"jszip": "^3.10.1",
 				"lucide-react": "^0.344.0",
 				"prism-react-renderer": "^2.4.1",
 				"react": "^18.3.1",
@@ -4446,10 +4445,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"license": "MIT"
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"license": "MIT",
@@ -5400,10 +5395,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/immediate": {
-			"version": "3.0.6",
-			"license": "MIT"
-		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"dev": true,
@@ -5426,10 +5417,6 @@
 			"engines": {
 				"node": ">=0.8.19"
 			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"license": "ISC"
 		},
 		"node_modules/inline-style-parser": {
 			"version": "0.2.7",
@@ -5554,10 +5541,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"license": "MIT"
-		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"license": "ISC"
@@ -5633,16 +5616,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/jszip": {
-			"version": "3.10.1",
-			"license": "(MIT OR GPL-3.0-or-later)",
-			"dependencies": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "^1.0.5"
-			}
-		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"dev": true,
@@ -5661,13 +5634,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/lie": {
-			"version": "3.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"immediate": "~3.0.5"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -6734,10 +6700,6 @@
 			"version": "1.0.1",
 			"license": "BlueOak-1.0.0"
 		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"license": "(MIT AND Zlib)"
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"dev": true,
@@ -7046,10 +7008,6 @@
 				"react": ">=16.0.0"
 			}
 		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"license": "MIT"
-		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
 			"license": "MIT",
@@ -7329,19 +7287,6 @@
 				"pify": "^2.3.0"
 			}
 		},
-		"node_modules/readable-stream": {
-			"version": "2.3.8",
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"license": "MIT",
@@ -7537,10 +7482,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"license": "MIT"
-		},
 		"node_modules/scheduler": {
 			"version": "0.23.2",
 			"license": "MIT",
@@ -7555,10 +7496,6 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
-		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"license": "MIT"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -7602,13 +7539,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string-width": {

--- a/board/package.json
+++ b/board/package.json
@@ -44,7 +44,6 @@
 		"i18next": "^25.5.3",
 		"i18next-browser-languagedetector": "^8.2.0",
 		"json5": "^2.2.3",
-		"jszip": "^3.10.1",
 		"lucide-react": "^0.344.0",
 		"prism-react-renderer": "^2.4.1",
 		"react": "^18.3.1",

--- a/board/src/App.tsx
+++ b/board/src/App.tsx
@@ -45,6 +45,7 @@ import {
 	shouldReportBackendReadinessAttempt,
 } from "./lib/backend-readiness-diagnostics";
 import { recordDesktopDiagnosticEvent } from "./lib/desktop-diagnostics";
+import { shouldBlockDesktopDropNavigation } from "./lib/desktop-drop-guard";
 import { isTauriEnvironmentSync } from "./lib/platform";
 
 const ClientDetailPage = lazy(() =>
@@ -93,6 +94,7 @@ function App() {
 					}}
 				>
 					<DesktopFullBoardPathBridge>
+						<DesktopDropNavigationGuard />
 						<Routes>
 							<Route path="oauth/callback" element={<OAuthCallbackPage />} />
 							<Route path="onboarding" element={<OnboardingPage />} />
@@ -176,6 +178,47 @@ function toFullBoardPath(raw: unknown): string | undefined {
 		return undefined;
 	}
 	return raw;
+}
+
+function DesktopDropNavigationGuard() {
+	useEffect(() => {
+		if (!isTauriEnvironmentSync()) {
+			return;
+		}
+
+		const handleDragOver = (event: DragEvent) => {
+			if (
+				event.defaultPrevented ||
+				!shouldBlockDesktopDropNavigation(event.dataTransfer, event.target)
+			) {
+				return;
+			}
+			event.preventDefault();
+			if (event.dataTransfer) {
+				event.dataTransfer.dropEffect = "none";
+			}
+		};
+
+		const handleDrop = (event: DragEvent) => {
+			if (
+				event.defaultPrevented ||
+				!shouldBlockDesktopDropNavigation(event.dataTransfer, event.target)
+			) {
+				return;
+			}
+			event.preventDefault();
+			event.stopPropagation();
+		};
+
+		window.addEventListener("dragover", handleDragOver, { capture: true });
+		window.addEventListener("drop", handleDrop, { capture: true });
+		return () => {
+			window.removeEventListener("dragover", handleDragOver, { capture: true });
+			window.removeEventListener("drop", handleDrop, { capture: true });
+		};
+	}, []);
+
+	return null;
 }
 
 function DesktopFullBoardPathBridge({ children }: { children: ReactNode }) {

--- a/board/src/App.tsx
+++ b/board/src/App.tsx
@@ -210,11 +210,11 @@ function DesktopDropNavigationGuard() {
 			event.stopPropagation();
 		};
 
-		window.addEventListener("dragover", handleDragOver, { capture: true });
-		window.addEventListener("drop", handleDrop, { capture: true });
+		window.addEventListener("dragover", handleDragOver);
+		window.addEventListener("drop", handleDrop);
 		return () => {
-			window.removeEventListener("dragover", handleDragOver, { capture: true });
-			window.removeEventListener("drop", handleDrop, { capture: true });
+			window.removeEventListener("dragover", handleDragOver);
+			window.removeEventListener("drop", handleDrop);
 		};
 	}, []);
 

--- a/board/src/components/list-grid-container.tsx
+++ b/board/src/components/list-grid-container.tsx
@@ -8,6 +8,7 @@ export interface ListGridContainerProps {
 	loadingSkeleton?: ReactNode;
 	emptyState?: ReactNode;
 	className?: string;
+	emptyClassName?: string;
 }
 
 export function ListGridContainer({
@@ -16,6 +17,7 @@ export function ListGridContainer({
 	loadingSkeleton,
 	emptyState,
 	className,
+	emptyClassName,
 }: ListGridContainerProps) {
 	const defaultView = useAppStore(
 		(state) => state.dashboardSettings.defaultView,
@@ -37,7 +39,9 @@ export function ListGridContainer({
 	}
 
 	if (emptyState) {
-		return <div className={cn("col-span-full", className)}>{emptyState}</div>;
+		return (
+			<div className={cn("col-span-full", emptyClassName)}>{emptyState}</div>
+		);
 	}
 
 	return (

--- a/board/src/components/list-grid-container.tsx
+++ b/board/src/components/list-grid-container.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useAppStore } from "../lib/store";
+import { cn } from "../lib/utils";
 
 export interface ListGridContainerProps {
 	children: ReactNode;
@@ -14,6 +15,7 @@ export function ListGridContainer({
 	loading = false,
 	loadingSkeleton,
 	emptyState,
+	className,
 }: ListGridContainerProps) {
 	const defaultView = useAppStore(
 		(state) => state.dashboardSettings.defaultView,
@@ -22,11 +24,12 @@ export function ListGridContainer({
 	if (loading) {
 		return (
 			<div
-				className={
+				className={cn(
 					defaultView === "grid"
 						? "grid gap-4 md:grid-cols-2 xl:grid-cols-3"
-						: "space-y-4"
-				}
+						: "space-y-4",
+					className,
+				)}
 			>
 				{loadingSkeleton}
 			</div>
@@ -34,16 +37,17 @@ export function ListGridContainer({
 	}
 
 	if (emptyState) {
-		return <div className="col-span-full">{emptyState}</div>;
+		return <div className={cn("col-span-full", className)}>{emptyState}</div>;
 	}
 
 	return (
 		<div
-			className={
+			className={cn(
 				defaultView === "grid"
 					? "grid gap-4 md:grid-cols-2 xl:grid-cols-3"
-					: "space-y-4"
-			}
+					: "space-y-4",
+				className,
+			)}
 		>
 			{children}
 		</div>

--- a/board/src/components/server-install/hooks/use-ingest.ts
+++ b/board/src/components/server-install/hooks/use-ingest.ts
@@ -1,16 +1,13 @@
 import { useCallback, useState } from "react";
 import type { ServerInstallDraft } from "../../../hooks/use-server-install-pipeline";
-import { normalizeIngestResult } from "../../../lib/install-normalizer";
+import {
+	normalizeIngestPayload,
+	type ServerIngestPayload,
+} from "../../../lib/install-normalizer";
 import { notifyError } from "../../../lib/notify";
 import type { ManualFormStateJson } from "../types";
 import { DEFAULT_INGEST_MESSAGE } from "../types";
 import { draftToFormState } from "./draft-to-form-state";
-
-type IngestPayload = {
-	text?: string;
-	buffer?: ArrayBuffer;
-	fileName?: string;
-};
 
 interface UseIngestProps {
 	ingestEnabled: boolean;
@@ -128,21 +125,12 @@ export function useIngest({
 	);
 
 	const handleIngestPayload = useCallback(
-		async (payload: {
-			text?: string;
-			buffer?: ArrayBuffer;
-			fileName?: string;
-			payloads?: IngestPayload[];
-		}) => {
+		async (payload: ServerIngestPayload) => {
 			if (!canIngestProgrammatically) return;
 			try {
 				setIsIngesting(true);
 				setIngestError(null);
-				const payloads = payload.payloads ?? [payload];
-				const draftGroups = await Promise.all(
-					payloads.map((item) => normalizeIngestResult(item)),
-				);
-				const drafts = draftGroups.flat();
+				const drafts = await normalizeIngestPayload(payload);
 				await finalizeIngest(drafts);
 			} catch (error) {
 				const message =

--- a/board/src/components/server-install/server-install-wizard.tsx
+++ b/board/src/components/server-install/server-install-wizard.tsx
@@ -45,6 +45,7 @@ import { onboardingApi } from "../../lib/onboarding-api";
 import {
 	canIngestFromDataTransfer,
 	extractPayloadFromDataTransfer,
+	formatServerUniImportTransferError,
 } from "../../lib/server-uni-import-transfer";
 import {
 	compactKeyValueFields,
@@ -1935,7 +1936,7 @@ export const ServerInstallWizard = forwardRef(
 											if (payload) await handleIngestPayload(payload);
 										} catch (error) {
 											setIngestError(
-												error instanceof Error ? error.message : String(error),
+												formatServerUniImportTransferError(error, t),
 											);
 											setIngestMessage(ingestMessages.defaultMessage);
 										}

--- a/board/src/components/server-install/server-install-wizard.tsx
+++ b/board/src/components/server-install/server-install-wizard.tsx
@@ -1911,11 +1911,19 @@ export const ServerInstallWizard = forwardRef(
 									onDrop={async (e) => {
 										if (!canIngestFromDataTransfer(e.dataTransfer)) return;
 										e.preventDefault();
+										e.stopPropagation();
 										setIsDragOver(false);
-										const payload = await extractPayloadFromDataTransfer(
-											e.dataTransfer!,
-										);
-										if (payload) await handleIngestPayload(payload);
+										try {
+											const payload = await extractPayloadFromDataTransfer(
+												e.dataTransfer!,
+											);
+											if (payload) await handleIngestPayload(payload);
+										} catch (error) {
+											setIngestError(
+												error instanceof Error ? error.message : String(error),
+											);
+											setIngestMessage(ingestMessages.defaultMessage);
+										}
 									}}
 									onPaste={async (e) => {
 										if (isDropZoneCollapsed) return;

--- a/board/src/components/server-install/server-install-wizard.tsx
+++ b/board/src/components/server-install/server-install-wizard.tsx
@@ -10,6 +10,7 @@ import {
 	RefreshCw,
 	RotateCcw,
 } from "lucide-react";
+import type { ServerIngestPayload } from "../../lib/install-normalizer";
 import type { FocusEvent, MouseEvent } from "react";
 import {
 	forwardRef,
@@ -209,6 +210,10 @@ interface ServerInstallWizardProps {
 	allowProgrammaticIngest?: boolean;
 	// Optional shared pipeline instance from parent page (recommended)
 	pipeline?: ReturnType<typeof useServerInstallPipeline>;
+	/** Payload to ingest when the drawer opens (set by external drop zones). */
+	pendingIngestPayload?: ServerIngestPayload | null;
+	/** Called after pendingIngestPayload has been consumed. */
+	onPendingIngestConsumed?: () => void;
 }
 
 export const ServerInstallWizard = forwardRef(
@@ -222,6 +227,8 @@ export const ServerInstallWizard = forwardRef(
 			onImport,
 			allowProgrammaticIngest = false,
 			pipeline: externalPipeline,
+			pendingIngestPayload,
+			onPendingIngestConsumed,
 		}: ServerInstallWizardProps,
 		ref: React.Ref<ServerInstallManualFormHandle>,
 	) => {
@@ -1488,6 +1495,14 @@ export const ServerInstallWizard = forwardRef(
 			}
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [isOpen]);
+
+		// Ingest payload dropped on external drop zones (e.g. server list page)
+		useEffect(() => {
+			if (!isOpen || !pendingIngestPayload) return;
+			const payload = pendingIngestPayload;
+			onPendingIngestConsumed?.();
+			handleIngestPayload(payload);
+		}, [isOpen, pendingIngestPayload, handleIngestPayload, onPendingIngestConsumed]);
 
 		// Hydrate form when an initial draft is provided (e.g., Market mode)
 		// Create a stable key that only changes when the actual draft content changes

--- a/board/src/components/server-install/types.ts
+++ b/board/src/components/server-install/types.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ServerInstallDraft } from "../../hooks/use-server-install-pipeline";
+import type { ServerIngestPayload } from "../../lib/install-normalizer";
 import type { OAuthConfigRequest } from "../../lib/types";
 import type { SegmentOption } from "../ui/segment";
 
@@ -164,16 +165,7 @@ export interface ManualFormStateJson {
 }
 
 export interface ServerInstallManualFormHandle {
-	ingest: (payload: {
-		text?: string;
-		buffer?: ArrayBuffer;
-		fileName?: string;
-		payloads?: Array<{
-			text?: string;
-			buffer?: ArrayBuffer;
-			fileName?: string;
-		}>;
-	}) => Promise<void>;
+	ingest: (payload: ServerIngestPayload) => Promise<void>;
 	loadDraft: (draft: ServerInstallDraft) => Promise<void> | void;
 	getCurrentDraft: () => ServerInstallDraft | null;
 }

--- a/board/src/components/server-install/uni-import.tsx
+++ b/board/src/components/server-install/uni-import.tsx
@@ -26,6 +26,10 @@ import { readClipboardText } from "../../lib/clipboard";
 import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import { parseJsonDrafts } from "../../lib/install-normalizer";
 import { isTauriEnvironmentSync } from "../../lib/platform";
+import {
+	canIngestFromDataTransfer,
+	extractPayloadFromDataTransfer,
+} from "../../lib/server-uni-import-transfer";
 import type { SecretOrigin } from "../../lib/types";
 import {
 	InlineSecretCreate,
@@ -708,6 +712,7 @@ export const ServerInstallManualForm = forwardRef<
 		// Drag and drop handlers
 		const onDragEnter = (event: React.DragEvent<HTMLButtonElement>) => {
 			if (!ingestEnabled) return;
+			if (!canIngestFromDataTransfer(event.dataTransfer)) return;
 			event.preventDefault();
 			event.stopPropagation();
 			setIsDragOver(true);
@@ -730,40 +735,19 @@ export const ServerInstallManualForm = forwardRef<
 
 		const onDrop = async (event: React.DragEvent<HTMLButtonElement>) => {
 			if (!ingestEnabled) return;
+			if (!canIngestFromDataTransfer(event.dataTransfer)) return;
 			event.preventDefault();
+			event.stopPropagation();
 			setIsDragOver(false);
-			const { files, items } = event.dataTransfer;
-			if (files?.length) {
-				const file = files[0];
-				if (file.name.endsWith(".mcpb") || file.name.endsWith(".dxt")) {
-					const buffer = await file.arrayBuffer();
-					setIngestMessage(
-						t("manual.ingest.processingBundle", {
-							name: file.name,
-							defaultValue: "Processing bundle: {{name}}",
-						}),
-					);
-					await handleIngestPayload({ buffer, fileName: file.name });
-					return;
+			try {
+				const payload = await extractPayloadFromDataTransfer(event.dataTransfer);
+				if (payload) {
+					setIngestMessage(ingestMessages.parsingDropped);
+					await handleIngestPayload(payload);
 				}
-				const text = await file.text();
-				setIngestMessage(
-					t("manual.ingest.parsingFile", {
-						name: file.name,
-						defaultValue: "Parsing text from {{name}}",
-					}),
-				);
-				await handleIngestPayload({ text, fileName: file.name });
-				return;
-			}
-			if (items?.length) {
-				const item = items[0];
-				if (item.kind === "string") {
-					item.getAsString(async (text) => {
-						setIngestMessage(ingestMessages.parsingDropped);
-						await handleIngestPayload({ text });
-					});
-				}
+			} catch (error) {
+				setIngestError(error instanceof Error ? error.message : String(error));
+				setIngestMessage(ingestMessages.defaultMessage);
 			}
 		};
 

--- a/board/src/components/server-install/uni-import.tsx
+++ b/board/src/components/server-install/uni-import.tsx
@@ -29,6 +29,7 @@ import { isTauriEnvironmentSync } from "../../lib/platform";
 import {
 	canIngestFromDataTransfer,
 	extractPayloadFromDataTransfer,
+	formatServerUniImportTransferError,
 } from "../../lib/server-uni-import-transfer";
 import type { SecretOrigin } from "../../lib/types";
 import {
@@ -746,7 +747,7 @@ export const ServerInstallManualForm = forwardRef<
 					await handleIngestPayload(payload);
 				}
 			} catch (error) {
-				setIngestError(error instanceof Error ? error.message : String(error));
+				setIngestError(formatServerUniImportTransferError(error, t));
 				setIngestMessage(ingestMessages.defaultMessage);
 			}
 		};

--- a/board/src/lib/desktop-drop-guard.test.ts
+++ b/board/src/lib/desktop-drop-guard.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { shouldBlockDesktopDropNavigation } from "./desktop-drop-guard";
+
+function dataTransferWithTypes(types: string[]): DataTransfer {
+	return {
+		types: {
+			length: types.length,
+			contains: (value: string) => types.includes(value),
+		},
+	} as unknown as DataTransfer;
+}
+
+function targetWithClosest(isEditable: boolean): EventTarget {
+	return {
+		closest: () => (isEditable ? {} : null),
+	} as unknown as EventTarget;
+}
+
+describe("desktop drop guard", () => {
+	test("blocks dropped files so the WebView cannot navigate to local content", () => {
+		expect(
+			shouldBlockDesktopDropNavigation(
+				dataTransferWithTypes(["Files"]),
+				targetWithClosest(true),
+			),
+		).toBe(true);
+	});
+
+	test("blocks dropped text outside editable targets", () => {
+		expect(
+			shouldBlockDesktopDropNavigation(
+				dataTransferWithTypes(["text/plain"]),
+				targetWithClosest(false),
+			),
+		).toBe(true);
+	});
+
+	test("allows dropped text in editable targets", () => {
+		expect(
+			shouldBlockDesktopDropNavigation(
+				dataTransferWithTypes(["text/plain"]),
+				targetWithClosest(true),
+			),
+		).toBe(false);
+	});
+
+	test("blocks unrelated drag payloads outside editable targets", () => {
+		expect(
+			shouldBlockDesktopDropNavigation(
+				dataTransferWithTypes(["application/x-custom"]),
+				targetWithClosest(false),
+			),
+		).toBe(true);
+	});
+
+	test("allows unrelated drag payloads in editable targets", () => {
+		expect(
+			shouldBlockDesktopDropNavigation(
+				dataTransferWithTypes(["application/x-custom"]),
+				targetWithClosest(true),
+			),
+		).toBe(false);
+	});
+});

--- a/board/src/lib/desktop-drop-guard.ts
+++ b/board/src/lib/desktop-drop-guard.ts
@@ -1,0 +1,23 @@
+const EDITABLE_SELECTOR =
+	"input, textarea, select, [contenteditable=''], [contenteditable='true']";
+
+export function shouldBlockDesktopDropNavigation(
+	dataTransfer: DataTransfer | null,
+	target: EventTarget | null,
+): boolean {
+	const types = dataTransfer?.types;
+	if (!types?.length) {
+		return false;
+	}
+	if (
+		"contains" in types
+			? (types as unknown as DOMStringList).contains("Files")
+			: (types as readonly string[]).includes("Files")
+	) {
+		return true;
+	}
+	const el = target as { closest?: (s: string) => unknown } | null;
+	return (
+		typeof el?.closest !== "function" || el.closest(EDITABLE_SELECTOR) === null
+	);
+}

--- a/board/src/lib/install-normalizer.test.ts
+++ b/board/src/lib/install-normalizer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeIngestPayload } from "./install-normalizer";
+
+function serverJson(name: string, command: string): string {
+	return JSON.stringify({
+		mcpServers: {
+			[name]: {
+				command,
+				args: [`${name}-server`],
+			},
+		},
+	});
+}
+
+describe("install normalizer", () => {
+	test("normalizes multi-file ingest payloads into drafts", async () => {
+		const drafts = await normalizeIngestPayload({
+			payloads: [
+				{ text: serverJson("one", "uvx"), fileName: "one.json" },
+				{ text: serverJson("two", "node"), fileName: "two.json" },
+			],
+		});
+
+		expect(
+			drafts.map((draft) => ({
+				name: draft.name,
+				command: draft.command,
+				args: draft.args,
+			})),
+		).toEqual([
+			{ name: "one", command: "uvx", args: ["one-server"] },
+			{ name: "two", command: "node", args: ["two-server"] },
+		]);
+	});
+});

--- a/board/src/lib/install-normalizer.ts
+++ b/board/src/lib/install-normalizer.ts
@@ -1,5 +1,4 @@
 import JSON5 from "json5";
-import JSZip from "jszip";
 import * as TOML from "toml";
 import type { ServerInstallDraft } from "../hooks/use-server-install-pipeline";
 import type {
@@ -8,6 +7,15 @@ import type {
 	ServerIcon,
 	ServerMetaInfo,
 } from "./types";
+
+export type ServerIngestPayload = {
+	text?: string;
+	fileName?: string;
+	payloads?: Array<{
+		text?: string;
+		fileName?: string;
+	}>;
+};
 
 const normalizeKind = (value: unknown): ServerInstallDraft["kind"] => {
 	const token = typeof value === "string" ? value.trim().toLowerCase() : "";
@@ -441,54 +449,6 @@ const generateServerName = (kind: ServerInstallDraft["kind"]): string => {
 	return `${base}-${Math.random().toString(36).slice(2, 8)}`;
 };
 
-export async function parseMcpbBundle(
-	buffer: ArrayBuffer,
-): Promise<ServerInstallDraft[]> {
-	const zip = await JSZip.loadAsync(buffer);
-	const manifestEntry = zip.file("manifest.json");
-	if (!manifestEntry) {
-		throw new Error("MCPB bundle missing manifest.json");
-	}
-	const manifestText = await manifestEntry.async("string");
-	const manifest = JSON.parse(manifestText);
-	const serverConfig = manifest.server?.mcp_config ?? {};
-	const env = toEnvRecord(serverConfig.env);
-	const args = toStringArray(serverConfig.args);
-	const command = trimmedString(serverConfig.command);
-
-	const metaExtras = {
-		"anthropic.mcpb/manifest": manifest,
-	};
-	const metaIcons = normalizeIconList(
-		(manifest as any)?.icons || (manifest as any)?.icon,
-	);
-	const baseMeta = hydrateMeta(
-		normalizeMeta({
-			description: manifest.description,
-			version: manifest.version,
-			website: manifest.homepage ?? manifest.documentation,
-			repository: manifest.repository,
-			icons: metaIcons,
-		}),
-		metaExtras,
-	);
-
-	const envForDraft = env && Object.keys(env).length ? env : undefined;
-	const draft: ServerInstallDraft = {
-		name:
-			trimmedString(manifest.name) ||
-			trimmedString(manifest.display_name) ||
-			generateServerName("stdio"),
-		kind: "stdio",
-		command: command,
-		args,
-		env: envForDraft,
-		meta: baseMeta,
-	};
-
-	return [draft];
-}
-
 function wrapLooseServerMap(record: Record<string, unknown>): unknown {
 	const values = Object.values(record);
 	const isDictOfObjects =
@@ -584,12 +544,8 @@ export const draftFromText = (text: string): ServerInstallDraft[] => {
 
 export const normalizeIngestResult = async (payload: {
 	text?: string;
-	buffer?: ArrayBuffer;
 	fileName?: string;
 }): Promise<ServerInstallDraft[]> => {
-	if (payload.buffer) {
-		return parseMcpbBundle(payload.buffer);
-	}
 	if (payload.text) {
 		// Try JSON first for best fidelity, then TOML
 		const asJson = draftFromText(payload.text);
@@ -599,4 +555,14 @@ export const normalizeIngestResult = async (payload: {
 		return [];
 	}
 	return [];
+};
+
+export const normalizeIngestPayload = async (
+	payload: ServerIngestPayload,
+): Promise<ServerInstallDraft[]> => {
+	const payloads = payload.payloads ?? [payload];
+	const draftGroups = await Promise.all(
+		payloads.map((item) => normalizeIngestResult(item)),
+	);
+	return draftGroups.flat();
 };

--- a/board/src/lib/server-uni-import-transfer.test.ts
+++ b/board/src/lib/server-uni-import-transfer.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
 	SERVER_UNI_IMPORT_TEXT_MAX_BYTES,
+	ServerUniImportTransferError,
 	extractPayloadFromDataTransfer,
+	formatServerUniImportTransferError,
 } from "./server-uni-import-transfer";
 
 function dataTransferWithFiles(files: unknown[]): DataTransfer {
@@ -13,6 +15,14 @@ function dataTransferWithFiles(files: unknown[]): DataTransfer {
 				yield* files;
 			},
 		},
+	} as unknown as DataTransfer;
+}
+
+function dataTransferWithText(text: string): DataTransfer {
+	return {
+		files: { length: 0 },
+		getData: (type: string) => (type === "text/plain" ? text : ""),
+		types: ["text/plain"],
 	} as unknown as DataTransfer;
 }
 
@@ -65,6 +75,32 @@ describe("server uni-import transfer", () => {
 				]),
 			),
 		).rejects.toThrow("Dropped file exceeds the 1 MB import limit.");
+	});
+
+	test("rejects non-ASCII dropped text by UTF-8 byte size", async () => {
+		const oversizedText = "界".repeat(
+			Math.floor(SERVER_UNI_IMPORT_TEXT_MAX_BYTES / 3) + 1,
+		);
+
+		await expect(
+			extractPayloadFromDataTransfer(dataTransferWithText(oversizedText)),
+		).rejects.toMatchObject({
+			code: "textTooLarge",
+			message: "Dropped text exceeds the 1 MB import limit.",
+		});
+	});
+
+	test("formats transfer errors with translated messages", () => {
+		const message = formatServerUniImportTransferError(
+			new ServerUniImportTransferError(
+				"tooManyFiles",
+				"Drop up to 16 files at a time.",
+				{ maxFiles: 16 },
+			),
+			(key, options) => `${key}:${options?.maxFiles}`,
+		);
+
+		expect(message).toBe("notifications.importRejections.tooManyFiles:16");
 	});
 
 	test("extracts multiple text files as payloads", async () => {

--- a/board/src/lib/server-uni-import-transfer.test.ts
+++ b/board/src/lib/server-uni-import-transfer.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import {
+	SERVER_UNI_IMPORT_TEXT_MAX_BYTES,
+	extractPayloadFromDataTransfer,
+} from "./server-uni-import-transfer";
+
+function dataTransferWithFiles(files: unknown[]): DataTransfer {
+	return {
+		files: {
+			length: files.length,
+			...files,
+			[Symbol.iterator]: function* () {
+				yield* files;
+			},
+		},
+	} as unknown as DataTransfer;
+}
+
+function fileLike({
+	name,
+	size,
+	text,
+}: {
+	name: string;
+	size: number;
+	text?: () => Promise<string>;
+}): File {
+	return {
+		name,
+		size,
+		text: text ?? (async () => "{}"),
+		arrayBuffer: async () => {
+			throw new Error("bundle should not be read");
+		},
+	} as unknown as File;
+}
+
+describe("server uni-import transfer", () => {
+	test("rejects MCPB bundles before reading them", async () => {
+		await expect(
+			extractPayloadFromDataTransfer(
+				dataTransferWithFiles([
+					fileLike({
+						name: "server.mcpb",
+						size: 128,
+					}),
+				]),
+			),
+		).rejects.toMatchObject({
+			message: "MCPB and DXT bundle import is currently disabled.",
+		});
+	});
+
+	test("rejects oversized text files before reading them", async () => {
+		await expect(
+			extractPayloadFromDataTransfer(
+				dataTransferWithFiles([
+					fileLike({
+						name: "server.json",
+						size: SERVER_UNI_IMPORT_TEXT_MAX_BYTES + 1,
+						text: async () => {
+							throw new Error("oversized file should not be read");
+						},
+					}),
+				]),
+			),
+		).rejects.toThrow("Dropped file exceeds the 1 MB import limit.");
+	});
+
+	test("extracts multiple text files as payloads", async () => {
+		await expect(
+			extractPayloadFromDataTransfer(
+				dataTransferWithFiles([
+					fileLike({
+						name: "one.json",
+						size: 128,
+						text: async () => "{\"name\":\"one\",\"command\":\"uvx\"}",
+					}),
+					fileLike({
+						name: "two.json",
+						size: 128,
+						text: async () => "{\"name\":\"two\",\"command\":\"node\"}",
+					}),
+				]),
+			),
+		).resolves.toEqual({
+			payloads: [
+				{ text: "{\"name\":\"one\",\"command\":\"uvx\"}", fileName: "one.json" },
+				{ text: "{\"name\":\"two\",\"command\":\"node\"}", fileName: "two.json" },
+			],
+		});
+	});
+});

--- a/board/src/lib/server-uni-import-transfer.ts
+++ b/board/src/lib/server-uni-import-transfer.ts
@@ -5,8 +5,63 @@ export type ServerUniImportTransferPayload = ServerIngestPayload;
 export const SERVER_UNI_IMPORT_TEXT_MAX_BYTES = 1_048_576;
 const SERVER_UNI_IMPORT_MAX_FILES = 16;
 
+export type ServerUniImportTransferErrorCode =
+	| "bundleDisabled"
+	| "fileTooLarge"
+	| "textTooLarge"
+	| "tooManyFiles";
+
+type ServerUniImportTransferErrorParams = {
+	maxFiles?: number;
+	maxMb?: number;
+};
+
+type TranslationFunction = (
+	key: string,
+	options?: Record<string, unknown>,
+) => string;
+
+export class ServerUniImportTransferError extends Error {
+	readonly code: ServerUniImportTransferErrorCode;
+	readonly params: ServerUniImportTransferErrorParams;
+
+	constructor(
+		code: ServerUniImportTransferErrorCode,
+		message: string,
+		params: ServerUniImportTransferErrorParams = {},
+	) {
+		super(message);
+		this.name = "ServerUniImportTransferError";
+		this.code = code;
+		this.params = params;
+	}
+}
+
+export function formatServerUniImportTransferError(
+	error: unknown,
+	t: TranslationFunction,
+	keyPrefix = "notifications.importRejections",
+): string {
+	if (error instanceof ServerUniImportTransferError) {
+		return t(`${keyPrefix}.${error.code}`, {
+			defaultValue: error.message,
+			...error.params,
+		});
+	}
+	return error instanceof Error ? error.message : String(error);
+}
+
 function utf8ByteLength(value: string): number {
 	return new TextEncoder().encode(value).byteLength;
+}
+
+function hasNonAscii(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		if (value.charCodeAt(index) > 0x7f) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function isBundleFileName(fileName: string): boolean {
@@ -16,17 +71,37 @@ function isBundleFileName(fileName: string): boolean {
 
 function assertSupportedFile(file: File): void {
 	if (isBundleFileName(file.name)) {
-		throw new Error("MCPB and DXT bundle import is currently disabled.");
+		throw new ServerUniImportTransferError(
+			"bundleDisabled",
+			"MCPB and DXT bundle import is currently disabled.",
+		);
 	}
 	if (file.size > SERVER_UNI_IMPORT_TEXT_MAX_BYTES) {
-		throw new Error("Dropped file exceeds the 1 MB import limit.");
+		throw new ServerUniImportTransferError(
+			"fileTooLarge",
+			"Dropped file exceeds the 1 MB import limit.",
+			{ maxMb: 1 },
+		);
 	}
 }
 
 function assertTextWithinLimit(text: string): void {
-	if (text.length <= SERVER_UNI_IMPORT_TEXT_MAX_BYTES) return;
-	if (utf8ByteLength(text) > SERVER_UNI_IMPORT_TEXT_MAX_BYTES) {
-		throw new Error("Dropped text exceeds the 1 MB import limit.");
+	if (text.length > SERVER_UNI_IMPORT_TEXT_MAX_BYTES) {
+		throw new ServerUniImportTransferError(
+			"textTooLarge",
+			"Dropped text exceeds the 1 MB import limit.",
+			{ maxMb: 1 },
+		);
+	}
+	if (
+		hasNonAscii(text) &&
+		utf8ByteLength(text) > SERVER_UNI_IMPORT_TEXT_MAX_BYTES
+	) {
+		throw new ServerUniImportTransferError(
+			"textTooLarge",
+			"Dropped text exceeds the 1 MB import limit.",
+			{ maxMb: 1 },
+		);
 	}
 }
 
@@ -45,7 +120,11 @@ export async function extractPayloadFromDataTransfer(
 ): Promise<ServerUniImportTransferPayload | null> {
 	if (dataTransfer.files && dataTransfer.files.length > 0) {
 		if (dataTransfer.files.length > SERVER_UNI_IMPORT_MAX_FILES) {
-			throw new Error("Drop up to 16 files at a time.");
+			throw new ServerUniImportTransferError(
+				"tooManyFiles",
+				"Drop up to 16 files at a time.",
+				{ maxFiles: SERVER_UNI_IMPORT_MAX_FILES },
+			);
 		}
 		const payloads = await Promise.all(
 			Array.from(dataTransfer.files).map(async (file) => {

--- a/board/src/lib/server-uni-import-transfer.ts
+++ b/board/src/lib/server-uni-import-transfer.ts
@@ -1,13 +1,34 @@
-export type ServerUniImportTransferPayload = {
-	text?: string;
-	buffer?: ArrayBuffer;
-	fileName?: string;
-	payloads?: Array<{
-		text?: string;
-		buffer?: ArrayBuffer;
-		fileName?: string;
-	}>;
-};
+import type { ServerIngestPayload } from "./install-normalizer";
+
+export type ServerUniImportTransferPayload = ServerIngestPayload;
+
+export const SERVER_UNI_IMPORT_TEXT_MAX_BYTES = 1_048_576;
+const SERVER_UNI_IMPORT_MAX_FILES = 16;
+
+function utf8ByteLength(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
+function isBundleFileName(fileName: string): boolean {
+	const lower = fileName.toLowerCase();
+	return lower.endsWith(".mcpb") || lower.endsWith(".dxt");
+}
+
+function assertSupportedFile(file: File): void {
+	if (isBundleFileName(file.name)) {
+		throw new Error("MCPB and DXT bundle import is currently disabled.");
+	}
+	if (file.size > SERVER_UNI_IMPORT_TEXT_MAX_BYTES) {
+		throw new Error("Dropped file exceeds the 1 MB import limit.");
+	}
+}
+
+function assertTextWithinLimit(text: string): void {
+	if (text.length <= SERVER_UNI_IMPORT_TEXT_MAX_BYTES) return;
+	if (utf8ByteLength(text) > SERVER_UNI_IMPORT_TEXT_MAX_BYTES) {
+		throw new Error("Dropped text exceeds the 1 MB import limit.");
+	}
+}
 
 export function canIngestFromDataTransfer(dataTransfer: DataTransfer | null): boolean {
 	if (!dataTransfer) return false;
@@ -23,11 +44,12 @@ export async function extractPayloadFromDataTransfer(
 	dataTransfer: DataTransfer,
 ): Promise<ServerUniImportTransferPayload | null> {
 	if (dataTransfer.files && dataTransfer.files.length > 0) {
+		if (dataTransfer.files.length > SERVER_UNI_IMPORT_MAX_FILES) {
+			throw new Error("Drop up to 16 files at a time.");
+		}
 		const payloads = await Promise.all(
 			Array.from(dataTransfer.files).map(async (file) => {
-				if (file.name.endsWith(".mcpb") || file.name.endsWith(".dxt")) {
-					return { buffer: await file.arrayBuffer(), fileName: file.name };
-				}
+				assertSupportedFile(file);
 				return { text: await file.text(), fileName: file.name };
 			}),
 		);
@@ -39,11 +61,13 @@ export async function extractPayloadFromDataTransfer(
 
 	const plainText = dataTransfer.getData("text/plain");
 	if (plainText) {
+		assertTextWithinLimit(plainText);
 		return { text: plainText };
 	}
 
 	const uriList = dataTransfer.getData("text/uri-list");
 	if (uriList) {
+		assertTextWithinLimit(uriList);
 		return { text: uriList };
 	}
 
@@ -54,6 +78,7 @@ export async function extractPayloadFromDataTransfer(
 					item.getAsString((text) => resolve(text ?? null));
 				});
 				if (value) {
+					assertTextWithinLimit(value);
 					return { text: value };
 				}
 			}

--- a/board/src/pages/operator/use-operator-server-import.ts
+++ b/board/src/pages/operator/use-operator-server-import.ts
@@ -3,13 +3,15 @@ import { useTranslation } from "react-i18next";
 import type { ServerInstallDraft } from "../../hooks/use-server-install-pipeline";
 import { extractImportStats, serversApi, type ImportStats } from "../../lib/api";
 import { resolveAutoAddTargetProfileId } from "../../lib/default-profile";
-import { normalizeIngestResult } from "../../lib/install-normalizer";
+import {
+	normalizeIngestPayload,
+	type ServerIngestPayload,
+} from "../../lib/install-normalizer";
 import { notifyError, notifyInfo, notifySuccess } from "../../lib/notify";
 import { buildDraftServersImportRequest } from "../../lib/server-import-payload";
 import {
 	canIngestFromDataTransfer,
 	extractPayloadFromDataTransfer,
-	type ServerUniImportTransferPayload,
 } from "../../lib/server-uni-import-transfer";
 import { formatNameList, summarizeSkipped } from "../../lib/server-import-utils";
 import { useAppStore } from "../../lib/store";
@@ -164,7 +166,7 @@ export function useOperatorServerImport({
 	);
 
 	const ingestPayload = useCallback(
-		async (payload: ServerUniImportTransferPayload) => {
+		async (payload: ServerIngestPayload) => {
 			setOpen(true);
 			setPhase("parsing");
 			setParseError(null);
@@ -173,7 +175,7 @@ export function useOperatorServerImport({
 			setDryRunWarning(null);
 			setDryRunError(null);
 			try {
-				const parsed = await normalizeIngestResult(payload);
+				const parsed = await normalizeIngestPayload(payload);
 				if (!parsed.length) {
 					const title = t("servers:manual.ingest.noneDetectedTitle", {
 						defaultValue: "No servers detected",
@@ -216,12 +218,23 @@ export function useOperatorServerImport({
 					}),
 					t("servers:notifications.importUnsupported.message", {
 						defaultValue:
-							"Drop text, JSON snippets, URLs, or MCP bundles to use Uni-Import.",
+							"Drop text, JSON snippets, URLs, or config files to use Uni-Import.",
 					}),
 				);
 				return;
 			}
-			const payload = await extractPayloadFromDataTransfer(dataTransfer);
+			let payload;
+			try {
+				payload = await extractPayloadFromDataTransfer(dataTransfer);
+			} catch (error) {
+				notifyError(
+					t("servers:notifications.importUnsupported.title", {
+						defaultValue: "Unsupported content",
+					}),
+					error instanceof Error ? error.message : String(error),
+				);
+				return;
+			}
 			if (!payload) {
 				notifyError(
 					t("servers:notifications.importEmpty.title", {

--- a/board/src/pages/operator/use-operator-server-import.ts
+++ b/board/src/pages/operator/use-operator-server-import.ts
@@ -12,6 +12,7 @@ import { buildDraftServersImportRequest } from "../../lib/server-import-payload"
 import {
 	canIngestFromDataTransfer,
 	extractPayloadFromDataTransfer,
+	formatServerUniImportTransferError,
 } from "../../lib/server-uni-import-transfer";
 import { formatNameList, summarizeSkipped } from "../../lib/server-import-utils";
 import { useAppStore } from "../../lib/store";
@@ -231,7 +232,11 @@ export function useOperatorServerImport({
 					t("servers:notifications.importUnsupported.title", {
 						defaultValue: "Unsupported content",
 					}),
-					error instanceof Error ? error.message : String(error),
+					formatServerUniImportTransferError(
+						error,
+						t,
+						"servers:notifications.importRejections",
+					),
 				);
 				return;
 			}

--- a/board/src/pages/servers/i18n/index.ts
+++ b/board/src/pages/servers/i18n/index.ts
@@ -39,7 +39,7 @@ export const serversTranslations = {
 			importUnsupported: {
 				title: "Unsupported content",
 				message:
-					"Drop text, JSON snippets, URLs, or MCP bundles to use Uni-Import.",
+					"Drop text, JSON snippets, URLs, or config files to use Uni-Import.",
 			},
 			importEmpty: {
 				title: "Nothing to import",
@@ -426,8 +426,6 @@ export const serversTranslations = {
 					"We could not find any server definitions in the input.",
 				parseFailedFallback: "Failed to parse input",
 				parseFailedTitle: "Parsing failed",
-				processingBundle: "Processing bundle: {{name}}",
-				parsingFile: "Parsing text from {{name}}",
 				editing: "Editing server",
 				shortcut: "Ctrl/Cmd + V",
 				tipPrefix: "Tip: press",
@@ -923,7 +921,7 @@ export const serversTranslations = {
 		notifications: {
 			importUnsupported: {
 				title: "不支持的内容",
-				message: "请拖放文本、JSON 片段、URL 或 MCP 安装包以使用 Uni-Import。",
+				message: "请拖放文本、JSON 片段、URL 或配置文件以使用 Uni-Import。",
 			},
 			importEmpty: {
 				title: "没有可导入的内容",
@@ -1302,8 +1300,6 @@ export const serversTranslations = {
 				noneDetectedDescription: "无法在输入内容中找到任何服务器定义。",
 				parseFailedFallback: "解析输入失败",
 				parseFailedTitle: "解析失败",
-				processingBundle: "正在处理安装包：{{name}}",
-				parsingFile: "正在解析 {{name}} 中的文本",
 				editing: "编辑服务器",
 				shortcut: "Ctrl/Cmd + V",
 				tipPrefix: "提示：按下",
@@ -1763,7 +1759,7 @@ export const serversTranslations = {
 			importUnsupported: {
 				title: "サポートされていない内容",
 				message:
-					"Uni-Import を使うにはテキスト、JSON スニペット、URL、または MCP バンドルをドロップしてください。",
+					"Uni-Import を使うにはテキスト、JSON スニペット、URL、または設定ファイルをドロップしてください。",
 			},
 			importEmpty: {
 				title: "インポートできる内容がありません",
@@ -2152,8 +2148,6 @@ export const serversTranslations = {
 					"入力内容にサーバー定義が含まれていませんでした。",
 				parseFailedFallback: "入力の解析に失敗しました",
 				parseFailedTitle: "解析に失敗しました",
-				processingBundle: "バンドルを処理中：{{name}}",
-				parsingFile: "{{name}} のテキストを解析しています",
 				editing: "サーバーを編集",
 				shortcut: "Ctrl/Cmd + V",
 				tipPrefix: "ヒント：",

--- a/board/src/pages/servers/i18n/index.ts
+++ b/board/src/pages/servers/i18n/index.ts
@@ -41,6 +41,12 @@ export const serversTranslations = {
 				message:
 					"Drop text, JSON snippets, URLs, or config files to use Uni-Import.",
 			},
+			importRejections: {
+				bundleDisabled: "MCPB and DXT bundle import is currently disabled.",
+				fileTooLarge: "Dropped file exceeds the {{maxMb}} MB import limit.",
+				textTooLarge: "Dropped text exceeds the {{maxMb}} MB import limit.",
+				tooManyFiles: "Drop up to {{maxFiles}} files at a time.",
+			},
 			importEmpty: {
 				title: "Nothing to import",
 				message:
@@ -923,6 +929,12 @@ export const serversTranslations = {
 				title: "不支持的内容",
 				message: "请拖放文本、JSON 片段、URL 或配置文件以使用 Uni-Import。",
 			},
+			importRejections: {
+				bundleDisabled: "MCPB 与 DXT 安装包导入目前已暂停。",
+				fileTooLarge: "拖入的文件超过 {{maxMb}} MB 导入限制。",
+				textTooLarge: "拖入的文本超过 {{maxMb}} MB 导入限制。",
+				tooManyFiles: "一次最多拖入 {{maxFiles}} 个文件。",
+			},
 			importEmpty: {
 				title: "没有可导入的内容",
 				message: "无法从拖放的内容中检测到可用的配置。",
@@ -1760,6 +1772,15 @@ export const serversTranslations = {
 				title: "サポートされていない内容",
 				message:
 					"Uni-Import を使うにはテキスト、JSON スニペット、URL、または設定ファイルをドロップしてください。",
+			},
+			importRejections: {
+				bundleDisabled:
+					"MCPB と DXT バンドルのインポートは現在無効です。",
+				fileTooLarge:
+					"ドロップされたファイルは {{maxMb}} MB のインポート上限を超えています。",
+				textTooLarge:
+					"ドロップされたテキストは {{maxMb}} MB のインポート上限を超えています。",
+				tooManyFiles: "一度にドロップできるファイルは {{maxFiles}} 個までです。",
 			},
 			importEmpty: {
 				title: "インポートできる内容がありません",

--- a/board/src/pages/servers/server-list-page.tsx
+++ b/board/src/pages/servers/server-list-page.tsx
@@ -45,6 +45,7 @@ import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import { useUrlSort, useUrlView } from "../../lib/hooks/use-url-state";
 import { notifyError, notifyInfo, notifySuccess } from "../../lib/notify";
 import { useAppStore } from "../../lib/store";
+import { cn } from "../../lib/utils";
 import {
 	canIngestFromDataTransfer,
 	extractPayloadFromDataTransfer,
@@ -68,6 +69,22 @@ function isTransitionalServerStatus(status: string | undefined): boolean {
 	return TRANSITIONAL_SERVER_STATUSES.has(String(status || "").toLowerCase());
 }
 
+function prepareServerDropTargetEvent(
+	event: React.DragEvent<HTMLDivElement>,
+): boolean {
+	if (!canIngestFromDataTransfer(event.dataTransfer)) return false;
+	event.preventDefault();
+	event.stopPropagation();
+	return true;
+}
+
+function isDragLeaveInsideCurrentTarget(
+	event: React.DragEvent<HTMLDivElement>,
+): boolean {
+	const nextTarget = event.relatedTarget as Node | null;
+	return Boolean(nextTarget && event.currentTarget.contains(nextTarget));
+}
+
 // Helper function to get the instance count for a server
 function getCapabilitySummary(server: ServerSummary) {
 	return server.capability ?? server.capabilities ?? undefined;
@@ -81,6 +98,7 @@ export function ServerListPage() {
 	const [manualOpen, setManualOpen] = useState(false);
 	const manualRef = useRef<ServerInstallManualFormHandle | null>(null);
 	const [isAddDragActive, setAddDragActive] = useState(false);
+	const [isEmptyAddDragActive, setEmptyAddDragActive] = useState(false);
 	const [editingServer, setEditingServer] = useState<ServerDetail | null>(null);
 	const [deletingServer, setDeletingServer] = useState<string | null>(null);
 	const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
@@ -105,9 +123,7 @@ export function ServerListPage() {
 
 	const handleAddDragEnter = useCallback(
 		(event: React.DragEvent<HTMLDivElement>) => {
-			if (!canIngestFromDataTransfer(event.dataTransfer)) return;
-			event.preventDefault();
-			event.stopPropagation();
+			if (!prepareServerDropTargetEvent(event)) return;
 			setAddDragActive(true);
 		},
 		[],
@@ -115,27 +131,20 @@ export function ServerListPage() {
 
 	const handleAddDragOver = useCallback(
 		(event: React.DragEvent<HTMLDivElement>) => {
-			if (!canIngestFromDataTransfer(event.dataTransfer)) return;
-			event.preventDefault();
-			event.stopPropagation();
+			if (!prepareServerDropTargetEvent(event)) return;
 			if (event.dataTransfer) {
 				event.dataTransfer.dropEffect = "copy";
 			}
-			if (!isAddDragActive) {
-				setAddDragActive(true);
-			}
+			setAddDragActive(true);
 		},
-		[isAddDragActive],
+		[],
 	);
 
 	const handleAddDragLeave = useCallback(
 		(event: React.DragEvent<HTMLDivElement>) => {
 			event.preventDefault();
 			event.stopPropagation();
-			const nextTarget = event.relatedTarget as Node | null;
-			if (nextTarget && event.currentTarget.contains(nextTarget)) {
-				return;
-			}
+			if (isDragLeaveInsideCurrentTarget(event)) return;
 			setAddDragActive(false);
 		},
 		[],
@@ -204,12 +213,8 @@ export function ServerListPage() {
 		);
 	}, [pendingServerDeepLinkImport, setPendingServerDeepLinkImport, t]);
 
-	const handleAddDrop = useCallback(
-		async (event: React.DragEvent<HTMLDivElement>) => {
-			event.preventDefault();
-			event.stopPropagation();
-			setAddDragActive(false);
-			const dataTransfer = event.dataTransfer;
+	const ingestDroppedServerPayload = useCallback(
+		async (dataTransfer: DataTransfer | null) => {
 			if (!dataTransfer || !canIngestFromDataTransfer(dataTransfer)) {
 				notifyError(
 					t("notifications.importUnsupported.title", {
@@ -222,7 +227,18 @@ export function ServerListPage() {
 				);
 				return;
 			}
-			const payload = await extractPayloadFromDataTransfer(dataTransfer);
+			let payload;
+			try {
+				payload = await extractPayloadFromDataTransfer(dataTransfer);
+			} catch (error) {
+				notifyError(
+					t("notifications.importUnsupported.title", {
+						defaultValue: "Unsupported content",
+					}),
+					error instanceof Error ? error.message : String(error),
+				);
+				return;
+			}
 			if (!payload) {
 				notifyError(
 					t("notifications.importEmpty.title", {
@@ -241,6 +257,59 @@ export function ServerListPage() {
 			});
 		},
 		[t],
+	);
+
+	const handleAddDrop = useCallback(
+		async (event: React.DragEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			event.stopPropagation();
+			setAddDragActive(false);
+			await ingestDroppedServerPayload(event.dataTransfer);
+		},
+		[ingestDroppedServerPayload],
+	);
+
+	const handleEmptyAddDragEnter = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (!prepareServerDropTargetEvent(event)) return;
+			setEmptyAddDragActive(true);
+		},
+		[],
+	);
+
+	const handleEmptyAddDragOver = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (!prepareServerDropTargetEvent(event)) return;
+			if (event.dataTransfer) {
+				event.dataTransfer.dropEffect = "copy";
+			}
+			setEmptyAddDragActive(true);
+		},
+		[],
+	);
+
+	const handleEmptyAddDragLeave = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if (isDragLeaveInsideCurrentTarget(event)) return;
+			setEmptyAddDragActive(false);
+		},
+		[],
+	);
+
+	const handleEmptyAddDragEnd = useCallback(() => {
+		setEmptyAddDragActive(false);
+	}, []);
+
+	const handleEmptyAddDrop = useCallback(
+		async (event: React.DragEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			event.stopPropagation();
+			setEmptyAddDragActive(false);
+			await ingestDroppedServerPayload(event.dataTransfer);
+		},
+		[ingestDroppedServerPayload],
 	);
 
 	const {
@@ -1060,33 +1129,55 @@ const getConnectionTypeTags = (server: ServerSummary) => {
 		<Button
 			onClick={() => setManualOpen(true)}
 			size="sm"
-			className="mt-4"
+			className={cn(
+				"mt-4 transition-colors",
+				isEmptyAddDragActive &&
+					"bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900",
+			)}
 		>
-			<Plus className="mr-2 h-4 w-4" />
-			{t("emptyState.action", {
-				defaultValue: "Add First Server",
-			})}
+			{isEmptyAddDragActive ? (
+				<Target className="mr-2 h-4 w-4" />
+			) : (
+				<Plus className="mr-2 h-4 w-4" />
+			)}
+			{isEmptyAddDragActive
+				? t("emptyState.importAction", {
+					defaultValue: "Import server",
+				})
+				: t("emptyState.action", {
+					defaultValue: "Add First Server",
+				})}
 		</Button>
 	) : undefined;
 
 	const emptyState = (
-		<Card>
-			<CardContent className="flex flex-col items-center justify-center p-6">
-				<EmptyState
-					icon={<Server className="h-12 w-12" />}
-					title={t("emptyState.title", { defaultValue: "No servers found" })}
-					description={t("emptyState.description", {
-						defaultValue: "Add your first MCP server to get started",
-					})}
-					action={emptyStateAction}
-				/>
-			</CardContent>
-		</Card>
+		<div className="flex h-full min-h-[20rem]">
+			<Card className="flex flex-1">
+				<CardContent
+					className="flex flex-1 flex-col items-center justify-center p-6"
+					onDragEnter={handleEmptyAddDragEnter}
+					onDragOver={handleEmptyAddDragOver}
+					onDragLeave={handleEmptyAddDragLeave}
+					onDrop={handleEmptyAddDrop}
+					onDragEnd={handleEmptyAddDragEnd}
+				>
+					<EmptyState
+						icon={<Server className="h-12 w-12" />}
+						title={t("emptyState.title", { defaultValue: "No servers found" })}
+						description={t("emptyState.description", {
+							defaultValue: "Add your first MCP server to get started",
+						})}
+						action={emptyStateAction}
+					/>
+				</CardContent>
+			</Card>
+		</div>
 	);
 
 	return (
 		<PageLayout
 			title={t("title", { defaultValue: "Servers" })}
+			className="flex h-full min-h-0 flex-col"
 			headerActions={
 				<PageToolbar<ToolbarServer>
 					config={toolbarConfig}
@@ -1142,17 +1233,20 @@ const getConnectionTypeTags = (server: ServerSummary) => {
 				</Card>
 			)}
 
-			<ListGridContainer
-				loading={isLoading}
-				loadingSkeleton={loadingSkeleton}
-				emptyState={
-					filteredAndSortedServers.length === 0 ? emptyState : undefined
-				}
-			>
-				{viewMode === "grid"
-					? filteredAndSortedServers.map(renderServerCard)
-					: filteredAndSortedServers.map(renderServerListItem)}
-			</ListGridContainer>
+			<div className="min-h-0 flex-1">
+				<ListGridContainer
+					loading={isLoading}
+					loadingSkeleton={loadingSkeleton}
+					className="h-full"
+					emptyState={
+						filteredAndSortedServers.length === 0 ? emptyState : undefined
+					}
+				>
+					{viewMode === "grid"
+						? filteredAndSortedServers.map(renderServerCard)
+						: filteredAndSortedServers.map(renderServerListItem)}
+				</ListGridContainer>
+			</div>
 
 			{/* Server install pipeline */}
 			<ServerInstallWizard

--- a/board/src/pages/servers/server-list-page.tsx
+++ b/board/src/pages/servers/server-list-page.tsx
@@ -45,6 +45,7 @@ import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import { useUrlSort, useUrlView } from "../../lib/hooks/use-url-state";
 import { notifyError, notifyInfo, notifySuccess } from "../../lib/notify";
 import { useAppStore } from "../../lib/store";
+import type { ServerIngestPayload } from "../../lib/install-normalizer";
 import { cn } from "../../lib/utils";
 import {
 	canIngestFromDataTransfer,
@@ -96,6 +97,7 @@ export function ServerListPage() {
 	const navigate = useNavigate();
 	const [debugInfo, setDebugInfo] = useState<string | null>(null);
 	const [manualOpen, setManualOpen] = useState(false);
+	const [pendingIngestPayload, setPendingIngestPayload] = useState<ServerIngestPayload | null>(null);
 	const manualRef = useRef<ServerInstallManualFormHandle | null>(null);
 	const [isAddDragActive, setAddDragActive] = useState(false);
 	const [isEmptyAddDragActive, setEmptyAddDragActive] = useState(false);
@@ -222,7 +224,7 @@ export function ServerListPage() {
 					}),
 					t("notifications.importUnsupported.message", {
 						defaultValue:
-							"Drop text, JSON snippets, URLs, or MCP bundles to use Uni-Import.",
+							"Drop text, JSON snippets, URLs, or config files to use Uni-Import.",
 					}),
 				);
 				return;
@@ -251,10 +253,8 @@ export function ServerListPage() {
 				);
 				return;
 			}
+			setPendingIngestPayload(payload);
 			setManualOpen(true);
-			requestAnimationFrame(() => {
-				manualRef.current?.ingest(payload);
-			});
 		},
 		[t],
 	);
@@ -1255,6 +1255,8 @@ const getConnectionTypeTags = (server: ServerSummary) => {
 				onClose={() => setManualOpen(false)}
 				mode="new"
 				pipeline={installPipeline}
+				pendingIngestPayload={pendingIngestPayload}
+				onPendingIngestConsumed={() => setPendingIngestPayload(null)}
 			/>
 
 			{/* Edit server drawer */}

--- a/board/src/pages/servers/server-list-page.tsx
+++ b/board/src/pages/servers/server-list-page.tsx
@@ -50,6 +50,7 @@ import { cn } from "../../lib/utils";
 import {
 	canIngestFromDataTransfer,
 	extractPayloadFromDataTransfer,
+	formatServerUniImportTransferError,
 } from "../../lib/server-uni-import-transfer";
 import type {
 	MCPServerConfig,
@@ -237,7 +238,7 @@ export function ServerListPage() {
 					t("notifications.importUnsupported.title", {
 						defaultValue: "Unsupported content",
 					}),
-					error instanceof Error ? error.message : String(error),
+					formatServerUniImportTransferError(error, t),
 				);
 				return;
 			}

--- a/board/src/pages/servers/server-list-page.tsx
+++ b/board/src/pages/servers/server-list-page.tsx
@@ -1238,7 +1238,7 @@ const getConnectionTypeTags = (server: ServerSummary) => {
 				<ListGridContainer
 					loading={isLoading}
 					loadingSkeleton={loadingSkeleton}
-					className="h-full"
+					emptyClassName="h-full"
 					emptyState={
 						filteredAndSortedServers.length === 0 ? emptyState : undefined
 					}


### PR DESCRIPTION
## Motivation

Dropping local files onto the Tauri WebView can navigate the main window away
from the dashboard and leave the desktop shell in a broken document-view state.
The import flow also needs a single transfer boundary so supported text/config
payloads are routed into uni-import while unsupported or oversized payloads are
rejected before expensive parsing.

## Scope of changes

- Add a desktop drop-navigation guard that blocks global file-drop navigation
  unless an explicit drop target has already handled the event.
- Route server-list empty state, the add-server button area, the install wizard,
  and uni-import drop zones through the shared server uni-import transfer layer.
- Reject `.mcpb` and `.dxt` bundles before reading them; bundle parsing remains
  intentionally disabled because it is not fully implemented.
- Enforce 1 MB transfer limits by UTF-8 byte length for dropped text, including
  non-ASCII payloads.
- Return typed transfer rejection errors and localize user-facing rejection
  messages in English, Chinese, and Japanese.
- Remove the unused `jszip` dependency from `board/package.json`, `bun.lock`,
  and `package-lock.json`.
- Keep the compact panel and main window aligned on the same target-zone-only
  file-drop policy.

## Linked context

- Design direction: file drops should only be accepted by explicit import target
  zones. The global desktop guard should prevent accidental WebView navigation
  everywhere else.
- Linked issue/project item: none.

## Compatibility and config impact

- No schema, database, API, or runtime configuration changes.
- `.mcpb` and `.dxt` import paths are explicitly paused rather than partially
  parsed.
- The `jszip` runtime dependency is removed from the board package because
  bundle parsing is disabled.

## Validation

- `bun test src/lib/desktop-drop-guard.test.ts src/lib/server-uni-import-transfer.test.ts src/lib/install-normalizer.test.ts`
  - 11 tests passed.
- `git diff --cached --check`
  - Passed before commit.
- `rg -n "jszip|MCP bundles|MCP 安装包|MCP バンドル" board/package.json board/bun.lock board/package-lock.json board/src`
  - No residual matches.
- `bun run lint`
  - Passed with 0 errors and existing warnings.
- `bun run build`
  - Passed with existing Browserslist/chunk-size warnings.

## Known risks and follow-up

- GitHub Actions `Desktop (macOS) / build (x64)` failed during Tauri-generated
  `bundle_dmg.sh` execution after board build, Rust build, signing, and app
  notarization had already succeeded. The same workflow run passed for
  `build (aarch64)`. Current evidence points to macOS DMG packaging/runner
  tooling rather than this PR's import/drop logic. Re-running the failed job is
  the next best discriminator.
