### PR TITLE
fix(oauth): harden custody lifecycle and surface readiness in server UI

### DIFF
--- a/backend/src/api/handlers/audit.rs
+++ b/backend/src/api/handlers/audit.rs
@@ -276,9 +276,11 @@ mod tests {
             client_service: None::<Arc<ClientConfigService>>,
             inspector_calls: Arc::new(InspectorCallRegistry::new()),
             inspector_sessions: Arc::new(InspectorSessionManager::new()),
-            oauth_manager: None,
+            oauth_manager: RwLock::new(None),
             secret_store: RwLock::new(None),
-            secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness("test_unavailable")),
+            secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness(
+                "test_unavailable",
+            )),
         })
     }
 

--- a/backend/src/api/handlers/client/handlers.rs
+++ b/backend/src/api/handlers/client/handlers.rs
@@ -2,10 +2,9 @@
 
 use super::backups::parse_policy_payload;
 use super::inspection::{
-    build_config_file_parse_inspect_data, build_parse_metadata, configured_server_entries_data,
-    ClientFileGuardRejection, derive_attachment_state, detect_mcpmate_in_client_config,
-    attachment_state_drift_reason, evaluate_client_attach_file_guard, evaluate_client_detach_file_guard,
-    inspect_client_config_lenient,
+    ClientFileGuardRejection, attachment_state_drift_reason, build_config_file_parse_inspect_data,
+    build_parse_metadata, configured_server_entries_data, derive_attachment_state, detect_mcpmate_in_client_config,
+    evaluate_client_attach_file_guard, evaluate_client_detach_file_guard, inspect_client_config_lenient,
     mark_configured_server_managed_status, parse_api_transports, parse_rule_from_api_data, transports_data_from_state,
 };
 use super::runtime::sync_bound_client_runtime_state;
@@ -283,11 +282,7 @@ pub async fn config_details(
         .as_ref()
         .map(|inspected| inspected.document.clone())
         .unwrap_or_else(|| match state.effective_config_file_parse() {
-            Ok(parse_rule) => parse_config_fallback(
-                content.as_deref(),
-                parse_rule.as_ref(),
-                state.config_path(),
-            ),
+            Ok(parse_rule) => parse_config_fallback(content.as_deref(), parse_rule.as_ref(), state.config_path()),
             Err(err) => {
                 warnings.push(format!("Persisted config parse metadata is invalid: {err}"));
                 degraded_reasons.push("config_file_parse_invalid".to_string());
@@ -613,11 +608,7 @@ async fn apply_client_config_request(
                     None
                 }
             };
-            parse_config_fallback(
-                Some(preview_content),
-                parse_rule.as_ref(),
-                state.config_path(),
-            )
+            parse_config_fallback(Some(preview_content), parse_rule.as_ref(), state.config_path())
         }
         None => Value::String(preview_content.to_string()),
     };
@@ -1040,10 +1031,13 @@ pub async fn client_detach(
 ) -> Result<Json<ClientDetachResp>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let existing_state = service.fetch_state_repairing_local_target(&request.identifier).await.map_err(|err| {
-        tracing::error!(client = %request.identifier, error = %err, "Failed to load client state before detach");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let existing_state = service
+        .fetch_state_repairing_local_target(&request.identifier)
+        .await
+        .map_err(|err| {
+            tracing::error!(client = %request.identifier, error = %err, "Failed to load client state before detach");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let Some(state) = existing_state.as_ref() else {
         return Err(StatusCode::NOT_FOUND);
@@ -1131,10 +1125,13 @@ pub async fn client_attach(
 ) -> Result<Json<ClientAttachResp>, StatusCode> {
     let service = get_client_service(&app_state)?;
 
-    let existing_state = service.fetch_state_repairing_local_target(&request.identifier).await.map_err(|err| {
-        tracing::error!(client = %request.identifier, error = %err, "Failed to load client state before attach");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let existing_state = service
+        .fetch_state_repairing_local_target(&request.identifier)
+        .await
+        .map_err(|err| {
+            tracing::error!(client = %request.identifier, error = %err, "Failed to load client state before attach");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let Some(state) = existing_state.as_ref() else {
         return Err(StatusCode::NOT_FOUND);
@@ -1451,9 +1448,7 @@ fn map_mode(mode: ClientConfigMode) -> ConfigMode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::handlers::client::inspection::{
-        ATTACH_OVERWRITE_WARNING, DETACH_NO_EFFECT_WARNING,
-    };
+    use crate::api::handlers::client::inspection::{ATTACH_OVERWRITE_WARNING, DETACH_NO_EFFECT_WARNING};
     use crate::api::models::client::{ClientConfigFileParseData, ClientFormatRuleData, ClientSettingsUpdateReq};
     use crate::api::routes::AppState;
     use crate::clients::models::{ClientConfigFileState, ClientRegistrationOrigin};
@@ -1616,9 +1611,11 @@ mod tests {
             client_service: Some(client_service.clone()),
             inspector_calls: Arc::new(InspectorCallRegistry::new()),
             inspector_sessions: Arc::new(InspectorSessionManager::new()),
-            oauth_manager: Some(Arc::new(crate::core::oauth::OAuthManager::new(db_pool.clone()))),
+            oauth_manager: RwLock::new(Some(Arc::new(crate::core::oauth::OAuthManager::new(db_pool.clone())))),
             secret_store: RwLock::new(None),
-            secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness("test_unavailable")),
+            secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness(
+                "test_unavailable",
+            )),
         });
 
         TestContext {
@@ -4094,9 +4091,7 @@ mod tests {
         assert!(attach_response.success);
         let data = attach_response.data.expect("attach data");
         assert!(
-            data.warnings
-                .iter()
-                .any(|warning| warning == ATTACH_OVERWRITE_WARNING),
+            data.warnings.iter().any(|warning| warning == ATTACH_OVERWRITE_WARNING),
             "expected overwrite warning, got {:?}",
             data.warnings
         );
@@ -4183,9 +4178,7 @@ mod tests {
         let data = detach_response.data.expect("detach data");
         assert!(!data.changed);
         assert!(
-            data.warnings
-                .iter()
-                .any(|warning| warning == DETACH_NO_EFFECT_WARNING),
+            data.warnings.iter().any(|warning| warning == DETACH_NO_EFFECT_WARNING),
             "expected no-effect warning, got {:?}",
             data.warnings
         );
@@ -4195,9 +4188,12 @@ mod tests {
     async fn client_detach_rejects_undetectable_config_file() {
         let context = create_test_context().await;
         let config_path = context._temp_dir.path().join("undetectable-detach.json");
-        tokio::fs::write(&config_path, r#"{"mcpServers":{"MCPMate":{"url":"http://127.0.0.1:8000/mcp"}}}"#)
-            .await
-            .expect("seed undetectable detach config");
+        tokio::fs::write(
+            &config_path,
+            r#"{"mcpServers":{"MCPMate":{"url":"http://127.0.0.1:8000/mcp"}}}"#,
+        )
+        .await
+        .expect("seed undetectable detach config");
 
         context
             .client_service
@@ -4303,5 +4299,4 @@ mod tests {
             details.degraded_reasons
         );
     }
-
 }

--- a/backend/src/api/handlers/onboarding.rs
+++ b/backend/src/api/handlers/onboarding.rs
@@ -480,9 +480,11 @@ mod tests {
             client_service: Some(client_service),
             inspector_calls: Arc::new(InspectorCallRegistry::new()),
             inspector_sessions: Arc::new(InspectorSessionManager::new()),
-            oauth_manager: Some(Arc::new(crate::core::oauth::OAuthManager::new(db_pool.clone()))),
+            oauth_manager: RwLock::new(Some(Arc::new(crate::core::oauth::OAuthManager::new(db_pool.clone())))),
             secret_store: RwLock::new(None),
-            secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness("test_unavailable")),
+            secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness(
+                "test_unavailable",
+            )),
         });
 
         TestContext {

--- a/backend/src/api/handlers/registry.rs
+++ b/backend/src/api/handlers/registry.rs
@@ -1136,7 +1136,7 @@ mod tests {
             client_service: None::<Arc<ClientConfigService>>,
             inspector_calls: Arc::new(InspectorCallRegistry::new()),
             inspector_sessions: Arc::new(InspectorSessionManager::new()),
-            oauth_manager,
+            oauth_manager: RwLock::new(oauth_manager),
             secret_store: RwLock::new(None),
             secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness(
                 "test_unavailable",

--- a/backend/src/api/handlers/registry.rs
+++ b/backend/src/api/handlers/registry.rs
@@ -634,15 +634,13 @@ pub async fn refresh_managed_server_metadata(
     )
     .await;
 
-    let mut oauth_status = None;
-    if refreshed.server_type.is_http_transport() {
-        let manager = crate::core::oauth::manager::OAuthManager::new(db.pool.clone());
-        if let Ok(status) = manager.get_status(&server_id).await {
-            if status.configured {
-                oauth_status = Some(status.state);
-            }
-        }
-    }
+    let oauth_summary = crate::api::handlers::server::common::load_server_oauth_response_summary(
+        &db.pool,
+        &state,
+        &server_id,
+        refreshed.server_type.is_http_transport(),
+    )
+    .await?;
 
     Ok(Json(ServerDetailsResp::success(ServerDetailsData {
         id: Some(server_id),
@@ -665,10 +663,10 @@ pub async fn refresh_managed_server_metadata(
         updated_at: refreshed.updated_at.map(|dt| dt.to_rfc3339()),
         instances: details.instances,
         auth_mode: None,
-        oauth_status,
-        oauth_custody_state: None,
-        oauth_requires_reconnect: None,
-        oauth_issue: None,
+        oauth_status: oauth_summary.oauth_status,
+        oauth_custody_state: oauth_summary.oauth_custody_state,
+        oauth_requires_reconnect: oauth_summary.oauth_requires_reconnect,
+        oauth_issue: oauth_summary.oauth_issue,
     })))
 }
 
@@ -694,7 +692,7 @@ mod tests {
         common::server::ServerType,
         config::{
             database::Database,
-            models::Server,
+            models::{Server, ServerOAuthConfig, ServerOAuthToken},
             profile::init::initialize_profile_tables,
             registry::init::initialize_registry_cache_table,
             server::{self, init::initialize_server_tables},
@@ -1002,12 +1000,60 @@ mod tests {
             .await
             .expect("seed registry cache");
 
-        let server_id = seed_managed_server(&context.pool, "official-filesystem").await;
+        let server_id = seed_managed_streamable_http_server(&context.pool, "official-filesystem").await;
+        server::upsert_server_oauth_config(
+            &context.pool,
+            &ServerOAuthConfig {
+                id: None,
+                server_id: server_id.clone(),
+                authorization_endpoint: "https://issuer.example.com/authorize".to_string(),
+                token_endpoint: "https://issuer.example.com/token".to_string(),
+                client_id: "client-registry-refresh".to_string(),
+                client_secret: None,
+                scopes: Some("read".to_string()),
+                redirect_uri: "http://127.0.0.1:5173/oauth/callback".to_string(),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("seed managed oauth config");
+        server::upsert_server_oauth_token(
+            &context.pool,
+            &ServerOAuthToken {
+                id: None,
+                server_id: server_id.clone(),
+                access_token: "token-registry-refresh".to_string(),
+                refresh_token: None,
+                token_type: "bearer".to_string(),
+                expires_at: Some((Utc::now() + chrono::Duration::hours(1)).to_rfc3339()),
+                scope: Some("read".to_string()),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("seed managed oauth token");
         let response = refresh_managed_server_metadata(State(context.state), Json(ServerIdReq { id: server_id }))
             .await
             .expect("refresh managed server metadata");
 
-        let meta = response.0.data.expect("response payload").meta.expect("server meta");
+        let data = response.0.data.expect("response payload");
+        assert!(matches!(
+            data.oauth_status,
+            Some(crate::core::oauth::OAuthConnectionState::Connected)
+        ));
+        assert!(matches!(
+            data.oauth_custody_state,
+            Some(crate::core::oauth::OAuthCustodyState::Unavailable)
+        ));
+        assert_eq!(data.oauth_requires_reconnect, Some(true));
+        assert_eq!(
+            data.oauth_issue.as_ref().map(|issue| issue.code.as_str()),
+            Some("secure_store_unavailable")
+        );
+
+        let meta = data.meta.expect("server meta");
         assert_eq!(meta.website_url.as_deref(), Some("https://example.com/filesystem"));
         assert_eq!(
             meta.repository.as_ref().and_then(|repo| repo.source.as_deref()),
@@ -1164,5 +1210,29 @@ mod tests {
         };
 
         server::upsert_server(pool, &server).await.expect("seed managed server")
+    }
+
+    async fn seed_managed_streamable_http_server(
+        pool: &sqlx::SqlitePool,
+        registry_server_id: &str,
+    ) -> String {
+        let server = Server {
+            id: None,
+            name: "managed-filesystem".to_string(),
+            server_type: ServerType::StreamableHttp,
+            command: None,
+            url: Some("https://example.com/mcp".to_string()),
+            registry_server_id: Some(registry_server_id.to_string()),
+            capabilities: None,
+            enabled: crate::common::status::EnabledStatus::Enabled,
+            unify_direct_exposure_eligible: false,
+            created_at: None,
+            updated_at: None,
+            pending_import: false,
+        };
+
+        server::upsert_server(pool, &server)
+            .await
+            .expect("seed managed streamable http server")
     }
 }

--- a/backend/src/api/handlers/secrets.rs
+++ b/backend/src/api/handlers/secrets.rs
@@ -403,6 +403,17 @@ async fn apply_secret_store_bootstrap(
         state.connection_pool.lock().await.set_secret_resolver(store);
     }
 
+    // Rebuild the OAuth manager with the new secret store so that
+    // OAuth handlers can resolve credentials after unlock.
+    if let Some(db) = state.database.as_ref() {
+        let new_manager = Arc::new(crate::core::oauth::OAuthManager::new_optional_store(
+            db.pool.clone(),
+            store_arc.clone(),
+        ));
+        let mut manager_guard = state.oauth_manager.write().await;
+        *manager_guard = Some(new_manager);
+    }
+
     {
         let mut store_guard = state.secret_store.write().await;
         *store_guard = store_arc;

--- a/backend/src/api/handlers/server/basic.rs
+++ b/backend/src/api/handlers/server/basic.rs
@@ -1190,6 +1190,39 @@ mod tests {
     async fn unify_direct_exposure_eligibility_round_trips_through_update_list_and_details() {
         let context = create_test_context().await;
         let server_id = seed_streamable_http_server(&context.db_pool, "eligibility-server").await;
+        crate::config::server::upsert_server_oauth_config(
+            &context.db_pool,
+            &ServerOAuthConfig {
+                id: None,
+                server_id: server_id.clone(),
+                authorization_endpoint: "https://issuer.example.com/authorize".to_string(),
+                token_endpoint: "https://issuer.example.com/token".to_string(),
+                client_id: "client-eligibility".to_string(),
+                client_secret: None,
+                scopes: Some("read".to_string()),
+                redirect_uri: "http://127.0.0.1:5173/oauth/callback".to_string(),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("upsert eligibility oauth config");
+        crate::config::server::upsert_server_oauth_token(
+            &context.db_pool,
+            &ServerOAuthToken {
+                id: None,
+                server_id: server_id.clone(),
+                access_token: "token-eligibility".to_string(),
+                refresh_token: None,
+                token_type: "bearer".to_string(),
+                expires_at: Some((Utc::now() + chrono::Duration::hours(1)).to_rfc3339()),
+                scope: Some("read".to_string()),
+                created_at: None,
+                updated_at: None,
+            },
+        )
+        .await
+        .expect("upsert eligibility oauth token");
 
         let detail_before = server_details_core(
             &ServerDetailsReq { id: server_id.clone() },
@@ -1231,6 +1264,19 @@ mod tests {
         assert!(updated.unify_direct_exposure_eligible);
         assert_eq!(updated.name, "eligibility-server");
         assert_eq!(updated.url.as_deref(), Some("https://example.com/eligibility-server"));
+        assert!(matches!(
+            updated.oauth_status,
+            Some(crate::core::oauth::OAuthConnectionState::Connected)
+        ));
+        assert!(matches!(
+            updated.oauth_custody_state,
+            Some(crate::core::oauth::OAuthCustodyState::Unavailable)
+        ));
+        assert_eq!(updated.oauth_requires_reconnect, Some(true));
+        assert_eq!(
+            updated.oauth_issue.as_ref().map(|issue| issue.code.as_str()),
+            Some("secure_store_unavailable")
+        );
 
         let list_response = server_list_core(
             &ServerListReq {

--- a/backend/src/api/handlers/server/basic.rs
+++ b/backend/src/api/handlers/server/basic.rs
@@ -1317,7 +1317,7 @@ mod tests {
             client_service: None,
             inspector_calls: Arc::new(InspectorCallRegistry::new()),
             inspector_sessions: Arc::new(InspectorSessionManager::new()),
-            oauth_manager: Some(Arc::new(crate::core::oauth::OAuthManager::new(db_pool.clone()))),
+            oauth_manager: RwLock::new(Some(Arc::new(crate::core::oauth::OAuthManager::new(db_pool.clone())))),
             secret_store: RwLock::new(None),
             secret_store_readiness: RwLock::new(crate::api::routes::unavailable_secret_store_readiness(
                 "test_unavailable",

--- a/backend/src/api/handlers/server/common.rs
+++ b/backend/src/api/handlers/server/common.rs
@@ -17,6 +17,14 @@ use crate::{
 use axum::http::StatusCode;
 use tracing::{debug, warn};
 
+#[derive(Debug, Default)]
+pub(crate) struct ServerOAuthResponseSummary {
+    pub oauth_status: Option<crate::core::oauth::OAuthConnectionState>,
+    pub oauth_custody_state: Option<crate::core::oauth::OAuthCustodyState>,
+    pub oauth_requires_reconnect: Option<bool>,
+    pub oauth_issue: Option<crate::core::oauth::OAuthStatusIssue>,
+}
+
 pub(crate) fn parse_server_icons(raw: &str) -> Result<Option<Vec<ServerIcon>>, serde_json::Error> {
     if let Ok(list) = serde_json::from_str::<Vec<ServerIcon>>(raw) {
         return Ok((!list.is_empty()).then_some(list));
@@ -323,6 +331,34 @@ pub async fn get_complete_server_details(
     details.protocol_version = get_server_protocol_version(state, server_id).await;
 
     details
+}
+
+pub(crate) async fn load_server_oauth_response_summary(
+    pool: &Pool<Sqlite>,
+    state: &Arc<AppState>,
+    server_id: &str,
+    is_http_transport: bool,
+) -> Result<ServerOAuthResponseSummary, ApiError> {
+    if !is_http_transport {
+        return Ok(ServerOAuthResponseSummary::default());
+    }
+
+    let manager =
+        crate::core::oauth::OAuthManager::new_optional_store(pool.clone(), state.secret_store.read().await.clone());
+    let status = manager.get_status(server_id).await.map_err(|err| {
+        ApiError::InternalError(format!("Failed to load OAuth status for server '{server_id}': {err}"))
+    })?;
+
+    if !status.configured {
+        return Ok(ServerOAuthResponseSummary::default());
+    }
+
+    Ok(ServerOAuthResponseSummary {
+        oauth_status: Some(status.state),
+        oauth_custody_state: Some(status.custody_state),
+        oauth_requires_reconnect: Some(status.requires_reconnect),
+        oauth_issue: status.issue,
+    })
 }
 
 pub(crate) async fn reconcile_client_direct_exposure_after_server_constraint_change(

--- a/backend/src/api/handlers/server/crud.rs
+++ b/backend/src/api/handlers/server/crud.rs
@@ -390,6 +390,13 @@ pub async fn create_server(
 
     let details = common::get_complete_server_details(&db.pool, &server_id, &server_name, &state).await;
     let effective_enabled = details.globally_enabled && details.enabled_in_profile;
+    let oauth_summary = common::load_server_oauth_response_summary(
+        &db.pool,
+        &state,
+        &server_id,
+        server_row.server_type.is_http_transport(),
+    )
+    .await?;
 
     let audit_server_id = server_id.clone();
     let response = Json(ServerDetailsResp::success(ServerDetailsData {
@@ -413,10 +420,10 @@ pub async fn create_server(
         updated_at,
         instances: details.instances,
         auth_mode: None,
-        oauth_status: None,
-        oauth_custody_state: None,
-        oauth_requires_reconnect: None,
-        oauth_issue: None,
+        oauth_status: oauth_summary.oauth_status,
+        oauth_custody_state: oauth_summary.oauth_custody_state,
+        oauth_requires_reconnect: oauth_summary.oauth_requires_reconnect,
+        oauth_issue: oauth_summary.oauth_issue,
     }));
 
     let mut data = Map::new();
@@ -627,6 +634,13 @@ pub async fn update_server(
 
     // Get server details via shared helper
     let details = common::get_complete_server_details(&db.pool, &server_id, &existing_server.name, &state).await;
+    let oauth_summary = common::load_server_oauth_response_summary(
+        &db.pool,
+        &state,
+        &server_id,
+        updated_server.server_type.is_http_transport(),
+    )
+    .await?;
 
     // Return success response
     let audit_server_id = server_id.clone();
@@ -652,10 +666,10 @@ pub async fn update_server(
         updated_at: updated_server.updated_at.map(|dt| dt.to_rfc3339()),
         instances: details.instances,
         auth_mode: None,
-        oauth_status: None,
-        oauth_custody_state: None,
-        oauth_requires_reconnect: None,
-        oauth_issue: None,
+        oauth_status: oauth_summary.oauth_status,
+        oauth_custody_state: oauth_summary.oauth_custody_state,
+        oauth_requires_reconnect: oauth_summary.oauth_requires_reconnect,
+        oauth_issue: oauth_summary.oauth_issue,
     }));
 
     let mut data = Map::new();

--- a/backend/src/api/handlers/server/oauth.rs
+++ b/backend/src/api/handlers/server/oauth.rs
@@ -9,8 +9,8 @@ use crate::api::{
 use crate::core::oauth::{OAuthConfigInput, OAuthPrepareInput};
 
 async fn get_oauth_manager(state: &Arc<AppState>) -> Result<crate::core::oauth::OAuthManager, ApiError> {
-    let manager = state
-        .oauth_manager
+    let guard = state.oauth_manager.read().await;
+    let manager = guard
         .as_ref()
         .ok_or_else(|| ApiError::InternalError("OAuth manager unavailable".to_string()))?;
     Ok((**manager).clone())

--- a/backend/src/api/handlers/server/preview.rs
+++ b/backend/src/api/handlers/server/preview.rs
@@ -279,7 +279,8 @@ mod tests {
         models::{ServerOAuthConfig, ServerOAuthToken},
         server::{init::initialize_server_tables, upsert_server_oauth_config, upsert_server_oauth_token},
     };
-    use crate::core::secrets::store::{SecretCreateInput, SecretKindInput, SecretOriginInput};
+    use crate::core::secrets::store::{SecretCreateInput, SecretKindInput};
+    use crate::test_helpers::oauth_secret_origin;
     use chrono::{Duration, Utc};
     use tempfile::TempDir;
     use wiremock::{
@@ -358,7 +359,11 @@ mod tests {
                 kind: SecretKindInput::OAuthAccessToken,
                 value: "access-old".to_string(),
                 label: Some(format!("OAuth access token for server-{server_id}")),
-                origin: Some(oauth_secret_origin(server_id, "access-token")),
+                origin: Some(oauth_secret_origin(
+                    server_id,
+                    &format!("server-{server_id}"),
+                    "access-token",
+                )),
             })
             .await
             .expect("store access token")
@@ -369,7 +374,11 @@ mod tests {
                 kind: SecretKindInput::OAuthRefreshToken,
                 value: "refresh-123".to_string(),
                 label: Some(format!("OAuth refresh token for server-{server_id}")),
-                origin: Some(oauth_secret_origin(server_id, "refresh-token")),
+                origin: Some(oauth_secret_origin(
+                    server_id,
+                    &format!("server-{server_id}"),
+                    "refresh-token",
+                )),
             })
             .await
             .expect("store refresh token")
@@ -390,22 +399,6 @@ mod tests {
         )
         .await
         .expect("store expired token");
-    }
-
-    fn oauth_secret_origin(
-        server_id: &str,
-        field_key: &str,
-    ) -> SecretOriginInput {
-        SecretOriginInput {
-            server_id: Some(server_id.to_string()),
-            server_name: Some(format!("server-{server_id}")),
-            server_kind: Some("streamable_http".to_string()),
-            source: Some("oauth".to_string()),
-            field_group: Some("oauth".to_string()),
-            field_key: Some(field_key.to_string()),
-            field_index: None,
-            field_path: Some(format!("oauth.{field_key}")),
-        }
     }
 
     #[tokio::test]

--- a/backend/src/api/routes/mod.rs
+++ b/backend/src/api/routes/mod.rs
@@ -62,7 +62,7 @@ pub struct AppState {
     pub inspector_calls: Arc<InspectorCallRegistry>,
     /// Inspector session manager
     pub inspector_sessions: Arc<InspectorSessionManager>,
-    pub oauth_manager: Option<Arc<crate::core::oauth::OAuthManager>>,
+    pub oauth_manager: RwLock<Option<Arc<crate::core::oauth::OAuthManager>>>,
     pub secret_store: RwLock<Option<Arc<crate::core::secrets::store::LocalSecretStore>>>,
     pub secret_store_readiness: RwLock<crate::core::secrets::store::SecretStoreReadiness>,
 }
@@ -158,7 +158,7 @@ async fn create_router_internal(
             client_service: None,
             inspector_calls: inspector_calls.clone(),
             inspector_sessions: inspector_sessions.clone(),
-            oauth_manager: None,
+            oauth_manager: RwLock::new(None),
             secret_store: RwLock::new(None),
             secret_store_readiness: RwLock::new(crate::core::secrets::store::SecretStoreReadiness::unavailable(
                 "not_initialized",
@@ -237,7 +237,7 @@ async fn create_router_internal(
         client_service,
         inspector_calls,
         inspector_sessions,
-        oauth_manager,
+        oauth_manager: RwLock::new(oauth_manager),
         secret_store: RwLock::new(secret_store),
         secret_store_readiness: RwLock::new(secret_store_readiness),
     });

--- a/backend/src/config/server/mod.rs
+++ b/backend/src/config/server/mod.rs
@@ -19,13 +19,13 @@ pub use args::{get_server_args, upsert_server_args};
 pub use crud::{delete_server, get_all_servers, get_server, get_server_by_id, upsert_server, upsert_server_tx};
 pub use env::{get_server_env, upsert_server_env};
 pub use headers::{
-    get_server_headers, merge_env_for_update, merge_headers_for_update, replace_server_headers,
-    upsert_server_headers,
+    get_server_headers, merge_env_for_update, merge_headers_for_update, replace_server_headers, upsert_server_headers,
 };
 pub use meta::{get_server_meta, upsert_server_meta};
 pub use oauth::{
-    delete_server_oauth_config, delete_server_oauth_token, get_effective_server_headers, get_server_oauth_config,
-    get_server_oauth_token, has_manual_authorization_header, upsert_server_oauth_config, upsert_server_oauth_token,
+    delete_server_oauth_config, delete_server_oauth_token, get_all_oauth_configs, get_all_oauth_tokens,
+    get_effective_server_headers, get_server_oauth_config, get_server_oauth_token, has_manual_authorization_header,
+    upsert_server_oauth_config, upsert_server_oauth_token,
 };
 
 pub use capabilities::{

--- a/backend/src/config/server/oauth.rs
+++ b/backend/src/config/server/oauth.rs
@@ -129,6 +129,24 @@ pub async fn delete_server_oauth_token(
     Ok(())
 }
 
+pub async fn get_all_oauth_configs(pool: &Pool<Sqlite>) -> Result<Vec<ServerOAuthConfig>> {
+    sqlx::query_as::<_, ServerOAuthConfig>(
+        "SELECT id, server_id, authorization_endpoint, token_endpoint, client_id, client_secret, scopes, redirect_uri, created_at, updated_at FROM server_oauth_config",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(Into::into)
+}
+
+pub async fn get_all_oauth_tokens(pool: &Pool<Sqlite>) -> Result<Vec<ServerOAuthToken>> {
+    sqlx::query_as::<_, ServerOAuthToken>(
+        "SELECT id, server_id, access_token, refresh_token, token_type, expires_at, scope, created_at, updated_at FROM server_oauth_tokens",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(Into::into)
+}
+
 pub fn has_manual_authorization_header(headers: &Option<HashMap<String, String>>) -> bool {
     headers
         .as_ref()

--- a/backend/src/core/foundation/loader.rs
+++ b/backend/src/core/foundation/loader.rs
@@ -243,7 +243,8 @@ mod tests {
         models::{ServerOAuthConfig, ServerOAuthToken},
         server::{upsert_server_oauth_config, upsert_server_oauth_token},
     };
-    use crate::core::secrets::store::{LocalSecretStore, SecretCreateInput, SecretKindInput, SecretOriginInput};
+    use crate::core::secrets::store::{LocalSecretStore, SecretCreateInput, SecretKindInput};
+    use crate::test_helpers::oauth_secret_origin;
     use chrono::{Duration, Utc};
     use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
     use tempfile::TempDir;
@@ -422,22 +423,5 @@ mod tests {
             headers.get("authorization").map(String::as_str),
             Some("Bearer access-new")
         );
-    }
-
-    fn oauth_secret_origin(
-        server_id: &str,
-        server_name: &str,
-        field_key: &str,
-    ) -> SecretOriginInput {
-        SecretOriginInput {
-            server_id: Some(server_id.to_string()),
-            server_name: Some(server_name.to_string()),
-            server_kind: Some("streamable_http".to_string()),
-            source: Some("oauth".to_string()),
-            field_group: Some("oauth".to_string()),
-            field_key: Some(field_key.to_string()),
-            field_index: None,
-            field_path: Some(format!("oauth.{field_key}")),
-        }
     }
 }

--- a/backend/src/core/oauth/batch.rs
+++ b/backend/src/core/oauth/batch.rs
@@ -75,7 +75,8 @@ pub async fn load_oauth_states(
                     true,
                     Some(OAuthStatusIssue {
                         code: "custody_classification_error".to_string(),
-                        message: format!("Custody check failed: {error}"),
+                        message: "OAuth custody could not be verified; reconnect OAuth to restore secure storage."
+                            .to_string(),
                     }),
                 )
             }

--- a/backend/src/core/oauth/batch.rs
+++ b/backend/src/core/oauth/batch.rs
@@ -57,12 +57,29 @@ pub async fn load_oauth_states(
                 OAuthConnectionState::Connected
             }
         };
-        let (custody_state, requires_reconnect, issue) = oauth_summary_custody(
+        let (custody_state, requires_reconnect, issue) = match oauth_summary_custody(
             secure_store_available,
             client_secret.as_deref(),
             access_token.as_deref(),
             refresh_token.as_deref(),
-        )?;
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::warn!(
+                    server_id = %server_id,
+                    error = %error,
+                    "Custody classification failed for server; defaulting to LegacyPlaintext"
+                );
+                (
+                    OAuthCustodyState::LegacyPlaintext,
+                    true,
+                    Some(OAuthStatusIssue {
+                        code: "custody_classification_error".to_string(),
+                        message: format!("Custody check failed: {error}"),
+                    }),
+                )
+            }
+        };
 
         map.insert(
             server_id,

--- a/backend/src/core/oauth/manager.rs
+++ b/backend/src/core/oauth/manager.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
 use crate::config::{
-    models::{ServerOAuthConfig, ServerOAuthToken},
+    models::{Server, ServerOAuthConfig, ServerOAuthToken},
     server,
 };
 use crate::core::secrets::store::{
@@ -59,6 +59,34 @@ struct DynamicClientRegistrationResponse {
     client_id: String,
     client_secret: Option<String>,
     scope: Option<String>,
+}
+
+/// Existing token fields carried forward during a token refresh.
+struct ExistingTokenContext {
+    id: Option<String>,
+    refresh_token: Option<String>,
+    token_type: String,
+    scope: Option<String>,
+}
+
+/// Server metadata needed when storing OAuth-owned secrets.
+struct OAuthServerContext {
+    id: String,
+    name: String,
+    kind: String,
+}
+
+impl OAuthServerContext {
+    fn from_server(
+        server_id: &str,
+        server: &Server,
+    ) -> Self {
+        Self {
+            id: server_id.to_string(),
+            name: server.name.clone(),
+            kind: server.server_type.to_string(),
+        }
+    }
 }
 
 const OAUTH_TOKEN_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -140,43 +168,33 @@ impl OAuthManager {
 
     async fn store_or_preserve_client_secret(
         &self,
-        server_id: &str,
-        server_name: &str,
-        server_kind: &str,
+        server: &OAuthServerContext,
         value: &str,
     ) -> Result<String> {
         let trimmed = value.trim();
         if let Some(reference) = parse_placeholder(trimmed)? {
-            let expected_alias = oauth_secret_alias(server_id, OAuthSecretSlot::ClientSecret);
+            let expected_alias = oauth_secret_alias(&server.id, OAuthSecretSlot::ClientSecret);
             if reference.alias() != expected_alias {
                 bail!("OAuth client secret placeholder must reference the server OAuth client secret alias");
             }
             return Ok(trimmed.to_string());
         }
-        self.store_oauth_secret(
-            server_id,
-            server_name,
-            server_kind,
-            OAuthSecretSlot::ClientSecret,
-            trimmed.to_string(),
-        )
-        .await
+        self.store_oauth_secret(server, OAuthSecretSlot::ClientSecret, trimmed.to_string())
+            .await
     }
 
     async fn store_oauth_secret(
         &self,
-        server_id: &str,
-        server_name: &str,
-        server_kind: &str,
+        server: &OAuthServerContext,
         slot: OAuthSecretSlot,
         value: String,
     ) -> Result<String> {
         let store = self.secret_store()?;
-        let alias = oauth_secret_alias(server_id, slot);
+        let alias = oauth_secret_alias(&server.id, slot);
         let origin = Some(SecretOriginInput {
-            server_id: Some(server_id.to_string()),
-            server_name: Some(server_name.to_string()),
-            server_kind: Some(server_kind.to_string()),
+            server_id: Some(server.id.clone()),
+            server_name: Some(server.name.clone()),
+            server_kind: Some(server.kind.clone()),
             source: Some("oauth".to_string()),
             field_group: Some("oauth".to_string()),
             field_key: Some(slot.key().to_string()),
@@ -191,7 +209,7 @@ impl OAuthManager {
                         alias: alias.clone(),
                         kind: Some(slot.kind()),
                         value: Some(value),
-                        label: Some(format!("{} for {}", slot.label(), server_name)),
+                        label: Some(format!("{} for {}", slot.label(), server.name)),
                         origin,
                     })
                     .await?
@@ -202,7 +220,7 @@ impl OAuthManager {
                         alias: alias.clone(),
                         kind: slot.kind(),
                         value,
-                        label: Some(format!("{} for {}", slot.label(), server_name)),
+                        label: Some(format!("{} for {}", slot.label(), server.name)),
                         origin,
                     })
                     .await?
@@ -213,7 +231,7 @@ impl OAuthManager {
         store
             .upsert_usage(SecretUsageUpsertInput {
                 alias,
-                server_id: server_id.to_string(),
+                server_id: server.id.clone(),
                 location: SecretUsageLocationInput::OAuthToken,
             })
             .await?;
@@ -372,17 +390,12 @@ impl OAuthManager {
             bail!("OAuth is only supported for HTTP-based MCP servers (sse or streamable_http)");
         }
 
+        let server_context = OAuthServerContext::from_server(server_id, &server_model);
         let existing = server::get_server_oauth_config(&self.pool, server_id).await?;
         let client_secret = match input.client_secret {
-            Some(secret) if !secret.trim().is_empty() => Some(
-                self.store_or_preserve_client_secret(
-                    server_id,
-                    &server_model.name,
-                    &server_model.server_type.to_string(),
-                    &secret,
-                )
-                .await?,
-            ),
+            Some(secret) if !secret.trim().is_empty() => {
+                Some(self.store_or_preserve_client_secret(&server_context, &secret).await?)
+            }
             _ => existing.as_ref().and_then(|item| item.client_secret.clone()),
         };
         let config = ServerOAuthConfig {
@@ -583,8 +596,10 @@ impl OAuthManager {
         }
 
         let token_response = self.request_token_response(&config.token_endpoint, &form).await?;
+        let server_context = OAuthServerContext::from_server(&pending.server_id, &server_model);
 
-        self.store_oauth_token(&pending.server_id, token_response).await?;
+        self.store_oauth_token_with_context(&server_context, token_response, None)
+            .await?;
 
         self.get_status(&pending.server_id).await
     }
@@ -600,6 +615,22 @@ impl OAuthManager {
 
         let mut effective = manual_headers.unwrap_or_default();
         if let Some(token) = server::get_server_oauth_token(&self.pool, server_id).await? {
+            // Skip OAuth token injection when the secret resolver is unavailable
+            // (e.g. locked passphrase store at startup). The server will start
+            // without the Bearer header; the user can unlock the store later and
+            // re-authorize to restore authenticated access.
+            if self.secret_resolver.is_none() {
+                tracing::warn!(
+                    server_id = %server_id,
+                    "Secure Store not available; skipping OAuth token injection for startup"
+                );
+                return if effective.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(effective))
+                };
+            }
+
             let token = if is_token_refreshable(&token) {
                 self.refresh_access_token(server_id).await?
             } else {
@@ -642,6 +673,7 @@ impl OAuthManager {
             bail!("OAuth is only supported for HTTP-based MCP servers (sse or streamable_http)");
         }
         let resource = oauth_resource_from_server(&server_model)?;
+        let server_context = OAuthServerContext::from_server(server_id, &server_model);
 
         let mut form = vec![
             ("grant_type", "refresh_token".to_string()),
@@ -658,59 +690,56 @@ impl OAuthManager {
             bail!("OAuth refresh response did not include a usable access_token");
         }
 
-        self.store_oauth_token_with_existing_refresh(
-            server_id,
-            token.id,
+        self.store_oauth_token_with_context(
+            &server_context,
             token_response,
-            token.refresh_token,
-            token.token_type,
-            token.scope,
+            Some(ExistingTokenContext {
+                id: token.id,
+                refresh_token: token.refresh_token,
+                token_type: token.token_type,
+                scope: token.scope,
+            }),
         )
         .await
     }
 
-    async fn store_oauth_token(
+    #[cfg(test)]
+    async fn store_oauth_token_for_server(
         &self,
         server_id: &str,
         token_response: OAuthTokenResponse,
-    ) -> Result<ServerOAuthToken> {
-        self.store_oauth_token_with_existing_refresh(server_id, None, token_response, None, "bearer".to_string(), None)
-            .await
-    }
-
-    async fn store_oauth_token_with_existing_refresh(
-        &self,
-        server_id: &str,
-        id: Option<String>,
-        token_response: OAuthTokenResponse,
-        existing_refresh_token: Option<String>,
-        existing_token_type: String,
-        existing_scope: Option<String>,
+        existing: Option<ExistingTokenContext>,
     ) -> Result<ServerOAuthToken> {
         let server_model = server::get_server_by_id(&self.pool, server_id)
             .await?
             .ok_or_else(|| anyhow!("Server '{}' not found", server_id))?;
+        let server_context = OAuthServerContext::from_server(server_id, &server_model);
+        self.store_oauth_token_with_context(&server_context, token_response, existing)
+            .await
+    }
+
+    async fn store_oauth_token_with_context(
+        &self,
+        server: &OAuthServerContext,
+        token_response: OAuthTokenResponse,
+        existing: Option<ExistingTokenContext>,
+    ) -> Result<ServerOAuthToken> {
         let access_token = self
-            .store_oauth_secret(
-                server_id,
-                &server_model.name,
-                &server_model.server_type.to_string(),
-                OAuthSecretSlot::AccessToken,
-                token_response.access_token,
-            )
+            .store_oauth_secret(server, OAuthSecretSlot::AccessToken, token_response.access_token)
             .await?;
+        let existing_id = existing.as_ref().and_then(|ctx| ctx.id.clone());
+        let existing_refresh_token = existing.as_ref().and_then(|ctx| ctx.refresh_token.clone());
+        let existing_token_type = existing
+            .as_ref()
+            .map(|ctx| ctx.token_type.clone())
+            .unwrap_or_else(|| "bearer".to_string());
+        let existing_scope = existing.as_ref().and_then(|ctx| ctx.scope.clone());
         let incoming_refresh_token = token_response.refresh_token.filter(|value| !value.trim().is_empty());
-        let should_delete_stale_refresh_token = id.is_none() && incoming_refresh_token.is_none();
+        let should_delete_stale_refresh_token = existing_id.is_none() && incoming_refresh_token.is_none();
         let refresh_token = match incoming_refresh_token {
             Some(refresh_token) => Some(
-                self.store_oauth_secret(
-                    server_id,
-                    &server_model.name,
-                    &server_model.server_type.to_string(),
-                    OAuthSecretSlot::RefreshToken,
-                    refresh_token,
-                )
-                .await?,
+                self.store_oauth_secret(server, OAuthSecretSlot::RefreshToken, refresh_token)
+                    .await?,
             ),
             None => existing_refresh_token,
         };
@@ -718,8 +747,8 @@ impl OAuthManager {
             .expires_in
             .map(|seconds| (Utc::now() + Duration::seconds(seconds)).to_rfc3339());
         let stored = ServerOAuthToken {
-            id,
-            server_id: server_id.to_string(),
+            id: existing_id,
+            server_id: server.id.clone(),
             access_token,
             refresh_token,
             token_type: token_response.token_type.unwrap_or(existing_token_type),
@@ -731,7 +760,7 @@ impl OAuthManager {
 
         server::upsert_server_oauth_token(&self.pool, &stored).await?;
         if should_delete_stale_refresh_token {
-            self.delete_oauth_secret_if_available(server_id, OAuthSecretSlot::RefreshToken)
+            self.delete_oauth_secret_if_available(&server.id, OAuthSecretSlot::RefreshToken)
                 .await?;
         }
         Ok(stored)
@@ -1516,7 +1545,7 @@ mod tests {
             .await
             .expect("save secure oauth config");
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_delete_oauth_secrets",
                 OAuthTokenResponse {
                     access_token: "access-123".to_string(),
@@ -1525,6 +1554,7 @@ mod tests {
                     expires_in: Some(3600),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store secure oauth token");
@@ -1545,7 +1575,7 @@ mod tests {
         insert_server(&manager.pool, "serv_drop_refresh").await;
 
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_drop_refresh",
                 OAuthTokenResponse {
                     access_token: "access-old".to_string(),
@@ -1554,6 +1584,7 @@ mod tests {
                     expires_in: Some(3600),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store initial token");
@@ -1563,7 +1594,7 @@ mod tests {
             .expect("refresh secret should exist");
 
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_drop_refresh",
                 OAuthTokenResponse {
                     access_token: "access-new".to_string(),
@@ -1572,6 +1603,7 @@ mod tests {
                     expires_in: Some(3600),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store replacement token without refresh");
@@ -1595,7 +1627,7 @@ mod tests {
         insert_server(&manager.pool, "serv_oauth_usage").await;
 
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_oauth_usage",
                 OAuthTokenResponse {
                     access_token: "access-123".to_string(),
@@ -1604,6 +1636,7 @@ mod tests {
                     expires_in: Some(3600),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store secure oauth token");
@@ -1626,7 +1659,7 @@ mod tests {
         let (manager, _store, _temp_dir) = setup_secure_manager().await;
         insert_server(&manager.pool, "serv_revoke_no_store").await;
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_revoke_no_store",
                 OAuthTokenResponse {
                     access_token: "access-123".to_string(),
@@ -1635,6 +1668,7 @@ mod tests {
                     expires_in: Some(3600),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store secure oauth token");
@@ -1686,7 +1720,7 @@ mod tests {
             .await
             .expect("save oauth config");
         let stored = manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_secure_refresh",
                 OAuthTokenResponse {
                     access_token: "access-old".to_string(),
@@ -1695,6 +1729,7 @@ mod tests {
                     expires_in: Some(-60),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store secure token");
@@ -1754,7 +1789,7 @@ mod tests {
             .await
             .expect("save oauth config");
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_refresh_error_redaction",
                 OAuthTokenResponse {
                     access_token: "access-old".to_string(),
@@ -1763,6 +1798,7 @@ mod tests {
                     expires_in: Some(-60),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store expired token");
@@ -1814,7 +1850,7 @@ mod tests {
             .await
             .expect("save oauth config");
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_status_refresh",
                 OAuthTokenResponse {
                     access_token: "access-old".to_string(),
@@ -1823,6 +1859,7 @@ mod tests {
                     expires_in: Some(-60),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store expired token");
@@ -1877,7 +1914,7 @@ mod tests {
             .await
             .expect("save oauth config");
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_refresh",
                 OAuthTokenResponse {
                     access_token: "access-old".to_string(),
@@ -1886,6 +1923,7 @@ mod tests {
                     expires_in: Some(-60),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store expired token");
@@ -1955,7 +1993,7 @@ mod tests {
             .await
             .expect("save oauth config");
         manager
-            .store_oauth_token(
+            .store_oauth_token_for_server(
                 "serv_refresh_blank",
                 OAuthTokenResponse {
                     access_token: "access-old".to_string(),
@@ -1964,6 +2002,7 @@ mod tests {
                     expires_in: Some(-60),
                     scope: Some("read write".to_string()),
                 },
+                None,
             )
             .await
             .expect("store expired token");

--- a/backend/src/core/secrets.rs
+++ b/backend/src/core/secrets.rs
@@ -4,7 +4,7 @@ use mcpmate_secrets::{
     SecretError, SecretResolver, UnavailableSecretResolver, extract_secret_references, resolve_placeholders,
 };
 
-use crate::{config::server, core::models::MCPServerConfig};
+use crate::core::models::MCPServerConfig;
 use store::{LocalSecretStore, SecretUsageLocationInput, SecretUsageUpsertInput, SecretUsageView};
 
 pub mod store;
@@ -264,8 +264,11 @@ async fn discover_active_secret_usages_filtered(
     pool: &sqlx::SqlitePool,
     alias_filter: Option<&str>,
 ) -> anyhow::Result<Vec<SecretUsageView>> {
-    let mut usages = discover_config_usages_filtered(pool, alias_filter).await?;
-    usages.extend(discover_oauth_usages_filtered(pool, alias_filter).await?);
+    use crate::config::server::get_all_servers;
+
+    let servers = get_all_servers(pool).await?;
+    let mut usages = discover_config_usages_with_servers(pool, &servers, alias_filter).await?;
+    usages.extend(discover_oauth_usages_with_servers(pool, &servers, alias_filter).await?);
     dedup_secret_usage_views(&mut usages);
     Ok(usages)
 }
@@ -277,12 +280,20 @@ async fn discover_config_usages_filtered(
     use crate::config::server::get_all_servers;
 
     let servers = get_all_servers(pool).await?;
+    discover_config_usages_with_servers(pool, &servers, alias_filter).await
+}
+
+async fn discover_config_usages_with_servers(
+    pool: &sqlx::SqlitePool,
+    servers: &[crate::config::models::server::Server],
+    alias_filter: Option<&str>,
+) -> anyhow::Result<Vec<SecretUsageView>> {
     let mut usages = Vec::new();
     for server in servers {
         let Some(server_id) = server.id.clone() else {
             continue;
         };
-        let config = mcp_config_from_server(pool, &server_id, &server).await?;
+        let config = mcp_config_from_server(pool, &server_id, server).await?;
         for entry in collect_secret_usages(&server_id, &config)? {
             if alias_filter.is_some_and(|alias| entry.alias != alias) {
                 continue;
@@ -293,29 +304,37 @@ async fn discover_config_usages_filtered(
     Ok(usages)
 }
 
-async fn discover_oauth_usages_filtered(
+async fn discover_oauth_usages_with_servers(
     pool: &sqlx::SqlitePool,
+    servers: &[crate::config::models::server::Server],
     alias_filter: Option<&str>,
 ) -> anyhow::Result<Vec<SecretUsageView>> {
-    use crate::config::server::get_all_servers;
+    use crate::config::server::{get_all_oauth_configs, get_all_oauth_tokens};
 
-    let servers = get_all_servers(pool).await?;
+    let oauth_configs = get_all_oauth_configs(pool).await?;
+    let oauth_tokens = get_all_oauth_tokens(pool).await?;
+
+    let config_by_server: std::collections::HashMap<String, _> =
+        oauth_configs.into_iter().map(|c| (c.server_id.clone(), c)).collect();
+    let token_by_server: std::collections::HashMap<String, _> =
+        oauth_tokens.into_iter().map(|t| (t.server_id.clone(), t)).collect();
+
     let mut usages = Vec::new();
     for server_model in servers {
-        let Some(server_id) = server_model.id else {
+        let Some(server_id) = server_model.id.as_deref() else {
             continue;
         };
 
-        if let Some(config) = server::get_server_oauth_config(pool, &server_id).await? {
+        if let Some(config) = config_by_server.get(server_id) {
             if let Some(client_secret) = config.client_secret.as_deref() {
-                push_oauth_usages_from_value(&mut usages, alias_filter, &server_id, client_secret)?;
+                push_oauth_usages_from_value(&mut usages, alias_filter, server_id, client_secret)?;
             }
         }
 
-        if let Some(token) = server::get_server_oauth_token(pool, &server_id).await? {
-            push_oauth_usages_from_value(&mut usages, alias_filter, &server_id, &token.access_token)?;
+        if let Some(token) = token_by_server.get(server_id) {
+            push_oauth_usages_from_value(&mut usages, alias_filter, server_id, &token.access_token)?;
             if let Some(refresh_token) = token.refresh_token.as_deref() {
-                push_oauth_usages_from_value(&mut usages, alias_filter, &server_id, refresh_token)?;
+                push_oauth_usages_from_value(&mut usages, alias_filter, server_id, refresh_token)?;
             }
         }
     }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -11,6 +11,9 @@ pub mod mcper;
 pub mod runtime;
 pub mod system;
 
+#[cfg(test)]
+pub mod test_helpers;
+
 // Re-export FFI types for easier access
 #[cfg(feature = "interop")]
 pub use interop::{MCPMateEngine, ServiceInfo, ServiceStatus, StartupProgress};

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -1,0 +1,19 @@
+use mcpmate_secrets::store::SecretOriginInput;
+
+/// Build a `SecretOriginInput` for an OAuth-managed secret slot.
+pub fn oauth_secret_origin(
+    server_id: &str,
+    server_name: &str,
+    field_key: &str,
+) -> SecretOriginInput {
+    SecretOriginInput {
+        server_id: Some(server_id.to_string()),
+        server_name: Some(server_name.to_string()),
+        server_kind: Some("streamable_http".to_string()),
+        source: Some("oauth".to_string()),
+        field_group: Some("oauth".to_string()),
+        field_key: Some(field_key.to_string()),
+        field_index: None,
+        field_path: Some(format!("oauth.{field_key}")),
+    }
+}

--- a/backend/tests/inspector_smoke.rs
+++ b/backend/tests/inspector_smoke.rs
@@ -81,9 +81,11 @@ fn build_test_state() -> Arc<AppState> {
         client_service: None,
         inspector_calls,
         inspector_sessions,
-        oauth_manager: None,
+        oauth_manager: RwLock::new(None),
         secret_store: RwLock::new(None),
-        secret_store_readiness: RwLock::new(mcpmate::api::routes::unavailable_secret_store_readiness("test_unavailable")),
+        secret_store_readiness: RwLock::new(mcpmate::api::routes::unavailable_secret_store_readiness(
+            "test_unavailable",
+        )),
     })
 }
 
@@ -128,9 +130,11 @@ async fn build_database_state(temp_dir: &TempDir) -> Arc<AppState> {
         client_service: None,
         inspector_calls,
         inspector_sessions: Arc::new(InspectorSessionManager::new()),
-        oauth_manager: None,
+        oauth_manager: RwLock::new(None),
         secret_store: RwLock::new(None),
-        secret_store_readiness: RwLock::new(mcpmate::api::routes::unavailable_secret_store_readiness("test_unavailable")),
+        secret_store_readiness: RwLock::new(mcpmate::api::routes::unavailable_secret_store_readiness(
+            "test_unavailable",
+        )),
     })
 }
 

--- a/backend/tests/secrets_store_api.rs
+++ b/backend/tests/secrets_store_api.rs
@@ -106,7 +106,7 @@ async fn build_test_context() -> (TempDir, Arc<AppState>, Arc<LocalSecretStore>)
         client_service: None,
         inspector_calls,
         inspector_sessions: Arc::new(InspectorSessionManager::new()),
-        oauth_manager: None,
+        oauth_manager: RwLock::new(None),
         secret_store: RwLock::new(Some(secret_store.clone())),
         secret_store_readiness: RwLock::new(mcpmate::core::secrets::store::SecretStoreReadiness::ready(
             secret_store.provider_metadata(),
@@ -166,7 +166,7 @@ async fn build_passphrase_test_context(master_password: &str) -> (TempDir, Arc<A
         client_service: None,
         inspector_calls,
         inspector_sessions: Arc::new(InspectorSessionManager::new()),
-        oauth_manager: None,
+        oauth_manager: RwLock::new(None),
         secret_store: RwLock::new(Some(secret_store.clone())),
         secret_store_readiness: RwLock::new(mcpmate::core::secrets::store::SecretStoreReadiness::ready(
             secret_store.provider_metadata(),
@@ -197,7 +197,7 @@ fn build_unavailable_secret_store_state(temp_dir: &TempDir) -> Arc<AppState> {
         client_service: None,
         inspector_calls: Arc::new(InspectorCallRegistry::new()),
         inspector_sessions: Arc::new(InspectorSessionManager::new()),
-        oauth_manager: None,
+        oauth_manager: RwLock::new(None),
         secret_store: RwLock::new(None),
         secret_store_readiness: RwLock::new(mcpmate::api::routes::unavailable_secret_store_readiness(
             "database_unavailable",
@@ -823,7 +823,7 @@ async fn build_locked_passphrase_context(master_password: &str) -> (TempDir, Arc
         client_service: None,
         inspector_calls,
         inspector_sessions: Arc::new(InspectorSessionManager::new()),
-        oauth_manager: None,
+        oauth_manager: RwLock::new(None),
         secret_store: RwLock::new(bootstrap.store.map(Arc::new)),
         secret_store_readiness: RwLock::new(bootstrap_readiness),
     });
@@ -973,7 +973,7 @@ async fn provider_mode_persists_across_restart_simulation() {
         client_service: None,
         inspector_calls,
         inspector_sessions: Arc::new(InspectorSessionManager::new()),
-        oauth_manager: None,
+        oauth_manager: RwLock::new(None),
         secret_store: RwLock::new(Some(secret_store)),
         secret_store_readiness: RwLock::new(store_readiness),
     });

--- a/board/src/components/server-auth-badge.tsx
+++ b/board/src/components/server-auth-badge.tsx
@@ -116,9 +116,13 @@ export function ServerAuthBadge({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="inline-flex items-center">
+              <button
+                type="button"
+                aria-label={display.label}
+                className="inline-flex items-center border-0 bg-transparent p-0"
+              >
                 <AlertTriangle className="h-4 w-4 text-red-500 animate-pulse" />
-              </span>
+              </button>
             </TooltipTrigger>
             <TooltipContent>
               <p>{display.label}</p>

--- a/board/src/components/server-auth-badge.tsx
+++ b/board/src/components/server-auth-badge.tsx
@@ -1,121 +1,134 @@
 import { AlertTriangle, KeyRound, ShieldCheck } from "lucide-react";
+import type { ReactNode } from "react";
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
+import type { OAuthReadiness } from "../lib/oauth-readiness";
 import { Badge } from "./ui/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 interface ServerAuthBadgeProps {
-	authMode?: string | null;
-	oauthStatus?: string | null;
-	oauthCustodyState?: string | null;
-	oauthRequiresReconnect?: boolean | null;
-	oauthIssue?: {
-		code: string;
-		message: string;
-	} | null;
-	showLabel?: boolean;
+  authMode?: string | null;
+  oauthStatus?: string | null;
+  readiness?: OAuthReadiness | null;
+  showLabel?: boolean;
+}
+
+type ServerAuthBadgeDisplay =
+  | { kind: "none" }
+  | {
+      kind: "badge";
+      label: string;
+      className: string;
+      icon: ReactNode;
+    }
+  | {
+      kind: "warning";
+      label: string;
+    };
+
+function resolveServerAuthBadgeDisplay({
+  authMode,
+  oauthStatus,
+  readiness,
+  t,
+}: {
+  authMode?: string | null;
+  oauthStatus?: string | null;
+  readiness?: OAuthReadiness | null;
+  t: TFunction<"servers">;
+}): ServerAuthBadgeDisplay {
+  const normalizedMode = (authMode ?? "").toLowerCase();
+  const normalizedStatus = (oauthStatus ?? "").toLowerCase();
+
+  if (normalizedMode === "header") {
+    return {
+      kind: "badge",
+      label: t("entity.connectionTags.headerAuth", {
+        defaultValue: "Header auth",
+      }),
+      className:
+        "border-slate-200 text-slate-600 dark:border-slate-700 dark:text-slate-300",
+      icon: <KeyRound className="h-3 w-3" />,
+    };
+  }
+
+  if (normalizedMode !== "oauth") {
+    return { kind: "none" };
+  }
+
+  if (readiness?.notice) {
+    return {
+      kind: "warning",
+      label: t(readiness.notice.messageKey, {
+        defaultValue: readiness.notice.defaultMessage,
+      }),
+    };
+  }
+
+  if (normalizedStatus === "expired" || normalizedStatus === "disconnected") {
+    return {
+      kind: "warning",
+      label: t("entity.connectionTags.oauthWarning", {
+        defaultValue: "Authorization expired — reauthorize in Edit",
+      }),
+    };
+  }
+
+  return {
+    kind: "badge",
+    label: t("entity.connectionTags.oauth", {
+      defaultValue: "OAuth",
+    }),
+    className:
+      "border-emerald-200 text-emerald-700 dark:border-emerald-800 dark:text-emerald-300",
+    icon: <ShieldCheck className="h-3 w-3" />,
+  };
 }
 
 export function ServerAuthBadge({
-	authMode,
-	oauthStatus,
-	oauthCustodyState,
-	oauthRequiresReconnect,
-	oauthIssue,
-	showLabel = true,
+  authMode,
+  oauthStatus,
+  readiness,
+  showLabel = true,
 }: ServerAuthBadgeProps) {
-	const { t } = useTranslation("servers");
+  const { t } = useTranslation("servers");
+  const display = resolveServerAuthBadgeDisplay({
+    authMode,
+    oauthStatus,
+    readiness,
+    t,
+  });
 
-	const normalizedMode = (authMode ?? "").toLowerCase();
-	const normalizedStatus = (oauthStatus ?? "").toLowerCase();
-	const normalizedCustodyState = (oauthCustodyState ?? "").toLowerCase();
+  if (display.kind === "none") {
+    return null;
+  }
 
-	const content = (() => {
-		if (normalizedMode === "header") {
-			return {
-				kind: "badge" as const,
-				label: t("entity.connectionTags.headerAuth", {
-					defaultValue: "Header auth",
-				}),
-				className:
-					"border-slate-200 text-slate-600 dark:border-slate-700 dark:text-slate-300",
-				icon: <KeyRound className="h-3 w-3" />,
-			};
-		}
+  if (display.kind === "warning") {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex items-center">
+              <AlertTriangle className="h-4 w-4 text-red-500 animate-pulse" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{display.label}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
-		if (normalizedMode === "oauth") {
-			if (
-				normalizedCustodyState === "unavailable" ||
-				oauthIssue?.code === "secure_store_unavailable"
-			) {
-				return {
-					kind: "warning" as const,
-					label:
-						oauthIssue?.message ??
-						t("entity.connectionTags.oauthSecureStoreUnavailable", {
-							defaultValue: "Secure Store needs attention before OAuth can be used",
-						}),
-				};
-			}
-
-			if (normalizedCustodyState === "legacy_plaintext" || oauthRequiresReconnect) {
-				return {
-					kind: "warning" as const,
-					label:
-						oauthIssue?.message ??
-						t("entity.connectionTags.oauthReconnectRequired", {
-							defaultValue: "Reconnect OAuth to move credentials into Secure Store custody",
-						}),
-				};
-			}
-
-			if (normalizedStatus === "expired" || normalizedStatus === "disconnected") {
-				return {
-					kind: "warning" as const,
-					label: t("entity.connectionTags.oauthWarning", {
-						defaultValue: "Authorization expired — reauthorize in Edit",
-					}),
-				};
-			}
-
-			return {
-				kind: "badge" as const,
-				label: t("entity.connectionTags.oauth", {
-					defaultValue: "OAuth",
-				}),
-				className:
-					"border-emerald-200 text-emerald-700 dark:border-emerald-800 dark:text-emerald-300",
-				icon: <ShieldCheck className="h-3 w-3" />,
-			};
-		}
-
-		return null;
-	})();
-
-	if (!content) {
-		return null;
-	}
-
-	if (content.kind === "warning") {
-		return (
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<span className="inline-flex items-center">
-							<AlertTriangle className="h-4 w-4 text-red-500 animate-pulse" />
-						</span>
-					</TooltipTrigger>
-					<TooltipContent>
-						<p>{content.label}</p>
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
-		);
-	}
-
-	return (
-		<Badge variant="outline" className={`gap-1.5 ${content.className}`}>
-			{content.icon}
-			{showLabel ? content.label : null}
-		</Badge>
-	);
+  return (
+    <Badge variant="outline" className={`gap-1.5 ${display.className}`}>
+      {display.icon}
+      {showLabel ? display.label : null}
+    </Badge>
+  );
 }

--- a/board/src/components/server-auth-badge.tsx
+++ b/board/src/components/server-auth-badge.tsx
@@ -16,20 +16,21 @@ interface ServerAuthBadgeProps {
   oauthStatus?: string | null;
   readiness?: OAuthReadiness | null;
   showLabel?: boolean;
+  onAction?: () => void;
 }
 
 type ServerAuthBadgeDisplay =
   | { kind: "none" }
   | {
-      kind: "badge";
-      label: string;
-      className: string;
-      icon: ReactNode;
-    }
+    kind: "badge";
+    label: string;
+    className: string;
+    icon: ReactNode;
+  }
   | {
-      kind: "warning";
-      label: string;
-    };
+    kind: "warning";
+    label: string;
+  };
 
 function resolveServerAuthBadgeDisplay({
   authMode,
@@ -74,7 +75,7 @@ function resolveServerAuthBadgeDisplay({
     return {
       kind: "warning",
       label: t("entity.connectionTags.oauthWarning", {
-        defaultValue: "Authorization expired — reauthorize in Edit",
+        defaultValue: "Authorization expired — reauthorize required",
       }),
     };
   }
@@ -95,6 +96,7 @@ export function ServerAuthBadge({
   oauthStatus,
   readiness,
   showLabel = true,
+  onAction,
 }: ServerAuthBadgeProps) {
   const { t } = useTranslation("servers");
   const display = resolveServerAuthBadgeDisplay({
@@ -109,19 +111,40 @@ export function ServerAuthBadge({
   }
 
   if (display.kind === "warning") {
+    if (!showLabel) {
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex items-center">
+                <AlertTriangle className="h-4 w-4 text-red-500 animate-pulse" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{display.label}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    }
+
+    if (onAction) {
+      return (
+        <button
+          type="button"
+          onClick={onAction}
+          aria-label={display.label}
+          className="w-fit cursor-pointer text-left text-sm text-red-600 underline underline-offset-2 transition-colors hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+        >
+          {display.label}
+        </button>
+      );
+    }
+
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex items-center">
-              <AlertTriangle className="h-4 w-4 text-red-500 animate-pulse" />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>{display.label}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <span className="text-sm text-red-600 dark:text-red-400">
+        {display.label}
+      </span>
     );
   }
 

--- a/board/src/components/server-install/server-auth-section.tsx
+++ b/board/src/components/server-install/server-auth-section.tsx
@@ -15,7 +15,6 @@ import type {
 	OAuthConfigRequest,
 	OAuthStatus,
 } from "../../lib/types";
-import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Segment } from "../ui/segment";
@@ -51,14 +50,14 @@ function toFormState(status: OAuthStatus | null): OAuthConfigRequest {
 	};
 }
 
-function statusVariant(state: OAuthStatus["state"]): "secondary" | "outline" | "destructive" {
+function oauthStateTextClass(state: OAuthStatus["state"]): string {
 	switch (state) {
 		case "connected":
-			return "secondary";
+			return "text-emerald-700 dark:text-emerald-300";
 		case "expired":
-			return "destructive";
+			return "text-red-600 dark:text-red-400";
 		default:
-			return "outline";
+			return "text-slate-600 dark:text-slate-300";
 	}
 }
 
@@ -415,6 +414,16 @@ export function ServerAuthSection({
 	const secureOAuthCustodyLabel = t("manual.auth.oauth.secureStoreStored", {
 		defaultValue: "OAuth credentials are stored in Secure Store",
 	});
+	const oauthStatusLabel = (
+		<span
+			className={`inline-flex items-center gap-1.5 text-xs font-semibold ${oauthStateTextClass(status.state)}`}
+		>
+			{isSecureOAuthCustody ? (
+				<ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+			) : null}
+			{stateLabel}
+		</span>
+	);
 
 	const progressItems = [
 		{
@@ -525,13 +534,7 @@ export function ServerAuthSection({
 								<TooltipProvider delayDuration={200}>
 									<Tooltip>
 										<TooltipTrigger asChild>
-											<span className="inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
-												<ShieldCheck
-													className="h-3.5 w-3.5"
-													aria-hidden="true"
-												/>
-												{stateLabel}
-											</span>
+											{oauthStatusLabel}
 										</TooltipTrigger>
 										<TooltipContent side="top">
 											{secureOAuthCustodyLabel}
@@ -539,7 +542,7 @@ export function ServerAuthSection({
 									</Tooltip>
 								</TooltipProvider>
 							) : (
-								<Badge variant={statusVariant(status.state)}>{stateLabel}</Badge>
+								oauthStatusLabel
 							)}
 							<Button
 								type="button"

--- a/board/src/components/server-install/server-auth-section.tsx
+++ b/board/src/components/server-install/server-auth-section.tsx
@@ -485,7 +485,10 @@ export function ServerAuthSection({
 
 	const isBusy = connectMutation.isPending || revokeMutation.isPending;
 	const isConnectDisabled = isBusy || oauthReadiness.actionDisabled || (isDesktopEnvironment && !desktopListenerReady);
-	const isRevokeDisabled = isBusy || oauthReadiness.actionDisabled;
+	// Revoke is allowed even when the secure store is unavailable — the backend
+	// can delete plaintext OAuth tokens without the store and will return an
+	// error if the token actually requires store access.
+	const isRevokeDisabled = isBusy;
 
 	return (
 		<div className="space-y-4 pt-2 border-t mt-4">
@@ -580,7 +583,7 @@ export function ServerAuthSection({
 											? t("manual.auth.oauth.secureStoreUnavailable.title", { defaultValue: "Secure Store needs attention" })
 											: t("manual.auth.oauth.legacyReconnect.title", { defaultValue: "Reconnect OAuth to secure credentials" })}
 									</div>
-									<div>{oauthReadiness.notice.message}</div>
+									<div>{t(oauthReadiness.notice.messageKey, { defaultValue: oauthReadiness.notice.defaultMessage })}</div>
 								</div>
 							</div>
 						</div>

--- a/board/src/components/status-badge.tsx
+++ b/board/src/components/status-badge.tsx
@@ -11,6 +11,22 @@ interface StatusBadgeProps {
 	className?: string;
 	blinkOnError?: boolean;
 	isServerEnabled?: boolean;
+	appearance?: "badge" | "plain";
+}
+
+function getStatusTextClass(
+	variant: ReturnType<typeof getStatusVariant>,
+): string {
+	switch (variant) {
+		case "success":
+			return "text-emerald-700 dark:text-emerald-300";
+		case "warning":
+			return "text-amber-600 dark:text-amber-400";
+		case "destructive":
+			return "text-red-600 dark:text-red-400";
+		default:
+			return "text-slate-600 dark:text-slate-300";
+	}
 }
 
 function getStatusDotClass(variant: ReturnType<typeof getStatusVariant>): string {
@@ -36,6 +52,7 @@ export function StatusBadge({
 	className = "",
 	blinkOnError = true,
 	isServerEnabled = false,
+	appearance = "badge",
 }: StatusBadgeProps) {
 	const { t } = useTranslation();
 	let statusStr = status?.toString().toLowerCase() || "unknown";
@@ -121,6 +138,20 @@ export function StatusBadge({
 
 	if (statusLabel != null && statusLabel.trim().length > 0) {
 		displayText = statusLabel.trim();
+	}
+
+	if (appearance === "plain") {
+		if (!showLabel) {
+			return null;
+		}
+
+		return (
+			<span
+				className={`text-sm ${getStatusTextClass(variant)} ${className} ${shouldBlink ? "animate-pulse" : ""}`}
+			>
+				{displayText}
+			</span>
+		);
 	}
 
 	return (

--- a/board/src/lib/oauth-readiness.test.ts
+++ b/board/src/lib/oauth-readiness.test.ts
@@ -29,7 +29,7 @@ describe("resolveOAuthReadiness", () => {
 
 		expect(readiness.actionDisabled).toBe(true);
 		expect(readiness.notice?.kind).toBe("secure-store-unavailable");
-		expect(readiness.notice?.message).toContain("Secure Store is locked.");
+		expect(readiness.notice?.defaultMessage).toContain("Secure Store is locked.");
 	});
 
 	it("prompts reconnect for legacy plaintext OAuth credentials", () => {
@@ -52,7 +52,7 @@ describe("resolveOAuthReadiness", () => {
 
 		expect(readiness.actionDisabled).toBe(false);
 		expect(readiness.notice?.kind).toBe("legacy-reconnect-required");
-		expect(readiness.notice?.message).toContain("Reconnect OAuth");
+		expect(readiness.notice?.defaultMessage).toContain("Reconnect OAuth");
 	});
 
 	it("blocks when OAuth status reports unavailable custody without a store status", () => {
@@ -75,6 +75,6 @@ describe("resolveOAuthReadiness", () => {
 
 		expect(readiness.actionDisabled).toBe(true);
 		expect(readiness.notice?.kind).toBe("secure-store-unavailable");
-		expect(readiness.notice?.message).toContain("Secure Store is unavailable.");
+		expect(readiness.notice?.defaultMessage).toContain("Secure Store is unavailable.");
 	});
 });

--- a/board/src/lib/oauth-readiness.test.ts
+++ b/board/src/lib/oauth-readiness.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveOAuthReadiness } from "./oauth-readiness";
+import {
+	resolveOAuthReadiness,
+	resolveServerOAuthReadiness,
+} from "./oauth-readiness";
 import type { OAuthStatus, SecretStoreStatusData } from "./types";
 
 const readyStore: SecretStoreStatusData = {
@@ -71,6 +74,53 @@ describe("resolveOAuthReadiness", () => {
 		const readiness = resolveOAuthReadiness({
 			secretStoreStatus: undefined,
 			oauthStatus,
+		});
+
+		expect(readiness.actionDisabled).toBe(true);
+		expect(readiness.notice?.kind).toBe("secure-store-unavailable");
+		expect(readiness.notice?.defaultMessage).toContain("Secure Store is unavailable.");
+	});
+});
+
+describe("resolveServerOAuthReadiness", () => {
+	it("defaults requires_reconnect to false when omitted", () => {
+		const readiness = resolveServerOAuthReadiness({
+			id: "serv_default_reconnect",
+			oauth_status: "connected",
+			oauth_custody_state: "secure",
+		});
+
+		expect(readiness.actionDisabled).toBe(false);
+		expect(readiness.notice).toBeNull();
+	});
+
+	it("maps legacy plaintext custody into reconnect notice", () => {
+		const readiness = resolveServerOAuthReadiness({
+			id: "serv_legacy",
+			oauth_status: "connected",
+			oauth_custody_state: "legacy_plaintext",
+			oauth_requires_reconnect: true,
+			oauth_issue: {
+				code: "legacy_plaintext_oauth_credentials",
+				message: "Reconnect OAuth to store credentials securely.",
+			},
+		});
+
+		expect(readiness.actionDisabled).toBe(false);
+		expect(readiness.notice?.kind).toBe("legacy-reconnect-required");
+		expect(readiness.notice?.defaultMessage).toContain("Reconnect OAuth");
+	});
+
+	it("blocks actions when server summary reports unavailable custody", () => {
+		const readiness = resolveServerOAuthReadiness({
+			id: "serv_unavailable",
+			oauth_status: "connected",
+			oauth_custody_state: "unavailable",
+			oauth_requires_reconnect: true,
+			oauth_issue: {
+				code: "secure_store_unavailable",
+				message: "Secure Store is unavailable.",
+			},
 		});
 
 		expect(readiness.actionDisabled).toBe(true);

--- a/board/src/lib/oauth-readiness.ts
+++ b/board/src/lib/oauth-readiness.ts
@@ -6,7 +6,10 @@ export type OAuthReadinessNoticeKind =
 
 export interface OAuthReadinessNotice {
 	kind: OAuthReadinessNoticeKind;
-	message: string;
+	/** i18n translation key for the notice body */
+	messageKey: string;
+	/** English fallback shown until the key is translated */
+	defaultMessage: string;
 }
 
 export interface OAuthReadiness {
@@ -14,15 +17,23 @@ export interface OAuthReadiness {
 	notice: OAuthReadinessNotice | null;
 }
 
-const SECURE_STORE_UNAVAILABLE_MESSAGE =
-	"Secure Store is not ready. Unlock or initialize it before connecting OAuth.";
+export interface ServerOAuthReadinessSource {
+	id: string;
+	oauth_status?: OAuthStatus["state"] | null;
+	oauth_custody_state?: OAuthStatus["custody_state"] | null;
+	oauth_requires_reconnect?: boolean | null;
+	oauth_issue?: OAuthStatus["issue"] | null;
+}
 
 function secureStoreUnavailable(message?: string): OAuthReadiness {
 	return {
 		actionDisabled: true,
 		notice: {
 			kind: "secure-store-unavailable",
-			message: message ?? SECURE_STORE_UNAVAILABLE_MESSAGE,
+			messageKey: "manual.auth.oauth.secureStoreUnavailable.message",
+			defaultMessage:
+				message ??
+				"Secure Store is not ready. Unlock or initialize it before connecting OAuth.",
 		},
 	};
 }
@@ -50,7 +61,8 @@ export function resolveOAuthReadiness({
 			actionDisabled: false,
 			notice: {
 				kind: "legacy-reconnect-required",
-				message:
+				messageKey: "manual.auth.oauth.legacyReconnect.message",
+				defaultMessage:
 					oauthStatus.issue?.message ??
 					"Reconnect OAuth to move existing credentials into Secure Store custody.",
 			},
@@ -61,4 +73,19 @@ export function resolveOAuthReadiness({
 		actionDisabled: false,
 		notice: null,
 	};
+}
+
+export function resolveServerOAuthReadiness(
+	server: ServerOAuthReadinessSource,
+): OAuthReadiness {
+	return resolveOAuthReadiness({
+		oauthStatus: {
+			server_id: server.id,
+			configured: true,
+			state: server.oauth_status ?? null,
+			custody_state: server.oauth_custody_state ?? null,
+			requires_reconnect: server.oauth_requires_reconnect ?? false,
+			issue: server.oauth_issue ?? null,
+		},
+	});
 }

--- a/board/src/pages/servers/i18n/index.ts
+++ b/board/src/pages/servers/i18n/index.ts
@@ -126,6 +126,9 @@ export const serversTranslations = {
 				stdio: "STDIO",
 				http: "HTTP",
 				streamableHttp: "Streamable HTTP",
+				headerAuth: "Header auth",
+				oauth: "OAuth",
+				oauthWarning: "Authorization expired — reauthorize required",
 			},
 			iconAlt: {
 				named: "{{name}} icon",
@@ -175,6 +178,7 @@ export const serversTranslations = {
 					service: "Service",
 					runtime: "Runtime",
 					type: "Type",
+					auth: "Auth",
 					protocol: "Protocol",
 					version: "Version",
 					capabilities: "Capabilities",
@@ -639,6 +643,16 @@ export const serversTranslations = {
 					},
 					statusLabel: "OAuth status",
 					secureStoreStored: "OAuth credentials are stored in Secure Store",
+					secureStoreUnavailable: {
+						title: "Secure Store needs attention",
+						message:
+							"Secure Store is not ready. Unlock or initialize it before connecting OAuth.",
+					},
+					legacyReconnect: {
+						title: "Reconnect OAuth to secure credentials",
+						message:
+							"Reconnect OAuth to move existing credentials into Secure Store custody.",
+					},
 					manualOverride: {
 						title: "Manual Authorization header is active",
 						description:
@@ -1013,6 +1027,9 @@ export const serversTranslations = {
 				stdio: "STDIO",
 				http: "HTTP",
 				streamableHttp: "Streamable HTTP",
+				headerAuth: "请求头鉴权",
+				oauth: "OAuth",
+				oauthWarning: "授权已过期，请重新授权",
 			},
 			iconAlt: {
 				named: "{{name}} 图标",
@@ -1062,6 +1079,7 @@ export const serversTranslations = {
 					service: "服务",
 					runtime: "运行时",
 					type: "类型",
+					auth: "鉴权",
 					protocol: "协议",
 					version: "版本",
 					capabilities: "能力",
@@ -1513,6 +1531,14 @@ export const serversTranslations = {
 					},
 					statusLabel: "OAuth 状态",
 					secureStoreStored: "OAuth 凭据已存入安全存储",
+					secureStoreUnavailable: {
+						title: "安全存储需要处理",
+						message: "安全存储尚未就绪。请先解锁或初始化后再连接 OAuth。",
+					},
+					legacyReconnect: {
+						title: "重新连接 OAuth 以安全保存凭据",
+						message: "请重新连接 OAuth，将现有凭据迁移到安全存储托管。",
+					},
 					manualOverride: {
 						title: "手动 Authorization 请求头已生效",
 						description:
@@ -1861,6 +1887,9 @@ export const serversTranslations = {
 				stdio: "STDIO",
 				http: "HTTP",
 				streamableHttp: "Streamable HTTP",
+				headerAuth: "ヘッダー認証",
+				oauth: "OAuth",
+				oauthWarning: "認可の期限切れ — 再認可が必要です",
 			},
 			iconAlt: {
 				named: "{{name}} のアイコン",
@@ -1910,6 +1939,7 @@ export const serversTranslations = {
 					service: "サービス",
 					runtime: "ランタイム",
 					type: "タイプ",
+					auth: "認証",
 					protocol: "プロトコル",
 					version: "バージョン",
 					capabilities: "機能",
@@ -2377,6 +2407,16 @@ export const serversTranslations = {
 					},
 					statusLabel: "OAuth の状態",
 					secureStoreStored: "OAuth 認証情報は Secure Store に保存されています",
+					secureStoreUnavailable: {
+						title: "Secure Store の対応が必要です",
+						message:
+							"Secure Store の準備ができていません。OAuth を接続する前にロック解除または初期化してください。",
+					},
+					legacyReconnect: {
+						title: "認証情報を保護するため OAuth を再接続してください",
+						message:
+							"既存の認証情報を Secure Store の管理下に移すため、OAuth を再接続してください。",
+					},
 					manualOverride: {
 						title: "手動の Authorization ヘッダーが有効です",
 						description:

--- a/board/src/pages/servers/server-detail-page.tsx
+++ b/board/src/pages/servers/server-detail-page.tsx
@@ -13,7 +13,7 @@ import {
 	ShieldAlert,
 	Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import CapabilityList from "../../components/capability-list";
@@ -186,6 +186,35 @@ function makeLogId() {
 		return crypto.randomUUID();
 	}
 	return `log_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
+}
+
+const overviewMetadataGridClass =
+	"grid grid-cols-[auto_minmax(0,1fr)] gap-x-5 gap-y-2 text-sm leading-5";
+const overviewMetadataLabelClass =
+	"text-xs uppercase leading-5 text-slate-500";
+const overviewMetadataValueClass = "min-w-0 text-left text-sm leading-5";
+
+function OverviewMetadataRow({
+	label,
+	children,
+	multiline = false,
+}: {
+	label: ReactNode;
+	children: ReactNode;
+	multiline?: boolean;
+}) {
+	const rowAlignClass = multiline ? "self-start" : "self-center min-h-6";
+
+	return (
+		<div className="contents">
+			<span className={`${overviewMetadataLabelClass} ${rowAlignClass}`}>
+				{label}
+			</span>
+			<div className={`${overviewMetadataValueClass} ${rowAlignClass}`}>
+				{children}
+			</div>
+		</div>
+	);
 }
 
 export function ServerDetailPage() {
@@ -1036,6 +1065,9 @@ export function ServerDetailPage() {
 	}, [serverLogsQuery.data?.events, logFilter]);
 	const serverEnabled = Boolean(server?.enabled ?? server?.globally_enabled);
 	const runtimeStatus = server?.status ?? (serverEnabled ? "idle" : "disabled");
+	const authReadiness = server?.auth_mode
+		? resolveServerOAuthReadiness(server)
+		: null;
 	const overviewActionButtonClass =
 		"gap-2 rounded-none first:rounded-l-md last:rounded-r-md";
 	const showDefaultHeaders = useAppStore(
@@ -1262,145 +1294,137 @@ export function ServerDetailPage() {
 															fallback={serverDisplayName || "?"}
 															className="text-sm"
 														/>
-														<div className="grid grid-cols-[auto_1fr] gap-x-5 gap-y-2 text-sm">
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.service", {
+														<div className={`min-w-0 flex-1 ${overviewMetadataGridClass}`}>
+															<OverviewMetadataRow
+																label={t("detail.overview.labels.service", {
 																	defaultValue: "Service",
 																})}
-															</span>
-															<div className="flex flex-wrap items-center gap-2 justify-self-start">
-																<Badge
-																	variant={serverEnabled ? "secondary" : "outline"}
-																	className={`${serverEnabled ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200" : "text-slate-600 dark:text-slate-300"}`}
-																>
-																	{serverEnabled
-																		? t("detail.overview.status.enabled", {
-																			defaultValue: "Enabled",
-																		})
-																		: t("detail.overview.status.disabled", {
-																			defaultValue: "Disabled",
-																		})}
-																</Badge>
-																{server.unify_direct_exposure_eligible ? (
-																	<Badge
-																		variant="secondary"
-																		className="border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200"
+															>
+																<div className="flex flex-wrap items-center gap-2">
+																	<span
+																		className={
+																			serverEnabled
+																				? "text-emerald-700 dark:text-emerald-300"
+																				: "text-slate-600 dark:text-slate-300"
+																		}
 																	>
-																		{t("detail.overview.status.unifyEligible", {
-																			defaultValue: "Direct Exposure Eligible",
-																		})}
-																	</Badge>
-																) : null}
-															</div>
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.runtime", {
+																		{serverEnabled
+																			? t("detail.overview.status.enabled", {
+																				defaultValue: "Enabled",
+																			})
+																			: t("detail.overview.status.disabled", {
+																				defaultValue: "Disabled",
+																			})}
+																	</span>
+																	{server.unify_direct_exposure_eligible ? (
+																		<Badge
+																			variant="secondary"
+																			className="border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200"
+																		>
+																			{t("detail.overview.status.unifyEligible", {
+																				defaultValue: "Direct Exposure Eligible",
+																			})}
+																		</Badge>
+																	) : null}
+																</div>
+															</OverviewMetadataRow>
+															<OverviewMetadataRow
+																label={t("detail.overview.labels.runtime", {
 																	defaultValue: "Runtime",
 																})}
-															</span>
-															<StatusBadge
-																status={runtimeStatus}
-																instances={server.instances || []}
-																isServerEnabled={serverEnabled}
-																className="justify-self-start"
-															/>
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.type", {
+															>
+																<StatusBadge
+																	status={runtimeStatus}
+																	instances={server.instances || []}
+																	isServerEnabled={serverEnabled}
+																	appearance="plain"
+																/>
+															</OverviewMetadataRow>
+															<OverviewMetadataRow
+																label={t("detail.overview.labels.type", {
 																	defaultValue: "Type",
 																})}
-															</span>
-															<span className="font-mono text-sm leading-tight">
-																{server.server_type}
-															</span>
+															>
+																<span className="break-words font-mono">
+																	{server.server_type}
+																</span>
+															</OverviewMetadataRow>
 															{server.auth_mode ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.auth", {
-																			defaultValue: "Auth",
-																		})}
-																	</span>
-																	<div className="flex items-center gap-1.5 text-sm">
-																		<ServerAuthBadge
-																			authMode={server.auth_mode}
-																			oauthStatus={server.oauth_status}
-																			readiness={resolveServerOAuthReadiness(server)}
-																		/>
-																		<Button
-																			variant="ghost"
-																			size="sm"
-																			className="h-6 text-xs px-2"
-																			onClick={() => setIsEditOpen(true)}
-																		>
-																			{t("actions.edit", { defaultValue: "Edit" })}
-																		</Button>
-																	</div>
-																</>
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.auth", {
+																		defaultValue: "Auth",
+																	})}
+																>
+																	<ServerAuthBadge
+																		authMode={server.auth_mode}
+																		oauthStatus={server.oauth_status}
+																		readiness={authReadiness}
+																		onAction={() => setIsEditOpen(true)}
+																	/>
+																</OverviewMetadataRow>
 															) : null}
 															{protocolVersion ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.protocol", {
-																			defaultValue: "Protocol",
-																		})}
-																	</span>
-																	<span className="font-mono text-xs text-slate-600 dark:text-slate-300">
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.protocol", {
+																		defaultValue: "Protocol",
+																	})}
+																>
+																	<span className="font-mono text-slate-600 dark:text-slate-300">
 																		{protocolVersion}
 																	</span>
-																</>
+																</OverviewMetadataRow>
 															) : null}
 															{serverVersion ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.version", {
-																			defaultValue: "Version",
-																		})}
-																	</span>
-																	<span className="font-mono text-xs text-slate-600 dark:text-slate-300">
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.version", {
+																		defaultValue: "Version",
+																	})}
+																>
+																	<span className="font-mono text-slate-600 dark:text-slate-300">
 																		{serverVersion}
 																	</span>
-																</>
+																</OverviewMetadataRow>
 															) : null}
 															{capabilityOverviewText ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.capabilities", {
-																			defaultValue: "Capabilities",
-																		})}
-																	</span>
-																	<span className="text-sm text-slate-600 dark:text-slate-300">
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.capabilities", {
+																		defaultValue: "Capabilities",
+																	})}
+																	multiline
+																>
+																	<span className="text-slate-600 dark:text-slate-300">
 																		{capabilityOverviewText}
 																	</span>
-																</>
+																</OverviewMetadataRow>
 															) : null}
 															{serverDescription ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.description", {
-																			defaultValue: "Description",
-																		})}
-																	</span>
-																	<span className="text-sm text-slate-600 dark:text-slate-300">
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.description", {
+																		defaultValue: "Description",
+																	})}
+																	multiline
+																>
+																	<span className="text-slate-600 dark:text-slate-300">
 																		{serverDescription}
 																	</span>
-																</>
+																</OverviewMetadataRow>
 															) : null}
-
-															{/* Default HTTP Headers (redacted) */}
 															{showDefaultHeaders &&
-																redactedHeaders &&
-																Object.keys(redactedHeaders).length ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t(
-																			"detail.overview.labels.defaultHeaders",
-																			{
-																				defaultValue: "Default Headers",
-																			},
-																		)}
-																	</span>
+															redactedHeaders &&
+															Object.keys(redactedHeaders).length ? (
+																<OverviewMetadataRow
+																	label={t(
+																		"detail.overview.labels.defaultHeaders",
+																		{
+																			defaultValue: "Default Headers",
+																		},
+																	)}
+																	multiline
+																>
 																	<div className="grid grid-cols-1 gap-1">
 																		{Object.entries(redactedHeaders).map(
 																			([k, v]) => (
-																				<div key={k} className="text-sm">
+																				<div key={k}>
 																					<span className="font-mono text-slate-600 dark:text-slate-300">
 																						{k}
 																					</span>
@@ -1412,52 +1436,49 @@ export function ServerDetailPage() {
 																			),
 																		)}
 																	</div>
-																</>
+																</OverviewMetadataRow>
 															) : null}
 															{serverCategory ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.category", {
-																			defaultValue: "Category",
-																		})}
-																	</span>
-																	<span className="text-sm text-slate-600 dark:text-slate-300">
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.category", {
+																		defaultValue: "Category",
+																	})}
+																>
+																	<span className="text-slate-600 dark:text-slate-300">
 																		{serverCategory}
 																	</span>
-																</>
+																</OverviewMetadataRow>
 															) : null}
 															{serverScenario ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.scenario", {
-																			defaultValue: "Scenario",
-																		})}
-																	</span>
-																	<span className="text-sm text-slate-600 dark:text-slate-300">
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.scenario", {
+																		defaultValue: "Scenario",
+																	})}
+																>
+																	<span className="text-slate-600 dark:text-slate-300">
 																		{serverScenario}
 																	</span>
-																</>
+																</OverviewMetadataRow>
 															) : null}
 															{server.command ? (
-																<>
-																	<span className="text-xs uppercase text-slate-500">
-																		{t("detail.overview.labels.command", {
-																			defaultValue: "Command",
-																		})}
-																	</span>
-																	<span className="font-mono text-xs md:text-sm break-all">
+																<OverviewMetadataRow
+																	label={t("detail.overview.labels.command", {
+																		defaultValue: "Command",
+																	})}
+																	multiline
+																>
+																	<span className="break-all font-mono">
 																		{server.command}
 																	</span>
-																</>
+																</OverviewMetadataRow>
 															) : null}
-															<span className="text-xs uppercase text-slate-500">
-																{t("detail.overview.labels.repository", {
+															<OverviewMetadataRow
+																label={t("detail.overview.labels.repository", {
 																	defaultValue: "Repository",
 																})}
-															</span>
-															<span className="font-mono text-xs text-slate-500">
-																—
-															</span>
+															>
+																<span className="font-mono text-slate-500">—</span>
+															</OverviewMetadataRow>
 														</div>
 													</div>
 													<ButtonGroup className="ml-auto flex-shrink-0 flex-nowrap self-start">

--- a/board/src/pages/servers/server-detail-page.tsx
+++ b/board/src/pages/servers/server-detail-page.tsx
@@ -27,6 +27,7 @@ import InspectorDrawer, {
 	type InspectorLogEntry,
 } from "../../components/inspector-drawer";
 import { ServerAuthBadge } from "../../components/server-auth-badge";
+import { resolveServerOAuthReadiness } from "../../lib/oauth-readiness";
 import { ServerEditDrawer } from "../../components/server-edit-drawer";
 import { StatusBadge } from "../../components/status-badge";
 import {
@@ -1321,9 +1322,7 @@ export function ServerDetailPage() {
 																		<ServerAuthBadge
 																			authMode={server.auth_mode}
 																			oauthStatus={server.oauth_status}
-																			oauthCustodyState={server.oauth_custody_state}
-																			oauthRequiresReconnect={server.oauth_requires_reconnect}
-																			oauthIssue={server.oauth_issue}
+																			readiness={resolveServerOAuthReadiness(server)}
 																		/>
 																		<Button
 																			variant="ghost"

--- a/board/src/pages/servers/server-list-page.tsx
+++ b/board/src/pages/servers/server-list-page.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../components/page-layout";
 import { ServerEditDrawer } from "../../components/server-edit-drawer";
 import { ServerAuthBadge } from "../../components/server-auth-badge";
+import { resolveServerOAuthReadiness } from "../../lib/oauth-readiness";
 import { ServerInstallWizard, type ServerInstallManualFormHandle } from "../../components/server-install";
 import { StatsCards } from "../../components/stats-cards";
 import { StatusBadge } from "../../components/status-badge";
@@ -737,9 +738,7 @@ const getConnectionTypeTags = (server: ServerSummary) => {
 						<ServerAuthBadge
 							authMode={server.auth_mode}
 							oauthStatus={server.oauth_status}
-							oauthCustodyState={server.oauth_custody_state}
-							oauthRequiresReconnect={server.oauth_requires_reconnect}
-							oauthIssue={server.oauth_issue}
+							readiness={resolveServerOAuthReadiness(server)}
 						/>
 					</div>
 				}
@@ -875,9 +874,7 @@ const getConnectionTypeTags = (server: ServerSummary) => {
 						<ServerAuthBadge
 							authMode={server.auth_mode}
 							oauthStatus={server.oauth_status}
-							oauthCustodyState={server.oauth_custody_state}
-							oauthRequiresReconnect={server.oauth_requires_reconnect}
-							oauthIssue={server.oauth_issue}
+							readiness={resolveServerOAuthReadiness(server)}
 							showLabel={false}
 						/>
 					</div>


### PR DESCRIPTION
## Summary

- Harden OAuth Secure Store custody lifecycle in the backend: rebuild manager after unlock, batch custody discovery, fail-closed secret cleanup, and resilient startup when tokens exist without a resolver.
- Bind real OAuth readiness fields (`oauth_status`, `oauth_custody_state`, `oauth_requires_reconnect`, `oauth_issue`) into create/update/list/details/registry refresh responses via shared `load_server_oauth_response_summary`.
- Polish board server overview and readiness UX: plain-text status rows, clickable OAuth warning on detail page, compact icon+tooltip on list cards, shared readiness helper, and en/zh-CN/ja-JP copy.

## Scope notes

- `update_server` edit-path OAuth artifact cleanup on auth-shape changes is intentionally out of scope for this PR and tracked as a follow-up slice.
- Create/update/registry responses still return `auth_mode: None`; list/details continue to derive `auth_mode` from headers + OAuth configuration.

## Test plan

- [x] `cargo test server_list_derives_auth_mode unify_direct_exposure_eligibility --lib`
- [x] `cargo test` OAuth manager/batch unit tests (30 tests in oauth modules)
- [x] Registry refresh OAuth field mapping test (`test_refresh_managed_server_metadata_round_trips_registry_fields`)
- [x] `board`: `bun run lint` and `bun run build`
- [x] `board`: `oauth-readiness` vitest cases
- [x] Manual: server detail Overview — connected OAuth badge, expired warning text opens edit drawer, Idle/Enabled plain text alignment
- [x] Manual: server list/card — compact OAuth warning icon with tooltip when `showLabel={false}`
- [x] Manual: OAuth drawer — plain status text, secure-store notice, revoke while store unavailable