### PR TITLE
feat(secrets): Secure Store lifecycle cleanup UX

### DIFF
--- a/backend/src/api/handlers/secrets.rs
+++ b/backend/src/api/handlers/secrets.rs
@@ -76,13 +76,22 @@ pub async fn list_secrets(State(state): State<Arc<AppState>>) -> Result<Json<Sec
             .insert(binding_key);
     }
 
+    let all_indexed = store.list_all_usages().await.map_err(map_secret_store_error)?;
+    let mut indexed_by_alias: HashMap<String, Vec<SecretUsageView>> = HashMap::new();
+    for usage in all_indexed {
+        indexed_by_alias
+            .entry(usage.alias.clone())
+            .or_default()
+            .push(usage);
+    }
+
     let mut enriched = Vec::with_capacity(secrets.len());
     let mut server_config_cache: HashMap<String, Option<MCPServerConfig>> = HashMap::new();
     for metadata in secrets {
         let mut data = secret_metadata_data(metadata);
         data.used_by_count = active_count_by_alias.remove(&data.alias).unwrap_or(0);
         let active_binding_keys = active_binding_keys_by_alias.remove(&data.alias).unwrap_or_default();
-        let indexed = store.list_usages(&data.alias).await.map_err(map_secret_store_error)?;
+        let indexed = indexed_by_alias.remove(&data.alias).unwrap_or_default();
         let mut historical_usage_count = 0;
         for usage in indexed {
             let key = usage.location.binding_key(&usage.server_id);

--- a/backend/src/api/handlers/secrets.rs
+++ b/backend/src/api/handlers/secrets.rs
@@ -66,14 +66,34 @@ pub async fn list_secrets(State(state): State<Arc<AppState>>) -> Result<Json<Sec
         .await
         .map_err(crate::api::handlers::common::errors::map_anyhow_error)?;
     let mut active_count_by_alias: HashMap<String, u64> = HashMap::new();
+    let mut active_binding_keys_by_alias: HashMap<String, HashSet<String>> = HashMap::new();
     for usage in discovered {
-        *active_count_by_alias.entry(usage.alias).or_insert(0) += 1;
+        let binding_key = usage.location.binding_key(&usage.server_id);
+        *active_count_by_alias.entry(usage.alias.clone()).or_insert(0) += 1;
+        active_binding_keys_by_alias
+            .entry(usage.alias)
+            .or_default()
+            .insert(binding_key);
     }
 
     let mut enriched = Vec::with_capacity(secrets.len());
+    let mut server_config_cache: HashMap<String, Option<MCPServerConfig>> = HashMap::new();
     for metadata in secrets {
         let mut data = secret_metadata_data(metadata);
         data.used_by_count = active_count_by_alias.remove(&data.alias).unwrap_or(0);
+        let active_binding_keys = active_binding_keys_by_alias.remove(&data.alias).unwrap_or_default();
+        let indexed = store.list_usages(&data.alias).await.map_err(map_secret_store_error)?;
+        let mut historical_usage_count = 0;
+        for usage in indexed {
+            let key = usage.location.binding_key(&usage.server_id);
+            if active_binding_keys.contains(&key) {
+                continue;
+            }
+            if resolve_secret_usage_status(&db.pool, &usage, &mut server_config_cache).await? == "stale" {
+                historical_usage_count += 1;
+            }
+        }
+        data.historical_usage_count = historical_usage_count;
         enriched.push(data);
     }
     Ok(Json(SecretListResp::success(SecretListData { secrets: enriched })))
@@ -274,6 +294,7 @@ fn secret_metadata_data(metadata: SecretMetadataView) -> SecretMetadataData {
         provider_kind: metadata.provider_kind,
         version: metadata.version,
         used_by_count: metadata.used_by_count,
+        historical_usage_count: 0,
         created_at: metadata.created_at,
         updated_at: metadata.updated_at,
     }

--- a/backend/src/api/models/secrets.rs
+++ b/backend/src/api/models/secrets.rs
@@ -91,6 +91,7 @@ pub struct SecretMetadataData {
     pub provider_kind: String,
     pub version: u64,
     pub used_by_count: u64,
+    pub historical_usage_count: u64,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/tests/secrets_store_api.rs
+++ b/backend/tests/secrets_store_api.rs
@@ -1107,3 +1107,57 @@ async fn delete_secret_blocks_on_active_usage_but_allows_stale() {
         .expect("response");
     assert_eq!(resp.status(), StatusCode::OK);
 }
+
+#[tokio::test]
+#[serial_test::serial]
+async fn list_secrets_reports_historical_usage_count() {
+    let _key = EnvVarGuard::set(
+        "MCPMATE_SECRETS_LOCAL_KEY",
+        "MCPMate test key material for local store hist001",
+    );
+    let (_temp_dir, state, store) = build_test_context().await;
+    let app = axum::Router::new().merge(mcpmate::api::routes::secrets::routes(state.clone()));
+
+    store
+        .create_secret(SecretCreateInput {
+            alias: "server/ghost/token".to_string(),
+            kind: SecretKindInput::Token,
+            value: "secret-value".to_string(),
+            label: None,
+            origin: None,
+        })
+        .await
+        .expect("create secret");
+    store
+        .upsert_usage(SecretUsageUpsertInput {
+            alias: "server/ghost/token".to_string(),
+            server_id: "nonexistent-server".to_string(),
+            location: SecretUsageLocationInput::StdioEnv {
+                name: "TOKEN".to_string(),
+            },
+        })
+        .await
+        .expect("record stale usage");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/secrets/list")
+                .body(axum::body::Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_json_response(response).await;
+    let secret = body["data"]["secrets"]
+        .as_array()
+        .expect("secret list")
+        .iter()
+        .find(|item| item["alias"] == "server/ghost/token")
+        .expect("listed secret");
+
+    assert_eq!(secret["used_by_count"], 0);
+    assert_eq!(secret["historical_usage_count"], 1);
+}

--- a/board/src/components/secrets/secret-editor-drawer.tsx
+++ b/board/src/components/secrets/secret-editor-drawer.tsx
@@ -5,6 +5,7 @@ import type { SecretKind, SecretUsage } from "../../lib/types";
 import { writeClipboardText } from "../../lib/clipboard";
 import { notifyError, notifySuccess, stringifyError } from "../../lib/notify";
 import { isUserCreatableSecretKind } from "../../lib/secret-origin-hints";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import {
 	Tooltip,
@@ -43,6 +44,9 @@ const DRAWER_CLOSE_ANIMATION_MS = 500;
 
 /** Match Client/Server edit drawer form rows. */
 const SECRET_FORM_ROW_LABEL_CLASS = "w-20 shrink-0 text-right";
+
+/** Visual mask for write-only secrets in edit mode (not the stored value). */
+const STORED_SECRET_VALUE_MASK = "••••••••••••••••••••••••";
 
 function SecretFormRow({
 	label,
@@ -108,6 +112,7 @@ export function SecretEditorDrawer({
 	const [displayEditor, setDisplayEditor] = useState<SecretEditorState | null>(
 		null,
 	);
+	const [valueFieldFocused, setValueFieldFocused] = useState(false);
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const hadEditorRef = useRef(false);
 
@@ -115,6 +120,7 @@ export function SecretEditorDrawer({
 		if (editor) {
 			setDisplayEditor(editor);
 			setActiveTab(initialTab);
+			setValueFieldFocused(false);
 			if (!hadEditorRef.current) {
 				setOpen(true);
 			}
@@ -124,6 +130,7 @@ export function SecretEditorDrawer({
 
 		hadEditorRef.current = false;
 		setOpen(false);
+		setValueFieldFocused(false);
 	}, [editor, initialTab]);
 
 	useEffect(() => {
@@ -181,10 +188,24 @@ export function SecretEditorDrawer({
 		: "";
 	const isOAuthSecret = activeEditor ? !isUserCreatableSecretKind(activeEditor.kind) : false;
 	const isActiveOAuthSecret = isOAuthSecret && (usedByCount ?? 0) > 0;
+	const activeUsageCount =
+		usages.length > 0
+			? usages.filter((usage) => usage.status !== "stale").length
+			: (usedByCount ?? 0);
+	const historicalUsageCount = usages.filter(
+		(usage) => usage.status === "stale",
+	).length;
+	const canDeleteFromUsage = activeUsageCount === 0 && !isActiveOAuthSecret;
+	const showStoredValueMask =
+		activeEditor?.mode === "edit" &&
+		!isOAuthSecret &&
+		activeEditor.value === "" &&
+		!valueFieldFocused;
+
 	let valuePlaceholder = t("editor.placeholders.value", {
 		defaultValue: "Secret value",
 	});
-	if (activeEditor?.mode === "edit") {
+	if (activeEditor?.mode === "edit" && !showStoredValueMask) {
 		valuePlaceholder = t("editor.placeholders.keepValue", {
 			defaultValue: "Leave blank to keep existing value",
 		});
@@ -194,6 +215,9 @@ export function SecretEditorDrawer({
 			defaultValue: "Managed by OAuth; reconnect to update this value",
 		});
 	}
+	const valueInputDisplay = showStoredValueMask
+		? STORED_SECRET_VALUE_MASK
+		: activeEditor.value;
 	const copyPlaceholderLabel = t("editor.actions.copyPlaceholder", {
 		defaultValue: "Copy placeholder",
 	});
@@ -376,9 +400,25 @@ export function SecretEditorDrawer({
 								>
 									<Input
 										id={valueId}
-										type="password"
-										value={activeEditor.value}
+										type={showStoredValueMask ? "text" : "password"}
+										value={valueInputDisplay}
 										disabled={isOAuthSecret}
+										readOnly={showStoredValueMask}
+										className={
+											showStoredValueMask
+												? "cursor-text text-muted-foreground tracking-widest"
+												: undefined
+										}
+										aria-label={
+											showStoredValueMask
+												? t("editor.fields.storedValue", {
+													defaultValue:
+														"Stored secret value is hidden. Focus to replace it.",
+												})
+												: t("editor.fields.value", { defaultValue: "Value" })
+										}
+										onFocus={() => setValueFieldFocused(true)}
+										onBlur={() => setValueFieldFocused(false)}
 										onChange={(event) =>
 											onChange({ ...activeEditor, value: event.target.value })
 										}
@@ -386,7 +426,41 @@ export function SecretEditorDrawer({
 									/>
 								</SecretFormRow>
 							</TabsContent>
-							<TabsContent value="usage" className="pt-4">
+							<TabsContent value="usage" className="space-y-4 pt-4">
+								<div className="rounded-lg border bg-muted/30 p-3">
+									<div className="flex flex-wrap items-center gap-2">
+										<Badge variant={activeUsageCount > 0 ? "success" : "outline"}>
+											{t("usage.summary.active", {
+												defaultValue: "Active {{count}}",
+												count: activeUsageCount,
+											})}
+										</Badge>
+										<Badge
+											variant={historicalUsageCount > 0 ? "warning" : "outline"}
+										>
+											{t("usage.summary.historical", {
+												defaultValue: "Historical {{count}}",
+												count: historicalUsageCount,
+											})}
+										</Badge>
+									</div>
+									<p className="mt-2 text-xs text-muted-foreground">
+										{isActiveOAuthSecret
+											? t("usage.summary.oauthManaged", {
+												defaultValue:
+													"OAuth credentials are cleaned up by OAuth revoke or server deletion.",
+											})
+											: canDeleteFromUsage
+												? t("usage.summary.canDelete", {
+													defaultValue:
+														"No active runtime binding is using this secret.",
+												})
+												: t("usage.summary.blocked", {
+													defaultValue:
+														"Remove active bindings before deleting this secret.",
+												})}
+									</p>
+								</div>
 								<SecretUsageList
 									usages={usages}
 									isLoading={usagesLoading}
@@ -412,14 +486,19 @@ export function SecretEditorDrawer({
 										type="button"
 										variant="destructive"
 										className="gap-2"
-										disabled={isSaving || (usedByCount != null && usedByCount > 0)}
+										disabled={isSaving || !canDeleteFromUsage}
 										title={
-											usedByCount != null && usedByCount > 0
-												? t("editor.actions.deleteDisabledTooltip", {
-													defaultValue:
-														"Cannot delete: secret is actively used by {{count}} location(s)",
-													count: usedByCount,
-												})
+											!canDeleteFromUsage
+												? isActiveOAuthSecret
+													? t("editor.actions.deleteDisabledOAuthTooltip", {
+														defaultValue:
+															"OAuth-managed credentials are removed by OAuth revoke or server deletion.",
+													})
+													: t("editor.actions.deleteDisabledTooltip", {
+														defaultValue:
+															"Cannot delete: secret is actively used by {{count}} location(s)",
+														count: activeUsageCount,
+													})
 												: undefined
 										}
 										onClick={onDelete}

--- a/board/src/components/secrets/secret-usage-list.tsx
+++ b/board/src/components/secrets/secret-usage-list.tsx
@@ -165,9 +165,17 @@ export function SecretUsageList({
 
 	if (usages.length === 0) {
 		return (
-			<p className="py-8 text-center text-sm text-muted-foreground">
-				{t("usage.empty", { defaultValue: "No server usage recorded" })}
-			</p>
+			<div className="rounded-lg border border-dashed p-6 text-center">
+				<p className="text-sm font-medium">
+					{t("usage.empty", { defaultValue: "No server usage recorded" })}
+				</p>
+				<p className="mt-1 text-xs text-muted-foreground">
+					{t("usage.emptyDescription", {
+						defaultValue:
+							"This secret has no active or historical server binding.",
+					})}
+				</p>
+			</div>
 		);
 	}
 

--- a/board/src/components/server-install/inline-secure-string-field.tsx
+++ b/board/src/components/server-install/inline-secure-string-field.tsx
@@ -11,6 +11,7 @@ import {
 	type KeyboardEvent,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 import {
 	appendInlineText,
 	backspaceInlineAtEnd,
@@ -103,6 +104,7 @@ export function InlineSecureStringField({
 	pairRemove,
 }: InlineSecureStringFieldProps) {
 	const { t } = useTranslation("servers");
+	const navigate = useNavigate();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const insertTargetRef = useRef<InlineInsertTarget | null>(null);
 	const pickerInsertTargetRef = useRef<InlineInsertTarget | null>(null);
@@ -119,6 +121,14 @@ export function InlineSecureStringField({
 			defaultValue: "{{alias}}",
 			alias,
 		});
+
+	const handleInspectSecret = useCallback(
+		(alias: string) => {
+			const params = new URLSearchParams({ secret: alias, tab: "usage" });
+			navigate(`/secrets?${params.toString()}`);
+		},
+		[navigate],
+	);
 
 	const syncInsertTarget = useCallback(
 		(segmentIndex: number, input: HTMLInputElement | null) => {
@@ -632,7 +642,21 @@ export function InlineSecureStringField({
 														<X className="h-2.5 w-2.5" strokeWidth={3} />
 													</button>
 												</span>
-												<span className="truncate">{aliasLabel}</span>
+												<button
+													type="button"
+													className="min-w-0 truncate text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-emerald-700 dark:focus-visible:ring-emerald-200"
+													onClick={(event) => {
+														event.preventDefault();
+														event.stopPropagation();
+														handleInspectSecret(item.alias);
+													}}
+													aria-label={t("manual.secrets.inspect", {
+														defaultValue: "Open {{alias}} in Secure Store",
+														alias: item.alias,
+													})}
+												>
+													{aliasLabel}
+												</button>
 											</Badge>
 										</span>
 									</TooltipTrigger>

--- a/board/src/lib/secret-lifecycle.test.ts
+++ b/board/src/lib/secret-lifecycle.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { SecretMetadata } from "./types";
+import {
+  classifySecretLifecycle,
+  filterSecretsByLifecycle,
+  secretHasCleanupAvailable,
+} from "./secret-lifecycle";
+
+function secret(
+  alias: string,
+  overrides: Partial<SecretMetadata> = {},
+): SecretMetadata {
+  return {
+    alias,
+    placeholder: `[[secret:${alias}]]`,
+    kind: "token",
+    label: null,
+    origin: null,
+    provider_id: "local",
+    provider_kind: "local",
+    version: 1,
+    used_by_count: 0,
+    historical_usage_count: 0,
+    created_at: null,
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+describe("classifySecretLifecycle", () => {
+  it("marks active secrets before cleanup states", () => {
+    expect(
+      classifySecretLifecycle(
+        secret("active-token", {
+          used_by_count: 2,
+          historical_usage_count: 3,
+        }),
+      ).state,
+    ).toBe("active");
+  });
+
+  it("marks historical-only secrets as cleanup available", () => {
+    const lifecycle = classifySecretLifecycle(
+      secret("old-token", { historical_usage_count: 2 }),
+    );
+
+    expect(lifecycle.state).toBe("cleanup_available");
+    expect(secretHasCleanupAvailable(lifecycle)).toBe(true);
+  });
+
+  it("marks unreferenced user-created secrets as unused", () => {
+    expect(classifySecretLifecycle(secret("unused-token")).state).toBe(
+      "unused",
+    );
+  });
+
+  it("marks OAuth secrets as managed even without active usage", () => {
+    expect(
+      classifySecretLifecycle(
+        secret("oauth/server/access-token", {
+          kind: "oauth_access_token",
+          historical_usage_count: 1,
+        }),
+      ).state,
+    ).toBe("oauth_managed");
+  });
+});
+
+describe("filterSecretsByLifecycle", () => {
+  const secrets = [
+    secret("active", { used_by_count: 1 }),
+    secret("cleanup", { historical_usage_count: 1 }),
+    secret("unused"),
+    secret("oauth", { kind: "oauth_refresh_token" }),
+  ];
+
+  it("filters cleanup-available secrets", () => {
+    expect(
+      filterSecretsByLifecycle(secrets, "cleanup_available").map(
+        (item) => item.alias,
+      ),
+    ).toEqual(["cleanup"]);
+  });
+
+  it("keeps all secrets when filter is all", () => {
+    expect(filterSecretsByLifecycle(secrets, "all")).toHaveLength(4);
+  });
+});

--- a/board/src/lib/secret-lifecycle.ts
+++ b/board/src/lib/secret-lifecycle.ts
@@ -1,0 +1,83 @@
+import { OAUTH_SECRET_KINDS } from "./secret-origin-hints";
+import type { SecretMetadata } from "./types";
+
+export type SecretLifecycleState =
+  | "active"
+  | "cleanup_available"
+  | "unused"
+  | "oauth_managed";
+
+export type SecretLifecycleFilter = SecretLifecycleState | "all";
+
+export interface SecretLifecycle {
+  state: SecretLifecycleState;
+  activeCount: number;
+  historicalCount: number;
+}
+
+const OAUTH_SECRET_KIND_SET = new Set<string>(OAUTH_SECRET_KINDS);
+
+export function isOAuthManagedSecret(
+  secret: Pick<SecretMetadata, "kind">,
+): boolean {
+  return OAUTH_SECRET_KIND_SET.has(secret.kind);
+}
+
+export function classifySecretLifecycle(
+  secret: SecretMetadata,
+): SecretLifecycle {
+  const activeCount = secret.used_by_count;
+  const historicalCount = secret.historical_usage_count;
+
+  if (isOAuthManagedSecret(secret)) {
+    return {
+      state: "oauth_managed",
+      activeCount,
+      historicalCount,
+    };
+  }
+
+  if (activeCount > 0) {
+    return {
+      state: "active",
+      activeCount,
+      historicalCount,
+    };
+  }
+
+  if (historicalCount > 0) {
+    return {
+      state: "cleanup_available",
+      activeCount,
+      historicalCount,
+    };
+  }
+
+  return {
+    state: "unused",
+    activeCount,
+    historicalCount,
+  };
+}
+
+export function secretHasCleanupAvailable(
+  secretOrLifecycle: SecretMetadata | SecretLifecycle,
+): boolean {
+  const lifecycle =
+    "state" in secretOrLifecycle
+      ? secretOrLifecycle
+      : classifySecretLifecycle(secretOrLifecycle);
+  return (
+    lifecycle.state === "cleanup_available" || lifecycle.state === "unused"
+  );
+}
+
+export function filterSecretsByLifecycle(
+  secrets: SecretMetadata[],
+  filter: SecretLifecycleFilter,
+): SecretMetadata[] {
+  if (filter === "all") return secrets;
+  return secrets.filter(
+    (secret) => classifySecretLifecycle(secret).state === filter,
+  );
+}

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -618,6 +618,7 @@ export interface SecretMetadata {
   provider_kind: string;
   version: number;
   used_by_count: number;
+  historical_usage_count: number;
   created_at?: string | null;
   updated_at?: string | null;
 }

--- a/board/src/pages/secrets/i18n/index.ts
+++ b/board/src/pages/secrets/i18n/index.ts
@@ -39,12 +39,29 @@ export const secretsTranslations = {
 			local_file_root_key: "Local File",
 			local_encrypted_vault: "Development Vault",
 		},
+		lifecycle: {
+			state: {
+				all: "All lifecycle",
+				active: "Active",
+				cleanup_available: "Cleanup available",
+				unused: "Unused",
+				oauth_managed: "OAuth managed",
+			},
+			description: {
+				active: "Currently referenced by at least one server.",
+				cleanup_available:
+					"No active binding remains, but historical bindings exist.",
+				unused: "No active or historical server binding is recorded.",
+				oauth_managed: "Owned by OAuth and cleaned up with OAuth lifecycle actions.",
+			},
+		},
 		list: {
 			error: "Failed to load secrets. The secure store may be unavailable.",
 			retry: "Retry",
 			stats: {
 				provider: "Provider",
 				usage: "Usage",
+				history: "History",
 				version: "Version",
 			},
 			actions: {
@@ -59,6 +76,8 @@ export const secretsTranslations = {
 			description: "Store write-only values for server runtime placeholders.",
 			filteredDescription:
 				"Adjust the search or sort controls to find a secret.",
+			filteredLifecycleDescription:
+				"Adjust the lifecycle filter or search controls to find a secret.",
 			action: "Add First Secret",
 		},
 		editor: {
@@ -75,6 +94,8 @@ export const secretsTranslations = {
 				kind: "Kind",
 				label: "Label",
 				value: "Value",
+				storedValue:
+					"Stored secret value is hidden. Focus to replace it.",
 			},
 			kindLockedDescription: "Kind is set at creation and cannot be changed.",
 			oauthManagedDescription:
@@ -96,12 +117,27 @@ export const secretsTranslations = {
 					"Copy the [[secret:alias]] placeholder to paste into server env, headers, or args.",
 				create: "Create Record",
 				save: "Save Changes",
+				delete: "Delete",
+				deleteDisabledTooltip:
+					"Cannot delete: secret is actively used by {{count}} location(s)",
+				deleteDisabledOAuthTooltip:
+					"OAuth-managed credentials are removed by OAuth revoke or server deletion.",
 			},
 		},
 		usage: {
 			title: "Secret Usage",
 			loading: "Loading usages",
 			empty: "No server usage recorded",
+			emptyDescription:
+				"This secret has no active or historical server binding.",
+			summary: {
+				active: "Active {{count}}",
+				historical: "Historical {{count}}",
+				canDelete: "No active runtime binding is using this secret.",
+				blocked: "Remove active bindings before deleting this secret.",
+				oauthManaged:
+					"OAuth credentials are cleaned up by OAuth revoke or server deletion.",
+			},
 			sections: {
 				active: "Active bindings",
 				activeDescription:
@@ -134,6 +170,15 @@ export const secretsTranslations = {
 			title: "Delete secret?",
 			description:
 				"This removes the encrypted value only when no active usage is recorded.",
+			descriptionActive:
+				"This secret is still actively used. Remove active bindings before deleting it.",
+			descriptionHistorical:
+				"This removes the encrypted value. Historical usage metadata remains available without the secret value.",
+			descriptionUnused:
+				"This removes the encrypted value. No active or historical usage is recorded.",
+			descriptionOAuth:
+				"OAuth-managed credentials are normally removed by OAuth revoke or server deletion. Delete only orphaned OAuth records.",
+			usageSummary: "Active {{active}} · Historical {{historical}}",
 			actions: {
 				cancel: "Cancel",
 				confirm: "Delete",
@@ -179,9 +224,9 @@ export const secretsTranslations = {
 				title: "In Use",
 				description: "linked to servers",
 			},
-			usageRefs: {
-				title: "Usage References",
-				description: "runtime bindings",
+			cleanup: {
+				title: "Cleanup",
+				description: "ready to review",
 			},
 			store: {
 				title: "Secure Store",
@@ -235,12 +280,28 @@ export const secretsTranslations = {
 			local_file_root_key: "本地文件",
 			local_encrypted_vault: "开发加密库",
 		},
+		lifecycle: {
+			state: {
+				all: "全部生命周期",
+				active: "使用中",
+				cleanup_available: "可清理",
+				unused: "未使用",
+				oauth_managed: "OAuth 托管",
+			},
+			description: {
+				active: "当前至少被一个服务器引用。",
+				cleanup_available: "没有活跃绑定，但仍保留历史绑定记录。",
+				unused: "没有记录到活跃或历史服务器绑定。",
+				oauth_managed: "由 OAuth 拥有，并随 OAuth 生命周期动作清理。",
+			},
+		},
 		list: {
 			error: "加载密钥失败，安全存储可能不可用。",
 			retry: "重试",
 			stats: {
 				provider: "提供方",
 				usage: "使用",
+				history: "历史",
 				version: "版本",
 			},
 			actions: {
@@ -254,6 +315,8 @@ export const secretsTranslations = {
 			filteredTitle: "没有匹配的安全记录",
 			description: "为服务器运行时占位符保存写入后不可读的值。",
 			filteredDescription: "调整搜索或排序条件以查找安全记录。",
+			filteredLifecycleDescription:
+				"调整生命周期筛选或搜索条件以查找安全记录。",
 			action: "添加第一条安全记录",
 		},
 		editor: {
@@ -269,6 +332,7 @@ export const secretsTranslations = {
 				kind: "类型",
 				label: "标签",
 				value: "值",
+				storedValue: "已保存的密钥值已隐藏。聚焦后可替换。",
 			},
 			kindLockedDescription: "类型在创建时确定，之后不能修改。",
 			oauthManagedDescription:
@@ -289,12 +353,25 @@ export const secretsTranslations = {
 					"复制 [[secret:alias]] 占位符，以便粘贴到服务器的 env、header 或 args 配置中。",
 				create: "创建记录",
 				save: "保存更改",
+				delete: "删除",
+				deleteDisabledTooltip:
+					"无法删除：该安全记录仍被 {{count}} 处活跃使用引用",
+				deleteDisabledOAuthTooltip:
+					"OAuth 托管凭据请通过撤销 OAuth 或删除服务器来移除。",
 			},
 		},
 		usage: {
 			title: "安全记录使用情况",
 			loading: "正在加载使用情况",
 			empty: "暂无服务器使用记录",
+			emptyDescription: "此安全记录没有活跃或历史服务器绑定。",
+			summary: {
+				active: "活跃 {{count}}",
+				historical: "历史 {{count}}",
+				canDelete: "当前没有运行时绑定正在使用此安全记录。",
+				blocked: "删除此安全记录前，需要先移除活跃绑定。",
+				oauthManaged: "OAuth 凭据会随 OAuth 撤销或服务器删除自动清理。",
+			},
 			sections: {
 				active: "生效中的引用",
 				activeDescription: "当前在服务器运行时配置中仍引用此安全记录的位置。",
@@ -324,6 +401,13 @@ export const secretsTranslations = {
 		delete: {
 			title: "删除安全记录？",
 			description: "仅当没有活跃使用记录时，才会移除加密值。",
+			descriptionActive: "此安全记录仍在使用中。删除前请先移除活跃绑定。",
+			descriptionHistorical:
+				"这会移除加密值。历史使用元数据会保留，但不再包含密钥值。",
+			descriptionUnused: "这会移除加密值。当前没有活跃或历史使用记录。",
+			descriptionOAuth:
+				"OAuth 托管凭据通常会通过 OAuth 撤销或服务器删除自动移除。仅删除孤立的 OAuth 记录。",
+			usageSummary: "活跃 {{active}} · 历史 {{historical}}",
 			actions: {
 				cancel: "取消",
 				confirm: "删除",
@@ -367,9 +451,9 @@ export const secretsTranslations = {
 				title: "使用中",
 				description: "已关联服务器",
 			},
-			usageRefs: {
-				title: "使用引用",
-				description: "运行时绑定",
+			cleanup: {
+				title: "清理",
+				description: "可复核",
 			},
 			store: {
 				title: "安全存储",
@@ -423,12 +507,29 @@ export const secretsTranslations = {
 			local_file_root_key: "ローカルファイル",
 			local_encrypted_vault: "開発用ボルト",
 		},
+		lifecycle: {
+			state: {
+				all: "すべてのライフサイクル",
+				active: "使用中",
+				cleanup_available: "クリーンアップ可能",
+				unused: "未使用",
+				oauth_managed: "OAuth 管理",
+			},
+			description: {
+				active: "少なくとも 1 つのサーバーから現在参照されています。",
+				cleanup_available:
+					"有効なバインディングはありませんが、履歴バインディングが残っています。",
+				unused: "有効または履歴のサーバーバインディングは記録されていません。",
+				oauth_managed: "OAuth が所有し、OAuth ライフサイクル操作で削除されます。",
+			},
+		},
 		list: {
 			error: "シークレットの読み込みに失敗しました。セキュアストアが利用できない可能性があります。",
 			retry: "再試行",
 			stats: {
 				provider: "プロバイダー",
 				usage: "使用",
+				history: "履歴",
 				version: "バージョン",
 			},
 			actions: {
@@ -443,6 +544,8 @@ export const secretsTranslations = {
 			description:
 				"サーバー実行時プレースホルダー用の書き込み専用値を保存します。",
 			filteredDescription: "検索または並び替え条件を調整してください。",
+			filteredLifecycleDescription:
+				"ライフサイクルフィルターまたは検索条件を調整してください。",
 			action: "最初のシークレットを追加",
 		},
 		editor: {
@@ -458,6 +561,8 @@ export const secretsTranslations = {
 				kind: "種別",
 				label: "ラベル",
 				value: "値",
+				storedValue:
+					"保存済みのシークレット値は非表示です。フォーカスすると置き換えできます。",
 			},
 			kindLockedDescription: "種別は作成時に設定され、後から変更できません。",
 			oauthManagedDescription:
@@ -479,12 +584,27 @@ export const secretsTranslations = {
 					"[[secret:alias]] プレースホルダーをコピーし、サーバーの env、header、args に貼り付けます。",
 				create: "レコードを作成",
 				save: "変更を保存",
+				delete: "削除",
+				deleteDisabledTooltip:
+					"削除できません：このシークレットは {{count}} 件の有効な使用箇所で参照されています",
+				deleteDisabledOAuthTooltip:
+					"OAuth 管理の認証情報は、OAuth の取り消しまたはサーバー削除で削除されます。",
 			},
 		},
 		usage: {
 			title: "シークレットの使用状況",
 			loading: "使用状況を読み込み中",
 			empty: "サーバー使用記録はありません",
+			emptyDescription:
+				"このシークレットには有効または履歴のサーバーバインディングがありません。",
+			summary: {
+				active: "有効 {{count}}",
+				historical: "履歴 {{count}}",
+				canDelete: "このシークレットを使用中のランタイムバインディングはありません。",
+				blocked: "削除する前に有効なバインディングを削除してください。",
+				oauthManaged:
+					"OAuth 認証情報は OAuth の取り消しまたはサーバー削除で自動削除されます。",
+			},
 			sections: {
 				active: "有効な参照",
 				activeDescription: "現在サーバーのランタイム設定でこのシークレットを参照している場所。",
@@ -516,6 +636,15 @@ export const secretsTranslations = {
 			title: "シークレットを削除しますか？",
 			description:
 				"アクティブな使用記録がない場合のみ、暗号化された値を削除します。",
+			descriptionActive:
+				"このシークレットはまだ使用中です。削除する前に有効なバインディングを削除してください。",
+			descriptionHistorical:
+				"暗号化された値を削除します。履歴使用メタデータはシークレット値なしで残ります。",
+			descriptionUnused:
+				"暗号化された値を削除します。有効または履歴の使用記録はありません。",
+			descriptionOAuth:
+				"OAuth 管理の認証情報は通常、OAuth の取り消しまたはサーバー削除で削除されます。孤立した OAuth レコードのみ削除してください。",
+			usageSummary: "有効 {{active}} · 履歴 {{historical}}",
 			actions: {
 				cancel: "キャンセル",
 				confirm: "削除",
@@ -561,9 +690,9 @@ export const secretsTranslations = {
 				title: "使用中",
 				description: "サーバーにリンク済み",
 			},
-			usageRefs: {
-				title: "使用参照",
-				description: "ランタイムバインディング",
+			cleanup: {
+				title: "クリーンアップ",
+				description: "確認待ち",
 			},
 			store: {
 				title: "セキュアストア",

--- a/board/src/pages/secrets/i18n/index.ts
+++ b/board/src/pages/secrets/i18n/index.ts
@@ -41,7 +41,7 @@ export const secretsTranslations = {
 		},
 		lifecycle: {
 			state: {
-				all: "All lifecycle",
+				all: "All lifecycle states",
 				active: "Active",
 				cleanup_available: "Cleanup available",
 				unused: "Unused",
@@ -282,7 +282,7 @@ export const secretsTranslations = {
 		},
 		lifecycle: {
 			state: {
-				all: "全部生命周期",
+				all: "全部生命周期状态",
 				active: "使用中",
 				cleanup_available: "可清理",
 				unused: "未使用",
@@ -509,7 +509,7 @@ export const secretsTranslations = {
 		},
 		lifecycle: {
 			state: {
-				all: "すべてのライフサイクル",
+				all: "すべてのライフサイクル状態",
 				active: "使用中",
 				cleanup_available: "クリーンアップ可能",
 				unused: "未使用",

--- a/board/src/pages/secrets/secrets-page.tsx
+++ b/board/src/pages/secrets/secrets-page.tsx
@@ -35,6 +35,13 @@ import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { PageToolbar } from "../../components/ui/page-toolbar";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../../components/ui/select";
 import type {
 	Entity,
 	PageToolbarCallbacks,
@@ -54,6 +61,13 @@ import {
 } from "../../components/secrets";
 import { secretsApi, serversApi } from "../../lib/api";
 import { requiresEncryptionUnlock } from "../../lib/protection-password";
+import {
+	classifySecretLifecycle,
+	filterSecretsByLifecycle,
+	secretHasCleanupAvailable,
+	type SecretLifecycleFilter,
+	type SecretLifecycleState,
+} from "../../lib/secret-lifecycle";
 import { useUrlView } from "../../lib/hooks/use-url-state";
 import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import { notifyError, notifySuccess, stringifyError } from "../../lib/notify";
@@ -70,10 +84,17 @@ type SecretToolbarEntity = Entity & {
 	kind: string;
 	provider_kind: string;
 	used_by_count: number;
+	historical_usage_count: number;
 	version: number;
 };
 
-const defaultEditorState = defaultSecretEditorState;
+const SECRET_LIFECYCLE_FILTERS: SecretLifecycleFilter[] = [
+	"all",
+	"active",
+	"cleanup_available",
+	"unused",
+	"oauth_managed",
+];
 
 function getSecretDisplay(secret: SecretMetadata) {
 	const label = secret.label?.trim();
@@ -85,7 +106,7 @@ function getSecretDisplay(secret: SecretMetadata) {
 
 export function SecretsPage() {
 	usePageTranslations("secrets");
-	const { t } = useTranslation("secrets");
+	const { t, i18n } = useTranslation("secrets");
 	const queryClient = useQueryClient();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [editor, setEditor] = useState<SecretEditorState | null>(null);
@@ -155,8 +176,65 @@ export function SecretsPage() {
 	const providerLabel = (providerKind: string): string =>
 		t(`provider.${providerKind}`, { defaultValue: providerKind });
 
+	const lifecycleFilter = useMemo<SecretLifecycleFilter>(() => {
+		const raw = searchParams.get("lifecycle");
+		return SECRET_LIFECYCLE_FILTERS.includes(raw as SecretLifecycleFilter)
+			? (raw as SecretLifecycleFilter)
+			: "all";
+	}, [searchParams]);
+
+	const setLifecycleFilter = (value: SecretLifecycleFilter) => {
+		const next = new URLSearchParams(searchParams);
+		if (value === "all") {
+			next.delete("lifecycle");
+		} else {
+			next.set("lifecycle", value);
+		}
+		setSearchParams(next, { replace: true });
+	};
+
+	const lifecycleLabel = (state: SecretLifecycleState | "all"): string =>
+		t(`lifecycle.state.${state}`, { defaultValue: state.replaceAll("_", " ") });
+
+	const lifecycleDescription = (state: SecretLifecycleState): string =>
+		t(`lifecycle.description.${state}`, {
+			defaultValue: state.replaceAll("_", " "),
+		});
+
+	const lifecycleBadgeVariant = (
+		state: SecretLifecycleState,
+	): "secondary" | "success" | "warning" | "outline" | "info" => {
+		switch (state) {
+			case "active":
+				return "success";
+			case "cleanup_available":
+				return "warning";
+			case "oauth_managed":
+				return "info";
+			case "unused":
+				return "outline";
+		}
+	};
+
+	const renderLifecycleBadge = (secret: SecretMetadata) => {
+		const lifecycle = classifySecretLifecycle(secret);
+		return (
+			<Badge
+				variant={lifecycleBadgeVariant(lifecycle.state)}
+				title={lifecycleDescription(lifecycle.state)}
+			>
+				{lifecycleLabel(lifecycle.state)}
+			</Badge>
+		);
+	};
+
+	const filteredSecrets = useMemo(
+		() => filterSecretsByLifecycle(secretsQuery.data ?? [], lifecycleFilter),
+		[secretsQuery.data, lifecycleFilter],
+	);
+
 	const secretsAsEntities = useMemo<SecretToolbarEntity[]>(() => {
-		const mapped = (secretsQuery.data ?? []).map((secret) => ({
+		const mapped = filteredSecrets.map((secret) => ({
 			id: secret.alias,
 			name: secret.alias,
 			description: secret.label ?? secret.placeholder,
@@ -164,11 +242,12 @@ export function SecretsPage() {
 			kind: secret.kind,
 			provider_kind: secret.provider_kind,
 			used_by_count: secret.used_by_count,
+			historical_usage_count: secret.historical_usage_count,
 			version: secret.version,
 		}));
 		mapped.sort((left, right) => left.alias.localeCompare(right.alias));
 		return mapped;
-	}, [secretsQuery.data]);
+	}, [filteredSecrets]);
 
 	const secretsByAlias = useMemo(
 		() =>
@@ -212,7 +291,7 @@ export function SecretsPage() {
 			setEditor(nextEditor);
 		} else {
 			setEditor({
-				...defaultEditorState(),
+				...defaultSecretEditorState(),
 				alias: suggestedFromUrl,
 			});
 		}
@@ -223,6 +302,28 @@ export function SecretsPage() {
 		stripOriginSearchParams(next);
 		setSearchParams(next, { replace: true });
 	}, [searchParams, secretsQuery.data, setSearchParams, t]);
+
+	useEffect(() => {
+		const alias = searchParams.get("secret")?.trim();
+		if (!alias || !secretsQuery.data) return;
+		const secret = secretsByAlias.get(alias);
+		if (!secret) return;
+
+		setEditorInitialTab(searchParams.get("tab") === "usage" ? "usage" : "general");
+		setEditor({
+			mode: "edit",
+			alias: secret.alias,
+			kind: (secret.kind as SecretKind) || "generic",
+			label: secret.label ?? "",
+			value: "",
+			origin: secret.origin ?? null,
+		});
+
+		const next = new URLSearchParams(searchParams);
+		next.delete("secret");
+		next.delete("tab");
+		setSearchParams(next, { replace: true });
+	}, [searchParams, secretsByAlias, secretsQuery.data, setSearchParams]);
 
 	const saveMutation = useMutation({
 		mutationFn: async (state: SecretEditorState) => {
@@ -286,7 +387,7 @@ export function SecretsPage() {
 
 	const openCreate = () => {
 		setEditorInitialTab("general");
-		setEditor(defaultEditorState());
+		setEditor(defaultSecretEditorState());
 	};
 	const openEdit = (secret: SecretMetadata, tab: "general" | "usage" = "general") => {
 		setEditorInitialTab(tab);
@@ -329,7 +430,7 @@ export function SecretsPage() {
 	const statsCards = useMemo((): StatCardData[] => {
 		const secrets = secretsQuery.data ?? [];
 		const inUseCount = secrets.filter((secret) => secret.used_by_count > 0).length;
-		const usageRefs = secrets.reduce((sum, secret) => sum + secret.used_by_count, 0);
+		const cleanupCount = secrets.filter(secretHasCleanupAvailable).length;
 		const storeStatus = storeStatusQuery.data;
 
 		let storeValue: string | number = "—";
@@ -371,10 +472,10 @@ export function SecretsPage() {
 				}),
 			},
 			{
-				title: t("stats.usageRefs.title", { defaultValue: "Usage References" }),
-				value: secretsQuery.isLoading ? "—" : usageRefs,
-				description: t("stats.usageRefs.description", {
-					defaultValue: "runtime bindings",
+				title: t("stats.cleanup.title", { defaultValue: "Cleanup" }),
+				value: secretsQuery.isLoading ? "—" : cleanupCount,
+				description: t("stats.cleanup.description", {
+					defaultValue: "ready to review",
 				}),
 			},
 			{
@@ -388,7 +489,28 @@ export function SecretsPage() {
 		secretsQuery.isLoading,
 		storeStatusQuery.data,
 		t,
+		i18n.language,
 	]);
+
+	const filters = (
+		<Select
+			value={lifecycleFilter}
+			onValueChange={(value) =>
+				setLifecycleFilter(value as SecretLifecycleFilter)
+			}
+		>
+			<SelectTrigger className="h-9 w-[178px]">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent align="end">
+				{SECRET_LIFECYCLE_FILTERS.map((filter) => (
+					<SelectItem key={filter} value={filter}>
+						{lifecycleLabel(filter)}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
 
 	const toolbarConfig: PageToolbarConfig<SecretToolbarEntity> = {
 		data: secretsAsEntities,
@@ -516,10 +638,15 @@ export function SecretsPage() {
 							defaultValue:
 								"Store write-only values for server runtime placeholders.",
 						})
-						: t("empty.filteredDescription", {
-							defaultValue:
-								"Adjust the search or sort controls to find a secret.",
-						})
+						: lifecycleFilter !== "all"
+							? t("empty.filteredLifecycleDescription", {
+								defaultValue:
+									"Adjust the lifecycle filter or search controls to find a secret.",
+							})
+							: t("empty.filteredDescription", {
+								defaultValue:
+									"Adjust the search or sort controls to find a secret.",
+							})
 				}
 				action={emptyStateAction}
 			/>
@@ -583,6 +710,7 @@ export function SecretsPage() {
 					<Badge key="kind" variant="secondary">
 						{kindLabel(secret.kind)}
 					</Badge>,
+					<span key="lifecycle">{renderLifecycleBadge(secret)}</span>,
 				]}
 				stats={[
 					{
@@ -593,6 +721,10 @@ export function SecretsPage() {
 					{
 						label: t("list.stats.usage", { defaultValue: "Usage" }),
 						value: secret.used_by_count,
+					},
+					{
+						label: t("list.stats.history", { defaultValue: "History" }),
+						value: secret.historical_usage_count,
 					},
 					{
 						label: t("list.stats.version", { defaultValue: "Version" }),
@@ -647,7 +779,10 @@ export function SecretsPage() {
 				}}
 				avatarShape="rounded"
 				topRightBadge={
-					<Badge variant="secondary">{kindLabel(secret.kind)}</Badge>
+					<>
+						{renderLifecycleBadge(secret)}
+						<Badge variant="secondary">{kindLabel(secret.kind)}</Badge>
+					</>
 				}
 				stats={[
 					{
@@ -658,6 +793,10 @@ export function SecretsPage() {
 					{
 						label: t("list.stats.usage", { defaultValue: "Usage" }),
 						value: String(secret.used_by_count),
+					},
+					{
+						label: t("list.stats.history", { defaultValue: "History" }),
+						value: String(secret.historical_usage_count),
 					},
 					{
 						label: t("list.stats.version", { defaultValue: "Version" }),
@@ -683,6 +822,7 @@ export function SecretsPage() {
 					state={toolbarState}
 					callbacks={toolbarCallbacks}
 					actions={actions}
+					filters={filters}
 				/>
 			}
 			statsCards={<StatsCards cards={statsCards} />}
@@ -823,6 +963,8 @@ function SecretDeleteDialog({
 	onConfirm: () => void;
 }) {
 	const { t } = useTranslation("secrets");
+	const lifecycle = secret ? classifySecretLifecycle(secret) : null;
+	const description = resolveDeleteDescription(t, lifecycle?.state);
 	return (
 		<AlertDialog
 			open={Boolean(secret)}
@@ -833,15 +975,19 @@ function SecretDeleteDialog({
 					<AlertDialogTitle>
 						{t("delete.title", { defaultValue: "Delete secret?" })}
 					</AlertDialogTitle>
-					<AlertDialogDescription>
-						{t("delete.description", {
-							defaultValue:
-								"This removes the encrypted value only when no active usage is recorded.",
-						})}
-					</AlertDialogDescription>
+					<AlertDialogDescription>{description}</AlertDialogDescription>
 				</AlertDialogHeader>
-				<div className="rounded-md bg-muted px-3 py-2 font-mono text-xs">
-					{secret?.alias}
+				<div className="space-y-2 rounded-md bg-muted px-3 py-2 text-xs">
+					<div className="font-mono">{secret?.alias}</div>
+					{lifecycle ? (
+						<div className="text-muted-foreground">
+							{t("delete.usageSummary", {
+								defaultValue: "Active {{active}} · Historical {{historical}}",
+								active: lifecycle.activeCount,
+								historical: lifecycle.historicalCount,
+							})}
+						</div>
+					) : null}
 				</div>
 				<AlertDialogFooter>
 					<AlertDialogCancel disabled={isDeleting}>
@@ -858,4 +1004,37 @@ function SecretDeleteDialog({
 			</AlertDialogContent>
 		</AlertDialog>
 	);
+}
+
+function resolveDeleteDescription(
+	t: ReturnType<typeof useTranslation<"secrets">>["t"],
+	state?: SecretLifecycleState,
+): string {
+	switch (state) {
+		case "active":
+			return t("delete.descriptionActive", {
+				defaultValue:
+					"This secret is still actively used. Remove active bindings before deleting it.",
+			});
+		case "cleanup_available":
+			return t("delete.descriptionHistorical", {
+				defaultValue:
+					"This removes the encrypted value. Historical usage metadata remains available without the secret value.",
+			});
+		case "oauth_managed":
+			return t("delete.descriptionOAuth", {
+				defaultValue:
+					"OAuth-managed credentials are normally removed by OAuth revoke or server deletion. Delete only orphaned OAuth records.",
+			});
+		case "unused":
+			return t("delete.descriptionUnused", {
+				defaultValue:
+					"This removes the encrypted value. No active or historical usage is recorded.",
+			});
+		default:
+			return t("delete.description", {
+				defaultValue:
+					"This removes the encrypted value only when no active usage is recorded.",
+			});
+	}
 }

--- a/board/src/pages/servers/i18n/index.ts
+++ b/board/src/pages/servers/i18n/index.ts
@@ -76,7 +76,8 @@ export const serversTranslations = {
 			},
 			delete: {
 				title: "Server deleted",
-				message: "Server {{serverId}}",
+				message: "Server {{serverId}}. Review Secure Store cleanup if it used stored secrets.",
+				cleanupReview: "Review Secure Store cleanup if this server used stored secrets.",
 				errorFallback: "Error deleting server",
 			},
 			genericError: {
@@ -722,6 +723,7 @@ export const serversTranslations = {
 				empty: "No secrets stored",
 				createInline: "New secret",
 				tagAlias: "{{alias}}",
+				inspect: "Open {{alias}} in Secure Store",
 				inlinePrefix: "Text before secret",
 				inlineTrailing: "Text after secret",
 				inlineText: "Secret value text",
@@ -977,7 +979,8 @@ export const serversTranslations = {
 			},
 			delete: {
 				title: "服务器已删除",
-				message: "服务器 {{serverId}}",
+				message: "服务器 {{serverId}}。如果它使用过已存储密钥，请复核安全存储清理。",
+				cleanupReview: "如果此服务器使用过已存储密钥，请复核安全存储清理。",
 				errorFallback: "删除服务器时出错",
 			},
 			genericError: {
@@ -1604,6 +1607,7 @@ export const serversTranslations = {
 				empty: "暂无存储密钥",
 				createInline: "新建密钥",
 				tagAlias: "{{alias}}",
+				inspect: "在安全存储中打开 {{alias}}",
 				inlinePrefix: "密钥前的文本",
 				inlineTrailing: "密钥后的文本",
 				inlineText: "密钥字段文本",
@@ -1838,7 +1842,8 @@ export const serversTranslations = {
 			},
 			delete: {
 				title: "サーバーを削除しました",
-				message: "サーバー {{serverId}}",
+				message: "サーバー {{serverId}}。保存済みシークレットを使用していた場合は Secure Store のクリーンアップを確認してください。",
+				cleanupReview: "このサーバーが保存済みシークレットを使用していた場合は Secure Store のクリーンアップを確認してください。",
 				errorFallback: "サーバーの削除中にエラーが発生しました",
 			},
 			genericError: {
@@ -2485,6 +2490,7 @@ export const serversTranslations = {
 				empty: "保存されたシークレットはありません",
 				createInline: "新しいシークレット",
 				tagAlias: "{{alias}}",
+				inspect: "Secure Store で {{alias}} を開く",
 				inlinePrefix: "シークレット前のテキスト",
 				inlineTrailing: "シークレット後のテキスト",
 				inlineText: "シークレットフィールドのテキスト",

--- a/board/src/pages/servers/server-detail-page.tsx
+++ b/board/src/pages/servers/server-detail-page.tsx
@@ -403,6 +403,11 @@ export function ServerDetailPage() {
 		onSuccess: () => {
 			notifySuccess(
 				t("notifications.delete.title", { defaultValue: "Server deleted" }),
+				t("notifications.delete.cleanupReview", {
+					defaultValue:
+						"Review Secure Store cleanup if this server used stored secrets.",
+				}),
+				"/secrets?lifecycle=unused",
 			);
 			queryClient.invalidateQueries({ queryKey: ["servers"] });
 			queryClient.removeQueries({ queryKey: ["server", serverId] });

--- a/board/src/pages/servers/server-list-page.tsx
+++ b/board/src/pages/servers/server-list-page.tsx
@@ -498,8 +498,10 @@ export function ServerListPage() {
 				}),
 				t("notifications.delete.message", {
 					serverId: deletingServer,
-					defaultValue: "Server {{serverId}}",
+					defaultValue:
+						"Server {{serverId}}. Review Secure Store cleanup if it used stored secrets.",
 				}),
+				"/secrets?lifecycle=unused",
 			);
 			queryClient.invalidateQueries({ queryKey: ["servers"] });
 			setIsDeleteConfirmOpen(false);


### PR DESCRIPTION
## Summary

Adds operator-facing Secure Store lifecycle cleanup UX on top of the landed OAuth custody and secure-store foundation. Operators can see which secrets are active, historically referenced, unused, or OAuth-managed, filter the list accordingly, and delete safely when no active bindings remain.

## Scope

**Backend**
- `GET /api/secrets/list` now returns `historical_usage_count` (stale indexed usages not in active runtime bindings).
- Delete semantics unchanged: default delete blocks on active bindings only; stale/historical rows do not block deletion.

**Board**
- Lifecycle classification (`active` / `cleanup_available` / `unused` / `oauth_managed`) with badges and URL filter (`?lifecycle=`).
- Stats card: cleanup-ready count; History column on list/cards.
- Delete dialog copy keyed to lifecycle state; Usage tab Active/Historical summary.
- Edit drawer: 24-char write-only value mask when a stored value exists (no reveal control).
- Server delete toast links to `/secrets?lifecycle=unused`.
- Server config secret chip deep-links to `/secrets?secret=<alias>&tab=usage`.

**Simplify pass (same commit)**
- Reuse `secretHasCleanupAvailable` and shared OAuth kind registry.
- Align editor delete disable with Usage summary (`canDeleteFromUsage`).
- i18n hygiene (`i18n.language` deps, lifecycle empty state, remove dead `usageRefs` keys).

## Out of scope

- Force Delete (cancelled; API `force` remains unused by Board).
- Archive / soft delete, retention policy, enterprise archive policy.
- Full server-field binding polish (separate Project item; this PR only adds chip deep-link).
- `list_secrets` batch/N+1 optimization (follow-up after review).

## Related Project item

`0.3.0: Secure Store lifecycle cleanup UX`

## Test plan

- [x] `cargo test -p mcpmate --test secrets_store_api list_secrets_reports_historical_usage_count`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `bunx vitest run src/lib/secret-lifecycle.test.ts`
- [x] `bun run build` (board)
- [ ] Manual UAT: lifecycle filter, delete blocked for active secret, server-delete → unused flow, chip deep-link, edit-drawer value mask