### PR TITLE
feat(board): secure store degraded-state guidance and shared status hooks

### DIFF
--- a/board/e2e/secrets-status-degradation.spec.ts
+++ b/board/e2e/secrets-status-degradation.spec.ts
@@ -51,6 +51,25 @@ function ok(data: unknown) {
   };
 }
 
+function okBody(data: unknown) {
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(data),
+  };
+}
+
+function readinessAndPasswordMocks() {
+  return {
+    "/api/system/readiness": okBody({ type: "ready", status: "ok" }),
+    "/api/secrets/password/status": ok({
+      enabled: false,
+      has_password: false,
+      scope: [],
+    }),
+  };
+}
+
 async function installSecretsPageMocks(
   page: import("@playwright/test").Page,
   options: {
@@ -74,7 +93,12 @@ async function installSecretsPageMocks(
     const url = new URL(route.request().url());
     const { pathname } = url;
 
+    const mocks = readinessAndPasswordMocks();
     switch (pathname) {
+      case "/api/system/readiness":
+        return route.fulfill(mocks["/api/system/readiness"]);
+      case "/api/secrets/password/status":
+        return route.fulfill(mocks["/api/secrets/password/status"]);
       case "/api/secrets/status":
         return route.fulfill(ok(storeStatus));
       case "/api/secrets/list":
@@ -110,7 +134,7 @@ test.describe("Secrets store status degradation", () => {
     await expect(page.getByRole("alert")).toHaveCount(0);
     const addButton = page.getByRole("button", { name: /add secret/i });
     await expect(addButton).toBeEnabled();
-    await expect(page.getByText("github-token")).toBeVisible();
+    await expect(page.getByRole("button", { name: /GitHub PAT/i })).toBeVisible();
   });
 
   test("store unavailable → alert banner, Add button disabled", async ({
@@ -138,13 +162,15 @@ test.describe("Secrets store status degradation", () => {
 
     const alert = page.getByRole("alert");
     await expect(alert).toBeVisible();
-    await expect(alert).toContainText("Secure store unavailable");
+    await expect(alert).toContainText("Secure store provider unavailable");
     await expect(alert).toContainText("OS keychain not accessible for testing");
 
     const addButton = page.getByRole("button", { name: /add secret/i });
     await expect(addButton).toBeDisabled();
 
-    await expect(page.getByText("existing-token")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "existing-token" }),
+    ).toBeVisible();
   });
 
   test("store unavailable + empty list → empty-state CTA disabled", async ({
@@ -164,7 +190,7 @@ test.describe("Secrets store status degradation", () => {
     await expect(ctaButton).toBeDisabled();
   });
 
-  test("store unavailable → edit and delete buttons disabled", async ({
+  test("store unavailable → catalog write interactions disabled", async ({
     page,
   }) => {
     await installSecretsPageMocks(page, {
@@ -177,20 +203,30 @@ test.describe("Secrets store status degradation", () => {
           provider_id: "dev",
           provider_kind: "development",
           version: 1,
-          used_by_count: 0,
+          used_by_count: 1,
         },
       ],
     });
 
-    await page.goto("/secrets");
+    await page.goto("/secrets?view=list");
 
     await expect(page.getByRole("alert")).toBeVisible();
+    const catalogRow = page.getByRole("button", { name: /my-token/i });
+    await expect(catalogRow).toBeVisible();
 
-    const editButton = page.getByRole("button", { name: /edit secret/i });
-    await expect(editButton).toBeDisabled();
+    await catalogRow.click();
+    await expect(
+      page.getByRole("heading", { name: /edit secret/i }),
+    ).toHaveCount(0);
 
-    const deleteButton = page.getByRole("button", { name: /delete secret/i });
-    await expect(deleteButton).toBeDisabled();
+    const usageButton = page.getByRole("button", {
+      name: "View usage",
+      exact: true,
+    });
+    await usageButton.click();
+    await expect(
+      page.getByRole("heading", { name: /edit secret/i }),
+    ).toHaveCount(0);
   });
 
   test("status API error → error alert shown, Add button disabled", async ({
@@ -199,7 +235,14 @@ test.describe("Secrets store status degradation", () => {
     await page.route("**/api/**", async (route) => {
       const url = new URL(route.request().url());
       const { pathname } = url;
+      const mocks = readinessAndPasswordMocks();
 
+      if (pathname === "/api/system/readiness") {
+        return route.fulfill(mocks["/api/system/readiness"]);
+      }
+      if (pathname === "/api/secrets/password/status") {
+        return route.fulfill(mocks["/api/secrets/password/status"]);
+      }
       if (pathname === "/api/secrets/status") {
         return route.fulfill({
           status: 500,
@@ -242,7 +285,14 @@ test.describe("Secrets store status degradation", () => {
     await page.route("**/api/**", async (route) => {
       const url = new URL(route.request().url());
       const { pathname } = url;
+      const mocks = readinessAndPasswordMocks();
 
+      if (pathname === "/api/system/readiness") {
+        return route.fulfill(mocks["/api/system/readiness"]);
+      }
+      if (pathname === "/api/secrets/password/status") {
+        return route.fulfill(mocks["/api/secrets/password/status"]);
+      }
       if (pathname === "/api/secrets/status") {
         return route.fulfill(ok(storeStatus));
       }

--- a/board/src/components/error-display.tsx
+++ b/board/src/components/error-display.tsx
@@ -1,3 +1,4 @@
+import type { LucideIcon } from "lucide-react";
 import { RefreshCw } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
@@ -6,12 +7,16 @@ interface ErrorDisplayProps {
 	title?: string;
 	error: Error | string | null;
 	onRetry?: () => void;
+	retryLabel?: string;
+	icon?: LucideIcon;
 }
 
 export function ErrorDisplay({
 	title = "Error",
 	error,
 	onRetry,
+	retryLabel = "Retry",
+	icon: Icon,
 }: ErrorDisplayProps) {
 	if (!error) {
 		return null;
@@ -24,6 +29,7 @@ export function ErrorDisplay({
 
 	return (
 		<Alert variant="destructive" className="my-4">
+			{Icon ? <Icon className="h-4 w-4" /> : null}
 			<AlertTitle className="flex items-center justify-between">
 				{title}
 				{onRetry ? (
@@ -34,7 +40,7 @@ export function ErrorDisplay({
 						className="ml-2"
 					>
 						<RefreshCw className="mr-2 h-4 w-4" />
-						Retry
+						{retryLabel}
 					</Button>
 				) : null}
 			</AlertTitle>

--- a/board/src/components/lock-screen.tsx
+++ b/board/src/components/lock-screen.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Lock, Unlock } from "lucide-react";
 import { secretsApi } from "../lib/api";
+import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 
@@ -9,10 +10,16 @@ export type LockScreenVariant = "login" | "encryption";
 
 interface LockScreenProps {
 	variant?: LockScreenVariant;
+	/** Fill the parent content pane instead of the full viewport (use inside Layout). */
+	embedded?: boolean;
 	onSuccess: (password: string) => void | Promise<void>;
 }
 
-export function LockScreen({ variant = "login", onSuccess }: LockScreenProps) {
+export function LockScreen({
+	variant = "login",
+	embedded = false,
+	onSuccess,
+}: LockScreenProps) {
 	const { t } = useTranslation();
 	const [password, setPassword] = useState("");
 	const [focused, setFocused] = useState(true);
@@ -67,7 +74,12 @@ export function LockScreen({ variant = "login", onSuccess }: LockScreenProps) {
 	);
 
 	return (
-		<div className="flex h-screen w-screen items-center justify-center bg-background">
+		<div
+			className={cn(
+				"flex items-center justify-center bg-background",
+				embedded ? "h-full min-h-0 w-full" : "h-screen w-screen",
+			)}
+		>
 			<div className="w-full max-w-sm space-y-6 px-6">
 				<div className="flex flex-col items-center space-y-2 text-center">
 					<div className="relative inline-flex">
@@ -155,4 +167,9 @@ export function LockScreen({ variant = "login", onSuccess }: LockScreenProps) {
 			</div>
 		</div>
 	);
+}
+
+/** Lock screen sized for dashboard pages rendered inside Layout (sidebar visible). */
+export function PageLockScreen(props: Omit<LockScreenProps, "embedded">) {
+	return <LockScreen {...props} embedded />;
 }

--- a/board/src/components/secrets/index.ts
+++ b/board/src/components/secrets/index.ts
@@ -9,6 +9,8 @@ export {
 	type UseInlineSecretCreateOptions,
 } from "./inline-secret-create";
 export { SecretEditorDrawer } from "./secret-editor-drawer";
+export { SecretCatalogEntry } from "./secret-catalog-entry";
+export { SecretStoreIssueAlert } from "./secret-store-issue-alert";
 export {
 	buildCreateEditorStateFromOrigin,
 	defaultSecretEditorState,

--- a/board/src/components/secrets/secret-catalog-entry.tsx
+++ b/board/src/components/secrets/secret-catalog-entry.tsx
@@ -1,0 +1,204 @@
+import { ShieldCheck } from "lucide-react";
+import { memo, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { SecretLifecycleState } from "../../lib/secret-lifecycle";
+import type { SecretMetadata } from "../../lib/types";
+import { EntityCard } from "../entity-card";
+import { EntityListItem } from "../entity-list-item";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+
+export interface SecretCatalogDisplay {
+	title: string;
+	secondary: string | null;
+}
+
+export type SecretCatalogStatsLabels = {
+	provider: string;
+	usage: string;
+	history: string;
+	version: string;
+};
+
+type SecretCatalogEntryBaseProps = {
+	secret: SecretMetadata;
+	display: SecretCatalogDisplay;
+	kindLabel: string;
+	lifecycleState: SecretLifecycleState;
+	providerLabel: string;
+	statsLabels: SecretCatalogStatsLabels;
+	onOpen: (alias: string) => void;
+};
+
+export type SecretCatalogListEntryProps = SecretCatalogEntryBaseProps & {
+	variant: "list";
+	viewUsageLabel: string;
+	onViewUsage: (alias: string) => void;
+};
+
+export type SecretCatalogGridEntryProps = SecretCatalogEntryBaseProps & {
+	variant: "grid";
+};
+
+export type SecretCatalogEntryProps =
+	| SecretCatalogListEntryProps
+	| SecretCatalogGridEntryProps;
+
+function lifecycleBadgeVariant(
+	state: SecretLifecycleState,
+): "secondary" | "success" | "warning" | "outline" | "info" {
+	switch (state) {
+		case "active":
+			return "success";
+		case "cleanup_available":
+			return "warning";
+		case "oauth_managed":
+			return "info";
+		case "unused":
+			return "outline";
+	}
+}
+
+function buildStats(
+	secret: SecretMetadata,
+	providerLabel: string,
+	statsLabels: SecretCatalogStatsLabels,
+) {
+	return [
+		{
+			label: statsLabels.provider,
+			value: providerLabel,
+			valueTitle: secret.provider_kind,
+		},
+		{
+			label: statsLabels.usage,
+			value: secret.used_by_count,
+		},
+		{
+			label: statsLabels.history,
+			value: secret.historical_usage_count,
+		},
+		{
+			label: statsLabels.version,
+			value: secret.version,
+		},
+	];
+}
+
+function SecretCatalogEntryComponent(props: SecretCatalogEntryProps) {
+	const { t } = useTranslation("secrets");
+	const {
+		secret,
+		display,
+		kindLabel,
+		lifecycleState,
+		providerLabel,
+		statsLabels,
+		onOpen,
+	} = props;
+
+	const lifecycleLabel = t(`lifecycle.state.${lifecycleState}`, {
+		defaultValue: lifecycleState.replace(/_/g, " "),
+	});
+	const lifecycleDescription = t(`lifecycle.description.${lifecycleState}`, {
+		defaultValue: lifecycleState.replace(/_/g, " "),
+	});
+
+	const handleOpen = useCallback(() => {
+		onOpen(secret.alias);
+	}, [onOpen, secret.alias]);
+
+	const onViewUsage =
+		props.variant === "list" ? props.onViewUsage : undefined;
+	const handleViewUsage = useCallback(() => {
+		onViewUsage?.(secret.alias);
+	}, [onViewUsage, secret.alias]);
+
+	const description = useMemo(
+		() => (
+			<div className="min-w-0">
+				{display.secondary ? (
+					<div className="truncate font-mono text-xs">{display.secondary}</div>
+				) : null}
+				<div className="truncate font-mono text-xs text-muted-foreground">
+					{secret.placeholder}
+				</div>
+			</div>
+		),
+		[display.secondary, secret.placeholder],
+	);
+
+	const lifecycleBadge = useMemo(
+		() => (
+			<Badge
+				variant={lifecycleBadgeVariant(lifecycleState)}
+				title={lifecycleDescription}
+			>
+				{lifecycleLabel}
+			</Badge>
+		),
+		[lifecycleDescription, lifecycleLabel, lifecycleState],
+	);
+
+	const stats = useMemo(
+		() => buildStats(secret, providerLabel, statsLabels),
+		[providerLabel, secret, statsLabels],
+	);
+
+	if (props.variant === "list") {
+		return (
+			<EntityListItem
+				id={secret.alias}
+				title={display.title}
+				description={description}
+				avatar={{
+					fallback: secret.alias.slice(0, 2).toUpperCase(),
+				}}
+				titleBadges={[
+					<Badge key="kind" variant="secondary">
+						{kindLabel}
+					</Badge>,
+					<span key="lifecycle">{lifecycleBadge}</span>,
+				]}
+				stats={stats}
+				actionButtons={[
+					<Button
+						key="usage"
+						type="button"
+						variant="ghost"
+						size="sm"
+						className="h-9 px-2"
+						onClick={handleViewUsage}
+						aria-label={props.viewUsageLabel}
+					>
+						<ShieldCheck className="mr-2 h-4 w-4" />
+						{secret.used_by_count}
+					</Button>,
+				]}
+				onClick={handleOpen}
+			/>
+		);
+	}
+
+	return (
+		<EntityCard
+			id={secret.alias}
+			title={display.title}
+			description={description}
+			avatar={{
+				fallback: secret.alias.slice(0, 2).toUpperCase(),
+			}}
+			avatarShape="rounded"
+			topRightBadge={
+				<>
+					{lifecycleBadge}
+					<Badge variant="secondary">{kindLabel}</Badge>
+				</>
+			}
+			stats={stats}
+			onClick={handleOpen}
+		/>
+	);
+}
+
+export const SecretCatalogEntry = memo(SecretCatalogEntryComponent);

--- a/board/src/components/secrets/secret-editor-drawer.tsx
+++ b/board/src/components/secrets/secret-editor-drawer.tsx
@@ -75,6 +75,7 @@ interface SecretEditorDrawerProps {
 	onSave: () => void;
 	onDelete?: () => void;
 	isSaving: boolean;
+	writesDisabled?: boolean;
 	placeholder?: string;
 	usages?: SecretUsage[];
 	usagesLoading?: boolean;
@@ -93,6 +94,7 @@ export function SecretEditorDrawer({
 	onSave,
 	onDelete,
 	isSaving,
+	writesDisabled = false,
 	placeholder,
 	usages = [],
 	usagesLoading = false,
@@ -250,6 +252,9 @@ export function SecretEditorDrawer({
 					className="flex min-h-0 flex-1 flex-col"
 					onSubmit={(event) => {
 						event.preventDefault();
+						if (writesDisabled) {
+							return;
+						}
 						onSave();
 					}}
 				>
@@ -486,7 +491,7 @@ export function SecretEditorDrawer({
 										type="button"
 										variant="destructive"
 										className="gap-2"
-										disabled={isSaving || !canDeleteFromUsage}
+										disabled={isSaving || writesDisabled || !canDeleteFromUsage}
 										title={
 											!canDeleteFromUsage
 												? isActiveOAuthSecret
@@ -509,7 +514,9 @@ export function SecretEditorDrawer({
 								) : null}
 								<Button
 									type="submit"
-									disabled={isSaving || !activeEditor.alias.trim()}
+									disabled={
+										isSaving || writesDisabled || !activeEditor.alias.trim()
+									}
 								>
 									{activeEditor.mode === "create"
 										? t("editor.actions.create", {

--- a/board/src/components/secrets/secret-store-issue-alert.tsx
+++ b/board/src/components/secrets/secret-store-issue-alert.tsx
@@ -1,0 +1,124 @@
+import type { LucideIcon } from "lucide-react";
+import { RefreshCw, ShieldAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import {
+	resolveSecretStoreIssueGuidance,
+	type SwitchableSecretStoreProviderMode,
+} from "../../lib/secret-store-guidance";
+import type { SecretStoreStatusData } from "../../lib/types";
+import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
+import { Button } from "../ui/button";
+
+interface SecretStoreIssueAlertProps {
+	status: SecretStoreStatusData;
+	onRetryStatus?: () => void;
+	onRetryProvider?: (mode: SwitchableSecretStoreProviderMode) => void;
+	isRetrying?: boolean;
+	settingsHref?: string;
+	hideSettingsLink?: boolean;
+	icon?: LucideIcon;
+}
+
+export function SecretStoreIssueAlert({
+	status,
+	onRetryStatus,
+	onRetryProvider,
+	isRetrying = false,
+	settingsHref = "/settings?tab=security",
+	hideSettingsLink = false,
+	icon: Icon = ShieldAlert,
+}: SecretStoreIssueAlertProps) {
+	const { t } = useTranslation("secrets");
+	const guidance = resolveSecretStoreIssueGuidance(status, t);
+	if (!guidance) {
+		return null;
+	}
+
+	const showRetryStatus =
+		guidance.actions.includes("retry_status") && onRetryStatus;
+	const showRetryProvider =
+		guidance.actions.includes("retry_provider") &&
+		guidance.retryProviderMode &&
+		onRetryProvider;
+	const showSettingsLink =
+		!hideSettingsLink &&
+		guidance.actions.includes("open_security_settings");
+
+	return (
+		<Alert variant="destructive">
+			<Icon className="h-4 w-4" />
+			<AlertTitle>{guidance.title}</AlertTitle>
+			<AlertDescription className="space-y-3">
+				<p>{guidance.description}</p>
+				{guidance.technicalDetail ? (
+					<p className="font-mono text-xs text-destructive/80">
+						{guidance.technicalDetail}
+					</p>
+				) : null}
+				{showRetryStatus || showRetryProvider || showSettingsLink ? (
+					<div className="flex flex-wrap gap-2">
+						{showRetryProvider ? (
+							<RetryButton
+								disabled={isRetrying}
+								spinning={isRetrying}
+								onClick={() => {
+									if (guidance.retryProviderMode) {
+										onRetryProvider(guidance.retryProviderMode);
+									}
+								}}
+								label={t("guidance.actions.retryProvider", {
+									defaultValue: "Retry secure storage",
+								})}
+							/>
+						) : null}
+						{showRetryStatus ? (
+							<RetryButton
+								disabled={isRetrying}
+								spinning={isRetrying}
+								onClick={onRetryStatus}
+								label={t("guidance.actions.retryStatus", {
+									defaultValue: "Retry status check",
+								})}
+							/>
+						) : null}
+						{showSettingsLink ? (
+							<Button type="button" variant="outline" size="sm" asChild>
+								<Link to={settingsHref}>
+									{t("guidance.actions.openSecuritySettings", {
+										defaultValue: "Open Security settings",
+									})}
+								</Link>
+							</Button>
+						) : null}
+					</div>
+				) : null}
+			</AlertDescription>
+		</Alert>
+	);
+}
+
+function RetryButton({
+	disabled,
+	spinning,
+	onClick,
+	label,
+}: {
+	disabled: boolean;
+	spinning: boolean;
+	onClick: () => void;
+	label: string;
+}) {
+	return (
+		<Button
+			type="button"
+			variant="outline"
+			size="sm"
+			disabled={disabled}
+			onClick={onClick}
+		>
+			<RefreshCw className={`mr-2 h-4 w-4 ${spinning ? "animate-spin" : ""}`} />
+			{label}
+		</Button>
+	);
+}

--- a/board/src/components/server-install/secret-picker-button.tsx
+++ b/board/src/components/server-install/secret-picker-button.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { secretsApi } from "../../lib/api";
+import { useSecretStoreStatusQuery } from "../../lib/hooks/use-secret-store-status";
 import { suggestSecretAliasFromOrigin } from "../../lib/secret-alias";
 import { isUserCreatableSecretKind } from "../../lib/secret-origin-hints";
 import type { SecretOrigin } from "../../lib/types";
@@ -39,10 +40,7 @@ export function SecretPickerButton({
 		enabled: open,
 	});
 
-	const storeStatusQuery = useQuery({
-		queryKey: ["secrets", "status"],
-		queryFn: secretsApi.status,
-	});
+	const storeStatusQuery = useSecretStoreStatusQuery();
 	const storeReady = storeStatusQuery.data?.status === "ready";
 
 	const secrets = useMemo(() => {

--- a/board/src/components/server-install/server-auth-section.tsx
+++ b/board/src/components/server-install/server-auth-section.tsx
@@ -8,6 +8,7 @@ import {
 	getOAuthRedirectUriForForm,
 } from "../../lib/oauth-callback-access";
 import { secretsApi, serversApi } from "../../lib/api";
+import { useSecretStoreStatusQuery } from "../../lib/hooks/use-secret-store-status";
 import { resolveOAuthReadiness } from "../../lib/oauth-readiness";
 import { isTauriEnvironmentSync } from "../../lib/platform";
 import type {
@@ -244,9 +245,7 @@ export function ServerAuthSection({
 		refetchOnWindowFocus: progressState === "awaiting_callback",
 		retry: false,
 	});
-	const secretStoreStatusQ = useQuery({
-		queryKey: ["secrets", "status"],
-		queryFn: secretsApi.status,
+	const secretStoreStatusQ = useSecretStoreStatusQuery({
 		enabled: !isStdio,
 		retry: false,
 	});

--- a/board/src/lib/api.ts
+++ b/board/src/lib/api.ts
@@ -80,6 +80,7 @@ import type {
 	SecretOrigin,
 	SecretStoreStatusData,
 	SecretStoreStatusResp,
+	SwitchableSecretStoreProviderMode,
 	ProviderSwitchResp,
 	PasswordStatusResp,
 	PasswordSetResp,
@@ -946,7 +947,7 @@ export const secretsApi = {
 	},
 
 	switchProvider: async (
-		mode: "operating_system" | "passphrase" | "local_file",
+		mode: SwitchableSecretStoreProviderMode,
 		options?: { passphrase?: string; currentPassphrase?: string },
 	): Promise<SecretStoreStatusData> => {
 		const body: {

--- a/board/src/lib/hooks/use-secret-store-provider-retry.ts
+++ b/board/src/lib/hooks/use-secret-store-provider-retry.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { TFunction } from "i18next";
+import { secretsApi } from "../api";
+import { notifyError, notifySuccess, stringifyError } from "../notify";
+import type { SwitchableSecretStoreProviderMode } from "../types";
+import {
+	invalidateSecretStoreCatalog,
+	invalidateSecretStoreStatus,
+} from "./use-secret-store-status";
+
+interface UseSecretStoreProviderRetryOptions {
+	invalidateCatalog?: boolean;
+}
+
+export function useSecretStoreProviderRetryMutation(
+	t: TFunction,
+	options: UseSecretStoreProviderRetryOptions = {},
+) {
+	const queryClient = useQueryClient();
+	const { invalidateCatalog = false } = options;
+
+	return useMutation({
+		mutationFn: (mode: SwitchableSecretStoreProviderMode) =>
+			secretsApi.switchProvider(mode),
+		onSuccess: async (newStatus) => {
+			await invalidateSecretStoreStatus(queryClient);
+
+			if (newStatus.status === "ready") {
+				if (invalidateCatalog) {
+					await invalidateSecretStoreCatalog(queryClient);
+				}
+				notifySuccess(
+					t("guidance.notifications.retrySuccess", {
+						defaultValue: "Secure store status refreshed",
+					}),
+				);
+				return;
+			}
+
+			notifyError(
+				t("guidance.notifications.retryStillUnavailable", {
+					defaultValue: "Secure store is still unavailable",
+				}),
+				newStatus.issue?.message ??
+					t("guidance.generic.description", {
+						defaultValue:
+							"Secret storage is not ready. Create and update operations stay disabled until the issue is resolved.",
+					}),
+			);
+		},
+		onError: (error: unknown) => {
+			notifyError(
+				t("guidance.notifications.retryError", {
+					defaultValue: "Failed to retry secure storage",
+				}),
+				stringifyError(error),
+			);
+		},
+	});
+}

--- a/board/src/lib/hooks/use-secret-store-status.ts
+++ b/board/src/lib/hooks/use-secret-store-status.ts
@@ -1,0 +1,59 @@
+import {
+	useQuery,
+	type QueryClient,
+	type UseQueryOptions,
+} from "@tanstack/react-query";
+import { secretsApi } from "../api";
+import type { SecretStoreStatusData } from "../types";
+
+export const SECRET_STORE_STATUS_QUERY_KEY = ["secrets", "status"] as const;
+export const SECRET_STORE_CATALOG_QUERY_KEY = ["secrets"] as const;
+export const SECRET_STORE_USAGES_QUERY_KEY = ["secrets", "usages"] as const;
+
+const DEFAULT_STALE_TIME_MS = 30_000;
+
+type SecretStoreStatusQueryOptions = Pick<
+	UseQueryOptions<SecretStoreStatusData>,
+	"enabled" | "staleTime" | "retry" | "refetchOnWindowFocus"
+>;
+
+export function useSecretStoreStatusQuery(
+	options: SecretStoreStatusQueryOptions = {},
+) {
+	return useQuery({
+		queryKey: SECRET_STORE_STATUS_QUERY_KEY,
+		queryFn: secretsApi.status,
+		staleTime: DEFAULT_STALE_TIME_MS,
+		...options,
+	});
+}
+
+export async function invalidateSecretStoreStatus(
+	queryClient: QueryClient,
+): Promise<void> {
+	await queryClient.invalidateQueries({ queryKey: SECRET_STORE_STATUS_QUERY_KEY });
+}
+
+export async function invalidateSecretStoreCatalog(
+	queryClient: QueryClient,
+): Promise<void> {
+	await Promise.all([
+		queryClient.invalidateQueries({
+			queryKey: SECRET_STORE_CATALOG_QUERY_KEY,
+			exact: true,
+		}),
+		queryClient.invalidateQueries({
+			queryKey: SECRET_STORE_USAGES_QUERY_KEY,
+		}),
+	]);
+}
+
+export async function invalidateSecretStoreData(
+	queryClient: QueryClient,
+	options: { catalog?: boolean } = {},
+): Promise<void> {
+	await invalidateSecretStoreStatus(queryClient);
+	if (options.catalog) {
+		await invalidateSecretStoreCatalog(queryClient);
+	}
+}

--- a/board/src/lib/hooks/use-secrets-translations.ts
+++ b/board/src/lib/hooks/use-secrets-translations.ts
@@ -1,0 +1,8 @@
+import { useTranslation } from "react-i18next";
+import { usePageTranslations } from "../i18n/usePageTranslations";
+
+/** Load secrets page bundles and return the secrets namespace translator. */
+export function useSecretsTranslations() {
+	usePageTranslations("secrets");
+	return useTranslation("secrets");
+}

--- a/board/src/lib/protection-password.ts
+++ b/board/src/lib/protection-password.ts
@@ -45,14 +45,5 @@ export function requiresEncryptionUnlock(status?: {
 	provider?: { provider_mode: string } | null;
 	issue?: { reason_code: string } | null;
 }): boolean {
-	if (!status) {
-		return false;
-	}
-	if (status.issue?.reason_code === "passphrase_unlock_required") {
-		return true;
-	}
-	return (
-		status.status !== "ready" &&
-		status.provider?.provider_mode === "passphrase"
-	);
+	return status?.issue?.reason_code === "passphrase_unlock_required";
 }

--- a/board/src/lib/secret-store-guidance.test.ts
+++ b/board/src/lib/secret-store-guidance.test.ts
@@ -1,0 +1,137 @@
+import type { TFunction } from "i18next";
+import { describe, expect, it } from "vitest";
+import {
+	normalizeSecretStoreReasonCode,
+	resolveSecretStoreIssueGuidance,
+} from "./secret-store-guidance";
+import type { SecretStoreStatusData } from "./types";
+
+const t = ((key: string, options?: { defaultValue?: string }) =>
+	options?.defaultValue ?? key) as TFunction;
+
+describe("resolveSecretStoreIssueGuidance", () => {
+	it("returns null for ready status", () => {
+		expect(
+			resolveSecretStoreIssueGuidance({ status: "ready", provider: null }, t),
+		).toBeNull();
+	});
+
+	it("returns null for passphrase unlock because the lock screen owns that flow", () => {
+		expect(
+			resolveSecretStoreIssueGuidance(
+				{
+					status: "unavailable",
+					issue: {
+						reason_code: "passphrase_unlock_required",
+						message: "Unlock required",
+					},
+				},
+				t,
+			),
+		).toBeNull();
+	});
+
+	it("guides OS keychain denial with retry and settings actions", () => {
+		const guidance = resolveSecretStoreIssueGuidance(
+			{
+				status: "unavailable",
+				provider: {
+					provider_id: "os",
+					provider_kind: "operating_system_keychain",
+					provider_mode: "operating_system",
+					security_level: "high",
+				},
+				issue: {
+					reason_code: "provider_unavailable",
+					message: "keyring set: denied",
+				},
+			} satisfies SecretStoreStatusData,
+			t,
+		);
+
+		expect(guidance?.actions).toEqual(["retry_provider", "open_security_settings"]);
+		expect(guidance?.retryProviderMode).toBe("operating_system");
+	});
+
+	it("guides passphrase provider_unavailable with retry provider", () => {
+		const guidance = resolveSecretStoreIssueGuidance(
+			{
+				status: "unavailable",
+				provider: {
+					provider_id: "passphrase",
+					provider_kind: "passphrase_wrapped_root_key",
+					provider_mode: "passphrase",
+					security_level: "medium",
+				},
+				issue: {
+					reason_code: "provider_unavailable",
+					message: "unlock failed",
+				},
+			} satisfies SecretStoreStatusData,
+			t,
+		);
+
+		expect(guidance?.actions).toEqual(["retry_provider", "open_security_settings"]);
+		expect(guidance?.retryProviderMode).toBe("passphrase");
+	});
+
+	it("falls back to status retry when provider mode is unknown", () => {
+		const guidance = resolveSecretStoreIssueGuidance(
+			{
+				status: "unavailable",
+				provider: {
+					provider_id: "unknown",
+					provider_kind: "unknown",
+					provider_mode: "unknown_mode" as "operating_system",
+					security_level: "low",
+				},
+				issue: {
+					reason_code: "provider_unavailable",
+					message: "init failed",
+				},
+			} satisfies SecretStoreStatusData,
+			t,
+		);
+
+		expect(guidance?.actions).toEqual(["retry_status", "open_security_settings"]);
+		expect(guidance?.retryProviderMode).toBeUndefined();
+	});
+
+	it("guides read lock failures with status retry only", () => {
+		const guidance = resolveSecretStoreIssueGuidance(
+			{
+				status: "unavailable",
+				issue: {
+					reason_code: "read_lock_failed",
+					message: "lock timeout",
+				},
+			} satisfies SecretStoreStatusData,
+			t,
+		);
+
+		expect(guidance?.actions).toEqual(["retry_status"]);
+	});
+
+	it("uses generic guidance for unknown reason codes", () => {
+		const guidance = resolveSecretStoreIssueGuidance(
+			{
+				status: "unavailable",
+				issue: {
+					reason_code: "database_unavailable",
+					message: "db locked",
+				},
+			} satisfies SecretStoreStatusData,
+			t,
+		);
+
+		expect(guidance?.actions).toEqual(["retry_status", "open_security_settings"]);
+		expect(guidance?.title).toBe("Secure store unavailable");
+	});
+
+	it("normalizes unknown reason codes", () => {
+		expect(normalizeSecretStoreReasonCode("future_backend_code")).toBe("unknown");
+		expect(normalizeSecretStoreReasonCode("read_lock_failed")).toBe(
+			"read_lock_failed",
+		);
+	});
+});

--- a/board/src/lib/secret-store-guidance.ts
+++ b/board/src/lib/secret-store-guidance.ts
@@ -1,0 +1,120 @@
+import type { TFunction } from "i18next";
+import type {
+	SecretStoreIssueReasonCode,
+	SecretStoreStatusData,
+	SwitchableSecretStoreProviderMode,
+} from "./types";
+import { SECRET_STORE_REASON_CODES } from "./types";
+
+type SecretStoreGuidanceAction =
+	| "retry_status"
+	| "retry_provider"
+	| "open_security_settings";
+
+export type { SecretStoreProviderMode, SwitchableSecretStoreProviderMode } from "./types";
+
+export interface SecretStoreIssueGuidance {
+	title: string;
+	description: string;
+	technicalDetail?: string;
+	actions: SecretStoreGuidanceAction[];
+	retryProviderMode?: SwitchableSecretStoreProviderMode;
+}
+
+export function isSwitchableSecretStoreProviderMode(
+	value: string | undefined,
+): value is SwitchableSecretStoreProviderMode {
+	return (
+		value === "operating_system" ||
+		value === "passphrase" ||
+		value === "local_file"
+	);
+}
+
+export function normalizeSecretStoreReasonCode(
+	value: string | undefined,
+): SecretStoreIssueReasonCode {
+	if (value && (SECRET_STORE_REASON_CODES as readonly string[]).includes(value)) {
+		return value as SecretStoreIssueReasonCode;
+	}
+	return "unknown";
+}
+
+export function resolveSecretStoreIssueGuidance(
+	status: SecretStoreStatusData | undefined,
+	t: TFunction,
+): SecretStoreIssueGuidance | null {
+	if (!status || status.status === "ready") {
+		return null;
+	}
+
+	const reasonCode = normalizeSecretStoreReasonCode(status.issue?.reason_code);
+	const technicalDetail = status.issue?.message;
+	const providerMode = status.provider?.provider_mode;
+
+	if (reasonCode === "passphrase_unlock_required") {
+		return null;
+	}
+
+	if (
+		reasonCode === "provider_unavailable" &&
+		providerMode === "operating_system"
+	) {
+		return {
+			title: t("guidance.providerUnavailable.os.title", {
+				defaultValue: "OS secure storage is unavailable",
+			}),
+			description: t("guidance.providerUnavailable.os.description", {
+				defaultValue:
+					"MCPMate could not access the OS keychain. Grant access when prompted, unlock Keychain Access on macOS, or switch to Password or Local File mode in Settings → Security.",
+			}),
+			technicalDetail,
+			actions: ["retry_provider", "open_security_settings"],
+			retryProviderMode: "operating_system",
+		};
+	}
+
+	if (reasonCode === "provider_unavailable") {
+		const mode = isSwitchableSecretStoreProviderMode(providerMode) ? providerMode : undefined;
+		return {
+			title: t("guidance.providerUnavailable.title", {
+				defaultValue: "Secure store provider unavailable",
+			}),
+			description: t("guidance.providerUnavailable.description", {
+				defaultValue:
+					"The configured root-key provider could not be initialized. Retry after fixing the environment, or choose a different security mode in Settings → Security.",
+			}),
+			technicalDetail,
+			actions: mode
+				? ["retry_provider", "open_security_settings"]
+				: ["retry_status", "open_security_settings"],
+			retryProviderMode: mode,
+		};
+	}
+
+	if (reasonCode === "read_lock_failed") {
+		return {
+			title: t("guidance.readLockFailed.title", {
+				defaultValue: "Secure store is busy",
+			}),
+			description: t("guidance.readLockFailed.description", {
+				defaultValue:
+					"MCPMate could not read the secure store status. Wait a moment and retry.",
+			}),
+			technicalDetail,
+			actions: ["retry_status"],
+		};
+	}
+
+	return {
+		title: t("guidance.generic.title", {
+			defaultValue: "Secure store unavailable",
+		}),
+		description: t("guidance.generic.description", {
+			defaultValue:
+				"Secret storage is not ready. Create and update operations stay disabled until the issue is resolved.",
+		}),
+		technicalDetail,
+		actions: ["retry_status", "open_security_settings"],
+	};
+}

--- a/board/src/lib/types.ts
+++ b/board/src/lib/types.ts
@@ -608,10 +608,39 @@ export type SecretKind =
   | "url_credential"
   | "header_value";
 
+export type SwitchableSecretStoreProviderMode =
+  | "operating_system"
+  | "passphrase"
+  | "local_file";
+
+export type SecretStoreProviderMode =
+  | SwitchableSecretStoreProviderMode
+  | "development"
+  | "custom";
+
+/** Known secure-store issue reason codes emitted by the backend. */
+export const SECRET_STORE_REASON_CODES = [
+  "passphrase_unlock_required",
+  "provider_unavailable",
+  "read_lock_failed",
+  "database_unavailable",
+  "schema_migration_required",
+  "cache_error",
+  "invalid_root_key",
+  "local_storage_error",
+  "development_storage_error",
+  "initialization_failed",
+] as const;
+
+export type SecretStoreReasonCode =
+  (typeof SECRET_STORE_REASON_CODES)[number];
+
+export type SecretStoreIssueReasonCode = SecretStoreReasonCode | "unknown";
+
 export interface SecretMetadata {
   alias: string;
   placeholder: string;
-  kind: string;
+  kind: SecretKind;
   label?: string | null;
   origin?: SecretOrigin | null;
   provider_id: string;
@@ -674,12 +703,12 @@ export interface SecretDeleteResp {
 export interface SecretStoreProviderData {
   provider_id: string;
   provider_kind: string;
-  provider_mode: string;
+  provider_mode: SecretStoreProviderMode;
   security_level: string;
 }
 
 export interface SecretStoreIssueData {
-  reason_code: string;
+  reason_code: SecretStoreReasonCode | (string & {});
   message: string;
 }
 

--- a/board/src/pages/secrets/i18n/index.ts
+++ b/board/src/pages/secrets/i18n/index.ts
@@ -209,10 +209,37 @@ export const secretsTranslations = {
 				description:
 					"Could not determine store status. Operations are disabled.",
 			},
-			unavailable: {
+		},
+		guidance: {
+			providerUnavailable: {
+				title: "Secure store provider unavailable",
+				description:
+					"The configured root-key provider could not be initialized. Retry after fixing the environment, or choose a different security mode in Settings → Security.",
+				os: {
+					title: "OS secure storage is unavailable",
+					description:
+						"MCPMate could not access the OS keychain. Grant access when prompted, unlock Keychain Access on macOS, or switch to Password or Local File mode in Settings → Security.",
+				},
+			},
+			readLockFailed: {
+				title: "Secure store is busy",
+				description:
+					"MCPMate could not read the secure store status. Wait a moment and retry.",
+			},
+			generic: {
 				title: "Secure store unavailable",
 				description:
-					"The secret store is not ready. Create and update operations are disabled until the issue is resolved.",
+					"Secret storage is not ready. Create and update operations stay disabled until the issue is resolved.",
+			},
+			actions: {
+				retryProvider: "Retry secure storage",
+				retryStatus: "Retry status check",
+				openSecuritySettings: "Open Security settings",
+			},
+			notifications: {
+				retrySuccess: "Secure store status refreshed",
+				retryError: "Failed to retry secure storage",
+				retryStillUnavailable: "Secure store is still unavailable",
 			},
 		},
 		stats: {
@@ -437,9 +464,35 @@ export const secretsTranslations = {
 				title: "存储状态检查失败",
 				description: "无法确定存储状态，相关操作已禁用。",
 			},
-			unavailable: {
+		},
+		guidance: {
+			providerUnavailable: {
+				title: "安全存储提供方不可用",
+				description:
+					"配置的根密钥提供方无法初始化。请修复环境后重试，或在设置 → 安全中选择其他安全模式。",
+				os: {
+					title: "操作系统安全存储不可用",
+					description:
+						"MCPMate 无法访问系统钥匙串。请在提示时授予访问权限、在 macOS 上解锁钥匙串访问，或在设置 → 安全中切换到密码或本地文件模式。",
+				},
+			},
+			readLockFailed: {
+				title: "安全存储繁忙",
+				description: "MCPMate 无法读取安全存储状态，请稍候后重试。",
+			},
+			generic: {
 				title: "安全存储不可用",
 				description: "密钥存储尚未就绪，在问题解决前无法创建或更新。",
+			},
+			actions: {
+				retryProvider: "重试安全存储",
+				retryStatus: "重试状态检查",
+				openSecuritySettings: "打开安全设置",
+			},
+			notifications: {
+				retrySuccess: "安全存储状态已刷新",
+				retryError: "重试安全存储失败",
+				retryStillUnavailable: "安全存储仍然不可用",
 			},
 		},
 		stats: {
@@ -675,10 +728,37 @@ export const secretsTranslations = {
 				description:
 					"ストア状態を取得できません。操作は無効になっています。",
 			},
-			unavailable: {
+		},
+		guidance: {
+			providerUnavailable: {
+				title: "セキュアストアプロバイダーが利用できません",
+				description:
+					"設定されたルートキープロバイダーを初期化できませんでした。環境を修正して再試行するか、設定 → セキュリティで別のセキュリティモードを選択してください。",
+				os: {
+					title: "OS セキュアストレージが利用できません",
+					description:
+						"MCPMate は OS キーチェーンにアクセスできませんでした。プロンプトでアクセスを許可するか、macOS ではキーチェーンアクセスのロックを解除するか、設定 → セキュリティでパスワードまたはローカルファイルモードに切り替えてください。",
+				},
+			},
+			readLockFailed: {
+				title: "セキュアストアがビジー状態です",
+				description:
+					"MCPMate はセキュアストアの状態を読み取れませんでした。しばらく待ってから再試行してください。",
+			},
+			generic: {
 				title: "セキュアストアは利用できません",
 				description:
 					"シークレットストアの準備ができていません。問題が解決するまで作成・更新は無効です。",
+			},
+			actions: {
+				retryProvider: "セキュアストレージを再試行",
+				retryStatus: "状態確認を再試行",
+				openSecuritySettings: "セキュリティ設定を開く",
+			},
+			notifications: {
+				retrySuccess: "セキュアストアの状態を更新しました",
+				retryError: "セキュアストレージの再試行に失敗しました",
+				retryStillUnavailable: "セキュアストアはまだ利用できません",
 			},
 		},
 		stats: {

--- a/board/src/pages/secrets/secrets-page.tsx
+++ b/board/src/pages/secrets/secrets-page.tsx
@@ -4,13 +4,10 @@ import {
 	Plus,
 	RefreshCw,
 	ShieldAlert,
-	ShieldCheck,
 } from "lucide-react";
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { EntityCard } from "../../components/entity-card";
-import { EntityListItem } from "../../components/entity-list-item";
 import { ListGridContainer } from "../../components/list-grid-container";
 import {
 	EmptyState,
@@ -20,7 +17,7 @@ import {
 import { StatsCards } from "../../components/stats-cards";
 import type { StatCardData } from "../../components/stats-cards";
 import { Pagination } from "../../components/pagination";
-import { Alert, AlertDescription, AlertTitle } from "../../components/ui/alert";
+import { ErrorDisplay } from "../../components/error-display";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -31,7 +28,6 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "../../components/ui/alert-dialog";
-import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { PageToolbar } from "../../components/ui/page-toolbar";
@@ -48,9 +44,11 @@ import type {
 	PageToolbarConfig,
 	PageToolbarState,
 } from "../../components/ui/page-toolbar";
-import { LockScreen } from "../../components/lock-screen";
+import { PageLockScreen } from "../../components/lock-screen";
 import {
 	SecretEditorDrawer,
+	SecretCatalogEntry,
+	SecretStoreIssueAlert,
 	buildCreateEditorStateFromOrigin,
 	defaultSecretEditorState,
 	originFromSearchParams,
@@ -63,19 +61,21 @@ import { secretsApi, serversApi } from "../../lib/api";
 import { requiresEncryptionUnlock } from "../../lib/protection-password";
 import {
 	classifySecretLifecycle,
-	filterSecretsByLifecycle,
 	secretHasCleanupAvailable,
 	type SecretLifecycleFilter,
 	type SecretLifecycleState,
 } from "../../lib/secret-lifecycle";
+import { useSecretStoreProviderRetryMutation } from "../../lib/hooks/use-secret-store-provider-retry";
+import {
+	invalidateSecretStoreCatalog,
+	invalidateSecretStoreData,
+	useSecretStoreStatusQuery,
+} from "../../lib/hooks/use-secret-store-status";
+import { useSecretsTranslations } from "../../lib/hooks/use-secrets-translations";
 import { useUrlView } from "../../lib/hooks/use-url-state";
-import { usePageTranslations } from "../../lib/i18n/usePageTranslations";
 import { notifyError, notifySuccess, stringifyError } from "../../lib/notify";
 import { useAppStore } from "../../lib/store";
-import type {
-	SecretKind,
-	SecretMetadata,
-} from "../../lib/types";
+import type { SecretMetadata } from "../../lib/types";
 
 const DEFAULT_PAGE_SIZE = 10;
 
@@ -104,9 +104,19 @@ function getSecretDisplay(secret: SecretMetadata) {
 	};
 }
 
+function buildEditEditorState(secret: SecretMetadata): SecretEditorState {
+	return {
+		mode: "edit",
+		alias: secret.alias,
+		kind: secret.kind,
+		label: secret.label ?? "",
+		value: "",
+		origin: secret.origin ?? null,
+	};
+}
+
 export function SecretsPage() {
-	usePageTranslations("secrets");
-	const { t, i18n } = useTranslation("secrets");
+	const { t, i18n } = useSecretsTranslations();
 	const queryClient = useQueryClient();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [editor, setEditor] = useState<SecretEditorState | null>(null);
@@ -126,17 +136,32 @@ export function SecretsPage() {
 		defaultView: storedDefaultView,
 		validViews: ["grid", "list"],
 	});
-	const viewMode = view;
 
 	const secretsQuery = useQuery({
 		queryKey: ["secrets"],
 		queryFn: secretsApi.list,
+		staleTime: 30_000,
 	});
+	const editorAlias = editor?.mode === "edit" ? editor.alias : null;
 	const serversQuery = useQuery({
 		queryKey: ["servers"],
 		queryFn: serversApi.getAll,
 		staleTime: 30_000,
+		enabled: Boolean(editorAlias),
 	});
+	const usagesQuery = useQuery({
+		queryKey: ["secrets", "usages", editorAlias],
+		queryFn: () => secretsApi.listUsages(editorAlias ?? ""),
+		enabled: Boolean(editorAlias),
+	});
+	const storeStatusQuery = useSecretStoreStatusQuery();
+	const storeReady = storeStatusQuery.data?.status === "ready";
+	const needsEncryptionUnlock = requiresEncryptionUnlock(storeStatusQuery.data);
+
+	const providerRetryMutation = useSecretStoreProviderRetryMutation(t, {
+		invalidateCatalog: true,
+	});
+
 	const serverNameById = useMemo(() => {
 		const map = new Map<string, string>();
 		for (const server of serversQuery.data?.servers ?? []) {
@@ -145,36 +170,41 @@ export function SecretsPage() {
 		}
 		return map;
 	}, [serversQuery.data]);
-	const editorAlias = editor?.mode === "edit" ? editor.alias : null;
-	const usagesQuery = useQuery({
-		queryKey: ["secrets", "usages", editorAlias],
-		queryFn: () => secretsApi.listUsages(editorAlias ?? ""),
-		enabled: Boolean(editorAlias),
-	});
-	const storeStatusQuery = useQuery({
-		queryKey: ["secrets", "status"],
-		queryFn: secretsApi.status,
-	});
-	const storeReady = storeStatusQuery.data?.status === "ready";
-	const needsEncryptionUnlock = requiresEncryptionUnlock(storeStatusQuery.data);
 
 	const handleEncryptionUnlock = async () => {
-		await queryClient.invalidateQueries({ queryKey: ["secrets", "status"] });
-		await queryClient.invalidateQueries({ queryKey: ["secrets"] });
+		await invalidateSecretStoreData(queryClient, { catalog: true });
 	};
 
-	const kindOptions = SECRET_KIND_VALUES.map((value) => ({
-		value,
-		label: t(`kind.${value}`, { defaultValue: value }),
-	}));
+	const kindOptions = useMemo(
+		() =>
+			SECRET_KIND_VALUES.map((value) => ({
+				value,
+				label: t(`kind.${value}`, { defaultValue: value }),
+			})),
+		[t, i18n.language],
+	);
+	const kindLabelByKind = useMemo(
+		() => new Map(kindOptions.map((option) => [option.value, option.label])),
+		[kindOptions],
+	);
+
+	const providerLabel = useCallback(
+		(providerKind: string): string =>
+			t(`provider.${providerKind}`, { defaultValue: providerKind }),
+		[t, i18n.language],
+	);
+
+	const catalogStatsLabels = useMemo(
+		() => ({
+			provider: t("list.stats.provider", { defaultValue: "Provider" }),
+			usage: t("list.stats.usage", { defaultValue: "Usage" }),
+			history: t("list.stats.history", { defaultValue: "History" }),
+			version: t("list.stats.version", { defaultValue: "Version" }),
+		}),
+		[t, i18n.language],
+	);
 
 	const editorKindOptions = useSecretEditorKindOptions(editor);
-
-	const kindLabel = (kind: string): string =>
-		kindOptions.find((option) => option.value === kind)?.label ?? kind;
-
-	const providerLabel = (providerKind: string): string =>
-		t(`provider.${providerKind}`, { defaultValue: providerKind });
 
 	const lifecycleFilter = useMemo<SecretLifecycleFilter>(() => {
 		const raw = searchParams.get("lifecycle");
@@ -193,48 +223,30 @@ export function SecretsPage() {
 		setSearchParams(next, { replace: true });
 	};
 
-	const lifecycleLabel = (state: SecretLifecycleState | "all"): string =>
-		t(`lifecycle.state.${state}`, { defaultValue: state.replaceAll("_", " ") });
-
-	const lifecycleDescription = (state: SecretLifecycleState): string =>
-		t(`lifecycle.description.${state}`, {
-			defaultValue: state.replaceAll("_", " "),
-		});
-
-	const lifecycleBadgeVariant = (
-		state: SecretLifecycleState,
-	): "secondary" | "success" | "warning" | "outline" | "info" => {
-		switch (state) {
-			case "active":
-				return "success";
-			case "cleanup_available":
-				return "warning";
-			case "oauth_managed":
-				return "info";
-			case "unused":
-				return "outline";
-		}
-	};
-
-	const renderLifecycleBadge = (secret: SecretMetadata) => {
-		const lifecycle = classifySecretLifecycle(secret);
-		return (
-			<Badge
-				variant={lifecycleBadgeVariant(lifecycle.state)}
-				title={lifecycleDescription(lifecycle.state)}
-			>
-				{lifecycleLabel(lifecycle.state)}
-			</Badge>
-		);
-	};
-
-	const filteredSecrets = useMemo(
-		() => filterSecretsByLifecycle(secretsQuery.data ?? [], lifecycleFilter),
-		[secretsQuery.data, lifecycleFilter],
+	const lifecycleLabel = useCallback(
+		(state: SecretLifecycleState | "all"): string =>
+			t(`lifecycle.state.${state}`, { defaultValue: state.replace(/_/g, " ") }),
+		[t, i18n.language],
 	);
 
+	const lifecycleByAlias = useMemo(() => {
+		const map = new Map<string, ReturnType<typeof classifySecretLifecycle>>();
+		for (const secret of secretsQuery.data ?? []) {
+			map.set(secret.alias, classifySecretLifecycle(secret));
+		}
+		return map;
+	}, [secretsQuery.data]);
+
+	const filteredSecrets = useMemo(() => {
+		const secrets = secretsQuery.data ?? [];
+		if (lifecycleFilter === "all") return secrets;
+		return secrets.filter(
+			(secret) => lifecycleByAlias.get(secret.alias)?.state === lifecycleFilter,
+		);
+	}, [lifecycleByAlias, lifecycleFilter, secretsQuery.data]);
+
 	const secretsAsEntities = useMemo<SecretToolbarEntity[]>(() => {
-		const mapped = filteredSecrets.map((secret) => ({
+		return filteredSecrets.map((secret) => ({
 			id: secret.alias,
 			name: secret.alias,
 			description: secret.label ?? secret.placeholder,
@@ -245,8 +257,6 @@ export function SecretsPage() {
 			historical_usage_count: secret.historical_usage_count,
 			version: secret.version,
 		}));
-		mapped.sort((left, right) => left.alias.localeCompare(right.alias));
-		return mapped;
 	}, [filteredSecrets]);
 
 	const secretsByAlias = useMemo(
@@ -256,6 +266,8 @@ export function SecretsPage() {
 			),
 		[secretsQuery.data],
 	);
+	const secretsByAliasRef = useRef(secretsByAlias);
+	secretsByAliasRef.current = secretsByAlias;
 
 	const totalPages = Math.max(
 		1,
@@ -265,6 +277,38 @@ export function SecretsPage() {
 		const start = (currentPage - 1) * itemsPerPage;
 		return sortedSecrets.slice(start, start + itemsPerPage);
 	}, [currentPage, itemsPerPage, sortedSecrets]);
+	const secretDisplayByAlias = useMemo(() => {
+		const map = new Map<string, ReturnType<typeof getSecretDisplay>>();
+		for (const secret of secretsQuery.data ?? []) {
+			map.set(secret.alias, getSecretDisplay(secret));
+		}
+		return map;
+	}, [secretsQuery.data]);
+	const catalogRows = useMemo(
+		() =>
+			pagedSecrets
+				.filter((entity) => secretsByAlias.has(entity.alias) && lifecycleByAlias.has(entity.alias))
+				.map((entity) => {
+					const secret = secretsByAlias.get(entity.alias)!;
+					const lifecycle = lifecycleByAlias.get(entity.alias)!;
+					return {
+						secret,
+						display: secretDisplayByAlias.get(secret.alias)!,
+						kindLabel:
+							kindLabelByKind.get(secret.kind) ?? secret.kind,
+						lifecycleState: lifecycle.state,
+						providerLabel: providerLabel(secret.provider_kind),
+					};
+				}),
+		[
+			kindLabelByKind,
+			lifecycleByAlias,
+			pagedSecrets,
+			providerLabel,
+			secretsByAlias,
+			secretDisplayByAlias,
+		],
+	);
 	const hasNoSecretRecords = (secretsQuery.data?.length ?? 0) === 0;
 
 	useEffect(() => {
@@ -275,6 +319,8 @@ export function SecretsPage() {
 
 	useEffect(() => {
 		if (searchParams.get("editor") !== "create") return;
+		if (!storeReady) return;
+
 		const origin = originFromSearchParams(searchParams);
 		const suggestedFromUrl = searchParams.get("suggested_alias")?.trim() ?? "";
 		const existingAliases = (secretsQuery.data ?? []).map((secret) => secret.alias);
@@ -301,29 +347,24 @@ export function SecretsPage() {
 		next.delete("suggested_alias");
 		stripOriginSearchParams(next);
 		setSearchParams(next, { replace: true });
-	}, [searchParams, secretsQuery.data, setSearchParams, t]);
+	}, [searchParams, secretsQuery.data, setSearchParams, storeReady, t]);
 
 	useEffect(() => {
 		const alias = searchParams.get("secret")?.trim();
 		if (!alias || !secretsQuery.data) return;
+		if (!storeReady) return;
+
 		const secret = secretsByAlias.get(alias);
 		if (!secret) return;
 
 		setEditorInitialTab(searchParams.get("tab") === "usage" ? "usage" : "general");
-		setEditor({
-			mode: "edit",
-			alias: secret.alias,
-			kind: (secret.kind as SecretKind) || "generic",
-			label: secret.label ?? "",
-			value: "",
-			origin: secret.origin ?? null,
-		});
+		setEditor(buildEditEditorState(secret));
 
 		const next = new URLSearchParams(searchParams);
 		next.delete("secret");
 		next.delete("tab");
 		setSearchParams(next, { replace: true });
-	}, [searchParams, secretsByAlias, secretsQuery.data, setSearchParams]);
+	}, [searchParams, secretsByAlias, secretsQuery.data, setSearchParams, storeReady]);
 
 	const saveMutation = useMutation({
 		mutationFn: async (state: SecretEditorState) => {
@@ -347,7 +388,7 @@ export function SecretsPage() {
 		},
 		onSuccess: async () => {
 			setEditor(null);
-			await queryClient.invalidateQueries({ queryKey: ["secrets"] });
+			await invalidateSecretStoreCatalog(queryClient);
 			notifySuccess(
 				t("notifications.saveSuccess", { defaultValue: "Secret saved" }),
 			);
@@ -370,7 +411,7 @@ export function SecretsPage() {
 		onSuccess: async () => {
 			setDeleteTarget(null);
 			setEditor(null);
-			await queryClient.invalidateQueries({ queryKey: ["secrets"] });
+			await invalidateSecretStoreCatalog(queryClient);
 			notifySuccess(
 				t("notifications.deleteSuccess", { defaultValue: "Secret deleted" }),
 			);
@@ -385,21 +426,54 @@ export function SecretsPage() {
 		},
 	});
 
-	const openCreate = () => {
+	const openCreate = useCallback(() => {
+		if (!storeReady) {
+			return;
+		}
 		setEditorInitialTab("general");
 		setEditor(defaultSecretEditorState());
-	};
-	const openEdit = (secret: SecretMetadata, tab: "general" | "usage" = "general") => {
-		setEditorInitialTab(tab);
-		setEditor({
-			mode: "edit",
-			alias: secret.alias,
-			kind: (secret.kind as SecretKind) || "generic",
-			label: secret.label ?? "",
-			value: "",
-			origin: secret.origin ?? null,
-		});
-	};
+	}, [storeReady]);
+	const openEdit = useCallback(
+		(secret: SecretMetadata, tab: "general" | "usage" = "general") => {
+			setEditorInitialTab(tab);
+			setEditor(buildEditEditorState(secret));
+		},
+		[],
+	);
+	const handleCatalogOpen = useCallback(
+		(alias: string) => {
+			if (!storeReady) {
+				return;
+			}
+			const secret = secretsByAliasRef.current.get(alias);
+			if (secret) {
+				openEdit(secret);
+			}
+		},
+		[openEdit, storeReady],
+	);
+	const handleCatalogViewUsage = useCallback(
+		(alias: string) => {
+			if (!storeReady) {
+				return;
+			}
+			const secret = secretsByAliasRef.current.get(alias);
+			if (secret) {
+				openEdit(secret, "usage");
+			}
+		},
+		[openEdit, storeReady],
+	);
+	const { refetch: refetchSecretsList } = secretsQuery;
+	const { refetch: refetchStoreStatus } = storeStatusQuery;
+	const refreshSecretsPage = useCallback(() => {
+		void Promise.all([refetchSecretsList(), refetchStoreStatus()]);
+	}, [refetchSecretsList, refetchStoreStatus]);
+	const isRefreshing =
+		secretsQuery.isRefetching || storeStatusQuery.isRefetching;
+	const viewUsageLabel = t("list.actions.viewUsage", {
+		defaultValue: "View usage",
+	});
 	const closeEditor = () => {
 		setEditor(null);
 		setEditorInitialTab("general");
@@ -413,24 +487,23 @@ export function SecretsPage() {
 		[navigate],
 	);
 
-	const editorPlaceholder = useMemo(() => {
+	const editorMeta = useMemo(() => {
 		if (!editor || editor.mode !== "edit") {
-			return undefined;
+			return { placeholder: undefined, usedByCount: undefined };
 		}
-		return secretsByAlias.get(editor.alias)?.placeholder;
-	}, [editor, secretsByAlias]);
-
-	const editorUsedByCount = useMemo(() => {
-		if (!editor || editor.mode !== "edit") {
-			return undefined;
-		}
-		return secretsByAlias.get(editor.alias)?.used_by_count;
+		const secret = secretsByAlias.get(editor.alias);
+		return {
+			placeholder: secret?.placeholder,
+			usedByCount: secret?.used_by_count,
+		};
 	}, [editor, secretsByAlias]);
 
 	const statsCards = useMemo((): StatCardData[] => {
 		const secrets = secretsQuery.data ?? [];
 		const inUseCount = secrets.filter((secret) => secret.used_by_count > 0).length;
-		const cleanupCount = secrets.filter(secretHasCleanupAvailable).length;
+		const cleanupCount = [...lifecycleByAlias.values()].filter(
+			secretHasCleanupAvailable,
+		).length;
 		const storeStatus = storeStatusQuery.data;
 
 		let storeValue: string | number = "—";
@@ -485,6 +558,7 @@ export function SecretsPage() {
 			},
 		];
 	}, [
+		lifecycleByAlias,
 		secretsQuery.data,
 		secretsQuery.isLoading,
 		storeStatusQuery.data,
@@ -512,78 +586,91 @@ export function SecretsPage() {
 		</Select>
 	);
 
-	const toolbarConfig: PageToolbarConfig<SecretToolbarEntity> = {
-		data: secretsAsEntities,
-		search: {
-			placeholder: t("toolbar.search.placeholder", {
-				defaultValue: "Search secrets...",
-			}),
-			fields: [
-				{
-					key: "alias",
-					label: t("toolbar.search.fields.alias", { defaultValue: "Alias" }),
-					weight: 10,
-				},
-				{
-					key: "description",
-					label: t("toolbar.search.fields.label", { defaultValue: "Label" }),
-					weight: 8,
-				},
-				{
-					key: "kind",
-					label: t("toolbar.search.fields.kind", { defaultValue: "Kind" }),
-					weight: 5,
-				},
-			],
-			debounceMs: 300,
-		},
-		viewMode: {
-			enabled: true,
-			defaultMode: storedDefaultView as "grid" | "list",
-		},
-		sort: {
-			enabled: true,
-			options: [
-				{
-					value: "alias",
-					label: t("toolbar.sort.options.alias", { defaultValue: "Alias" }),
-					defaultDirection: "asc",
-				},
-				{
-					value: "kind",
-					label: t("toolbar.sort.options.kind", { defaultValue: "Kind" }),
-					defaultDirection: "asc",
-				},
-				{
-					value: "used_by_count",
-					label: t("toolbar.sort.options.usage", { defaultValue: "Usage" }),
-					defaultDirection: "desc",
-				},
-			],
-			defaultSort: "alias",
-		},
-		urlPersistence: {
-			enabled: true,
-		},
-	};
+	const toolbarConfig = useMemo<PageToolbarConfig<SecretToolbarEntity>>(
+		() => ({
+			data: secretsAsEntities,
+			search: {
+				placeholder: t("toolbar.search.placeholder", {
+					defaultValue: "Search secrets...",
+				}),
+				fields: [
+					{
+						key: "alias",
+						label: t("toolbar.search.fields.alias", { defaultValue: "Alias" }),
+						weight: 10,
+					},
+					{
+						key: "description",
+						label: t("toolbar.search.fields.label", { defaultValue: "Label" }),
+						weight: 8,
+					},
+					{
+						key: "kind",
+						label: t("toolbar.search.fields.kind", { defaultValue: "Kind" }),
+						weight: 5,
+					},
+				],
+				debounceMs: 300,
+			},
+			viewMode: {
+				enabled: true,
+				defaultMode: storedDefaultView as "grid" | "list",
+			},
+			sort: {
+				enabled: true,
+				options: [
+					{
+						value: "alias",
+						label: t("toolbar.sort.options.alias", { defaultValue: "Alias" }),
+						defaultDirection: "asc",
+					},
+					{
+						value: "kind",
+						label: t("toolbar.sort.options.kind", { defaultValue: "Kind" }),
+						defaultDirection: "asc",
+					},
+					{
+						value: "used_by_count",
+						label: t("toolbar.sort.options.usage", { defaultValue: "Usage" }),
+						defaultDirection: "desc",
+					},
+				],
+				defaultSort: "alias",
+			},
+			urlPersistence: {
+				enabled: true,
+			},
+		}),
+		[secretsAsEntities, storedDefaultView, t, i18n.language],
+	);
 
 	const toolbarState: PageToolbarState = {
 		expanded,
 	};
 
-	const toolbarCallbacks: PageToolbarCallbacks<SecretToolbarEntity> = {
-		onViewModeChange: (mode: "grid" | "list") => {
+	const handleViewModeChange = useCallback(
+		(mode: "grid" | "list") => {
 			setDashboardSetting("defaultView", mode);
 		},
-		onSortedDataChange: (data) => {
-			setSortedSecrets(data);
-			setCurrentPage(1);
-		},
-		onExpandedChange: setExpanded,
-	};
+		[setDashboardSetting],
+	);
+
+	const handleSortedDataChange = useCallback((data: SecretToolbarEntity[]) => {
+		setSortedSecrets(data);
+		setCurrentPage(1);
+	}, []);
+
+	const toolbarCallbacks = useMemo<PageToolbarCallbacks<SecretToolbarEntity>>(
+		() => ({
+			onViewModeChange: handleViewModeChange,
+			onSortedDataChange: handleSortedDataChange,
+			onExpandedChange: setExpanded,
+		}),
+		[handleSortedDataChange, handleViewModeChange],
+	);
 
 	const loadingSkeleton =
-		viewMode === "grid"
+		view === "grid"
 			? Array.from({ length: 6 }, (_, index) => (
 				<Card key={`secret-grid-skeleton-${index}`} className="overflow-hidden">
 					<CardContent className="space-y-3 p-4">
@@ -660,12 +747,12 @@ export function SecretsPage() {
 				variant="outline"
 				size="sm"
 				className="h-9 w-9 p-0"
-				onClick={() => void secretsQuery.refetch()}
-				disabled={secretsQuery.isRefetching}
+				onClick={refreshSecretsPage}
+				disabled={isRefreshing}
 				title={t("toolbar.actions.refresh", { defaultValue: "Refresh" })}
 			>
 				<RefreshCw
-					className={`h-4 w-4 ${secretsQuery.isRefetching ? "animate-spin" : ""}`}
+					className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
 				/>
 			</Button>
 			<Button
@@ -681,135 +768,10 @@ export function SecretsPage() {
 		</div>
 	);
 
-	const renderSecretRow = (entity: SecretToolbarEntity) => {
-		const secret = secretsByAlias.get(entity.alias);
-		if (!secret) return null;
-		const display = getSecretDisplay(secret);
-
-		return (
-			<EntityListItem
-				key={secret.alias}
-				id={secret.alias}
-				title={display.title}
-				description={
-					<div className="min-w-0">
-						{display.secondary ? (
-							<div className="truncate font-mono text-xs">
-								{display.secondary}
-							</div>
-						) : null}
-						<div className="truncate font-mono text-xs text-muted-foreground">
-							{secret.placeholder}
-						</div>
-					</div>
-				}
-				avatar={{
-					fallback: secret.alias.slice(0, 2).toUpperCase(),
-				}}
-				titleBadges={[
-					<Badge key="kind" variant="secondary">
-						{kindLabel(secret.kind)}
-					</Badge>,
-					<span key="lifecycle">{renderLifecycleBadge(secret)}</span>,
-				]}
-				stats={[
-					{
-						label: t("list.stats.provider", { defaultValue: "Provider" }),
-						value: providerLabel(secret.provider_kind),
-						valueTitle: secret.provider_kind,
-					},
-					{
-						label: t("list.stats.usage", { defaultValue: "Usage" }),
-						value: secret.used_by_count,
-					},
-					{
-						label: t("list.stats.history", { defaultValue: "History" }),
-						value: secret.historical_usage_count,
-					},
-					{
-						label: t("list.stats.version", { defaultValue: "Version" }),
-						value: secret.version,
-					},
-				]}
-				actionButtons={[
-					<Button
-						key="usage"
-						type="button"
-						variant="ghost"
-						size="sm"
-						className="h-9 px-2"
-						onClick={() => openEdit(secret, "usage")}
-						aria-label={t("list.actions.viewUsage", {
-							defaultValue: "View usage",
-						})}
-					>
-						<ShieldCheck className="mr-2 h-4 w-4" />
-						{secret.used_by_count}
-					</Button>,
-				]}
-				onClick={() => openEdit(secret)}
-			/>
-		);
-	};
-
-	const renderSecretCard = (entity: SecretToolbarEntity) => {
-		const secret = secretsByAlias.get(entity.alias);
-		if (!secret) return null;
-		const display = getSecretDisplay(secret);
-
-		return (
-			<EntityCard
-				key={secret.alias}
-				id={secret.alias}
-				title={display.title}
-				description={
-					<div className="min-w-0">
-						{display.secondary ? (
-							<div className="truncate font-mono text-xs">
-								{display.secondary}
-							</div>
-						) : null}
-						<div className="truncate font-mono text-xs text-muted-foreground">
-							{secret.placeholder}
-						</div>
-					</div>
-				}
-				avatar={{
-					fallback: secret.alias.slice(0, 2).toUpperCase(),
-				}}
-				avatarShape="rounded"
-				topRightBadge={
-					<>
-						{renderLifecycleBadge(secret)}
-						<Badge variant="secondary">{kindLabel(secret.kind)}</Badge>
-					</>
-				}
-				stats={[
-					{
-						label: t("list.stats.provider", { defaultValue: "Provider" }),
-						value: providerLabel(secret.provider_kind),
-						valueTitle: secret.provider_kind,
-					},
-					{
-						label: t("list.stats.usage", { defaultValue: "Usage" }),
-						value: String(secret.used_by_count),
-					},
-					{
-						label: t("list.stats.history", { defaultValue: "History" }),
-						value: String(secret.historical_usage_count),
-					},
-					{
-						label: t("list.stats.version", { defaultValue: "Version" }),
-						value: String(secret.version),
-					},
-				]}
-				onClick={() => openEdit(secret)}
-			/>
-		);
-	};
-
 	if (storeStatusQuery.isSuccess && needsEncryptionUnlock) {
-		return <LockScreen variant="encryption" onSuccess={handleEncryptionUnlock} />;
+		return (
+			<PageLockScreen variant="encryption" onSuccess={handleEncryptionUnlock} />
+		);
 	}
 
 	return (
@@ -828,41 +790,34 @@ export function SecretsPage() {
 			statsCards={<StatsCards cards={statsCards} />}
 		>
 			<div className="flex min-h-0 flex-1 flex-col gap-4">
-				{storeStatusQuery.isError && (
-					<Alert variant="destructive">
-						<ShieldAlert className="h-4 w-4" />
-						<AlertTitle>
-							{t("status.error.title", {
-								defaultValue: "Store status check failed",
-							})}
-						</AlertTitle>
-						<AlertDescription>
-							{storeStatusQuery.error instanceof Error
-								? storeStatusQuery.error.message
+				{storeStatusQuery.isError ? (
+					<ErrorDisplay
+						icon={ShieldAlert}
+						title={t("status.error.title", {
+							defaultValue: "Store status check failed",
+						})}
+						error={
+							storeStatusQuery.error instanceof Error
+								? storeStatusQuery.error
 								: t("status.error.description", {
 									defaultValue:
 										"Could not determine store status. Operations are disabled.",
-								})}
-						</AlertDescription>
-					</Alert>
-				)}
-				{storeStatusQuery.isSuccess && !storeReady && (
-					<Alert variant="destructive">
-						<ShieldAlert className="h-4 w-4" />
-						<AlertTitle>
-							{t("status.unavailable.title", {
-								defaultValue: "Secure store unavailable",
-							})}
-						</AlertTitle>
-						<AlertDescription>
-							{storeStatusQuery.data?.issue?.message ??
-								t("status.unavailable.description", {
-									defaultValue:
-										"The secret store is not ready. Create and update operations are disabled until the issue is resolved.",
-								})}
-						</AlertDescription>
-					</Alert>
-				)}
+								})
+						}
+						onRetry={() => void storeStatusQuery.refetch()}
+						retryLabel={t("list.retry", { defaultValue: "Retry" })}
+					/>
+				) : null}
+				{storeStatusQuery.isSuccess && !storeReady && storeStatusQuery.data ? (
+					<SecretStoreIssueAlert
+						status={storeStatusQuery.data}
+						isRetrying={
+							providerRetryMutation.isPending || storeStatusQuery.isFetching
+						}
+						onRetryStatus={() => void storeStatusQuery.refetch()}
+						onRetryProvider={(mode) => providerRetryMutation.mutate(mode)}
+					/>
+				) : null}
 				{secretsQuery.isError ? (
 					<div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
 						<p className="text-sm text-destructive">
@@ -870,7 +825,7 @@ export function SecretsPage() {
 								defaultValue: "Failed to load secrets. The secure store may be unavailable.",
 							})}
 						</p>
-						<Button variant="outline" size="sm" onClick={() => secretsQuery.refetch()}>
+						<Button variant="outline" size="sm" onClick={refreshSecretsPage}>
 							<RefreshCw className="mr-2 h-4 w-4" />
 							{t("list.retry", { defaultValue: "Retry" })}
 						</Button>
@@ -883,9 +838,37 @@ export function SecretsPage() {
 							emptyClassName="h-full"
 							emptyState={sortedSecrets.length === 0 ? emptyState : undefined}
 						>
-							{viewMode === "grid"
-								? pagedSecrets.map(renderSecretCard)
-								: pagedSecrets.map(renderSecretRow)}
+							{pagedSecrets.length === 0
+								? null
+								: catalogRows.map((row) =>
+									view === "grid" ? (
+										<SecretCatalogEntry
+											key={row.secret.alias}
+											variant="grid"
+											secret={row.secret}
+											display={row.display}
+											kindLabel={row.kindLabel}
+											lifecycleState={row.lifecycleState}
+											providerLabel={row.providerLabel}
+											statsLabels={catalogStatsLabels}
+											onOpen={handleCatalogOpen}
+										/>
+									) : (
+										<SecretCatalogEntry
+											key={row.secret.alias}
+											variant="list"
+											secret={row.secret}
+											display={row.display}
+											kindLabel={row.kindLabel}
+											lifecycleState={row.lifecycleState}
+											providerLabel={row.providerLabel}
+											statsLabels={catalogStatsLabels}
+											viewUsageLabel={viewUsageLabel}
+											onOpen={handleCatalogOpen}
+											onViewUsage={handleCatalogViewUsage}
+										/>
+									),
+								)}
 						</ListGridContainer>
 						{sortedSecrets.length > 0 ? (
 							<Pagination
@@ -930,11 +913,12 @@ export function SecretsPage() {
 						}
 						: undefined
 				}
+				writesDisabled={!storeReady}
 				isSaving={saveMutation.isPending}
-				placeholder={editorPlaceholder}
+				placeholder={editorMeta.placeholder}
 				usages={usagesQuery.data ?? []}
 				usagesLoading={Boolean(editorAlias) && usagesQuery.isLoading}
-				usedByCount={editorUsedByCount}
+				usedByCount={editorMeta.usedByCount}
 				serverNameById={serverNameById}
 				initialTab={editorInitialTab}
 				onNavigateToServer={handleNavigateToServer}

--- a/board/src/pages/settings/i18n/index.ts
+++ b/board/src/pages/settings/i18n/index.ts
@@ -336,7 +336,7 @@ export const settingsTranslations = {
       encryptionModeDescription: "How the root encryption key is stored and protected.",
       encryptionModeStatus: "Encryption mode security level",
       providerModeUnknown:
-        "Encryption mode is unavailable until the secure store reports its provider.",
+        "Current encryption mode could not be determined. Choose a mode below to switch away from a broken provider.",
       encryptionPasswordRow: "Encryption Password",
       encryptionPasswordRowDescription:
         "Master password that wraps the root encryption key.",
@@ -729,7 +729,8 @@ export const settingsTranslations = {
       encryptionMode: "加密模式",
       encryptionModeDescription: "根加密密钥的存储与保护方式。",
       encryptionModeStatus: "加密模式安全级别",
-      providerModeUnknown: "安全存储尚未报告提供方信息，暂无法显示或切换加密模式。",
+      providerModeUnknown:
+        "无法确定当前加密模式。请在下方选择模式以从故障提供方切换离开。",
       encryptionPasswordRow: "加密密码",
       encryptionPasswordRowDescription: "用于包裹根加密密钥的主密码。",
       mode: {
@@ -1149,7 +1150,7 @@ export const settingsTranslations = {
         "ルート暗号化キーの保存と保護方法。",
       encryptionModeStatus: "暗号化モードのセキュリティレベル",
       providerModeUnknown:
-        "セキュアストアがプロバイダー情報を返すまで、暗号化モードは表示・切り替えできません。",
+        "現在の暗号化モードを特定できません。下からモードを選び、障害のあるプロバイダーから切り替えてください。",
       encryptionPasswordRow: "暗号化パスワード",
       encryptionPasswordRowDescription:
         "ルート暗号化キーをラップするマスターパスワード。",

--- a/board/src/pages/settings/i18n/index.ts
+++ b/board/src/pages/settings/i18n/index.ts
@@ -318,6 +318,7 @@ export const settingsTranslations = {
       error: {
         title: "Status check failed",
         description: "Could not retrieve store status.",
+        retry: "Retry",
       },
       passwordProtection: "Password Protection",
       passwordProtectionDescription:
@@ -334,6 +335,8 @@ export const settingsTranslations = {
       encryptionMode: "Encryption Mode",
       encryptionModeDescription: "How the root encryption key is stored and protected.",
       encryptionModeStatus: "Encryption mode security level",
+      providerModeUnknown:
+        "Encryption mode is unavailable until the secure store reports its provider.",
       encryptionPasswordRow: "Encryption Password",
       encryptionPasswordRowDescription:
         "Master password that wraps the root encryption key.",
@@ -709,6 +712,7 @@ export const settingsTranslations = {
       error: {
         title: "状态检查失败",
         description: "无法获取存储状态。",
+        retry: "重试",
       },
       passwordProtection: "密码保护",
       passwordProtectionDescription:
@@ -725,6 +729,7 @@ export const settingsTranslations = {
       encryptionMode: "加密模式",
       encryptionModeDescription: "根加密密钥的存储与保护方式。",
       encryptionModeStatus: "加密模式安全级别",
+      providerModeUnknown: "安全存储尚未报告提供方信息，暂无法显示或切换加密模式。",
       encryptionPasswordRow: "加密密码",
       encryptionPasswordRowDescription: "用于包裹根加密密钥的主密码。",
       mode: {
@@ -1125,6 +1130,7 @@ export const settingsTranslations = {
       error: {
         title: "状態確認に失敗しました",
         description: "ストア状態を取得できませんでした。",
+        retry: "再試行",
       },
       passwordProtection: "パスワード保護",
       passwordProtectionDescription:
@@ -1142,6 +1148,8 @@ export const settingsTranslations = {
       encryptionModeDescription:
         "ルート暗号化キーの保存と保護方法。",
       encryptionModeStatus: "暗号化モードのセキュリティレベル",
+      providerModeUnknown:
+        "セキュアストアがプロバイダー情報を返すまで、暗号化モードは表示・切り替えできません。",
       encryptionPasswordRow: "暗号化パスワード",
       encryptionPasswordRowDescription:
         "ルート暗号化キーをラップするマスターパスワード。",

--- a/board/src/pages/settings/settings-page.tsx
+++ b/board/src/pages/settings/settings-page.tsx
@@ -31,7 +31,8 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { useUrlTab } from "../../lib/hooks/use-url-state";
 import { Button } from "../../components/ui/button";
-import { LockScreen } from "../../components/lock-screen";
+import { ErrorDisplay } from "../../components/error-display";
+import { PageLockScreen } from "../../components/lock-screen";
 import {
 	Card,
 	CardContent,
@@ -54,7 +55,6 @@ import {
 	SelectValue,
 } from "../../components/ui/select";
 import { Switch } from "../../components/ui/switch";
-import { Alert, AlertDescription, AlertTitle } from "../../components/ui/alert";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -83,6 +83,17 @@ import {
 	type DesktopCoreSourceResponse,
 	useDesktopCoreState,
 } from "../../lib/desktop-core-state";
+import { SecretStoreIssueAlert } from "../../components/secrets";
+import { useSecretStoreProviderRetryMutation } from "../../lib/hooks/use-secret-store-provider-retry";
+import {
+	invalidateSecretStoreStatus,
+	useSecretStoreStatusQuery,
+} from "../../lib/hooks/use-secret-store-status";
+import { useSecretsTranslations } from "../../lib/hooks/use-secrets-translations";
+import {
+	isSwitchableSecretStoreProviderMode,
+	type SwitchableSecretStoreProviderMode,
+} from "../../lib/secret-store-guidance";
 import { notifyError, notifySuccess, stringifyError } from "../../lib/notify";
 import {
 	type ProtectionLevel,
@@ -347,6 +358,7 @@ function auditFormMatchesSaved(form: AuditPolicyFormState, saved: AuditPolicyFor
 
 export function SettingsPage() {
 	usePageTranslations("settings");
+	const { t: secretsT } = useSecretsTranslations();
 	const queryClient = useQueryClient();
 	const languageId = useId();
 	const backupLimitId = useId();
@@ -441,10 +453,7 @@ export function SettingsPage() {
 		queryKey: ["system", "settings"],
 		queryFn: () => systemApi.getSettings(),
 	});
-	const storeStatusQuery = useQuery({
-		queryKey: ["secrets", "status"],
-		queryFn: secretsApi.status,
-	});
+	const storeStatusQuery = useSecretStoreStatusQuery();
 	const [selectedMode, setSelectedMode] = useState<string>("");
 	const [passphraseInput, setPassphraseInput] = useState("");
 	const [passphraseConfirmInput, setPassphraseConfirmInput] = useState("");
@@ -458,9 +467,8 @@ export function SettingsPage() {
 	const passphraseSetupPasswordRef = useRef<HTMLInputElement>(null);
 	const currentPassphraseInputRef = useRef<HTMLInputElement>(null);
 
-	type ProviderSwitchMode = "operating_system" | "passphrase" | "local_file";
 	type PendingProviderSwitch = {
-		mode: ProviderSwitchMode;
+		mode: SwitchableSecretStoreProviderMode;
 		passphrase?: string;
 		currentPassphrase?: string;
 	};
@@ -476,8 +484,13 @@ export function SettingsPage() {
 		setCurrentPassphraseError(null);
 	}, []);
 
-	const currentProviderMode =
-		storeStatusQuery.data?.provider?.provider_mode ?? "operating_system";
+	const reportedProviderMode = storeStatusQuery.data?.provider?.provider_mode;
+	const currentProviderMode = isSwitchableSecretStoreProviderMode(
+		reportedProviderMode,
+	)
+		? reportedProviderMode
+		: null;
+	const encryptionModeKnown = currentProviderMode !== null;
 	const isPassphraseModeConfigured =
 		currentProviderMode === "passphrase" && storeStatusQuery.data?.status === "ready";
 	const isPendingPassphraseSwitch =
@@ -492,7 +505,7 @@ export function SettingsPage() {
 				passphraseConfirmInput,
 			),
 		onSuccess: async () => {
-			await queryClient.invalidateQueries({ queryKey: ["secrets", "status"] });
+			await invalidateSecretStoreStatus(queryClient);
 			resetPendingProviderSwitch();
 			setShowPassphraseSetupDialog(false);
 			setShowCurrentPassphraseDialog(false);
@@ -523,7 +536,7 @@ export function SettingsPage() {
 				currentPassphrase: pending.currentPassphrase,
 			}),
 		onSuccess: async () => {
-			await queryClient.invalidateQueries({ queryKey: ["secrets", "status"] });
+			await invalidateSecretStoreStatus(queryClient);
 			resetPendingProviderSwitch();
 			setShowPassphraseSetupDialog(false);
 			setShowSwitchConfirm(false);
@@ -545,6 +558,8 @@ export function SettingsPage() {
 		},
 	});
 
+	const providerRetryMutation = useSecretStoreProviderRetryMutation(secretsT);
+
 	const promptSecurityModeSwitchIfPending = useCallback(
 		(modeOverride?: string) => {
 			const mode = modeOverride ?? selectedMode;
@@ -564,8 +579,11 @@ export function SettingsPage() {
 			if (switchProviderMutation.isPending || showSwitchConfirm) {
 				return;
 			}
+			if (!isSwitchableSecretStoreProviderMode(mode)) {
+				return;
+			}
 			pendingProviderSwitchRef.current = {
-				mode: mode as ProviderSwitchMode,
+				mode,
 				passphrase: mode === "passphrase" ? passphraseInput : undefined,
 			};
 			setShowSwitchConfirm(true);
@@ -692,10 +710,13 @@ export function SettingsPage() {
 			setShowPassphraseSetupDialog(true);
 			return;
 		}
-		const mode = (selectedMode || currentProviderMode) as ProviderSwitchMode;
+		const modeCandidate = selectedMode || currentProviderMode;
+		if (!isSwitchableSecretStoreProviderMode(modeCandidate)) {
+			return;
+		}
 		pendingProviderSwitchRef.current = {
-			mode,
-			passphrase: mode === "passphrase" ? passphraseInput : undefined,
+			mode: modeCandidate,
+			passphrase: modeCandidate === "passphrase" ? passphraseInput : undefined,
 			currentPassphrase: currentPassphraseInput,
 		};
 		setShowCurrentPassphraseDialog(false);
@@ -1588,7 +1609,9 @@ export function SettingsPage() {
 	});
 
 	if (needsSettingsPassword) {
-		return <LockScreen variant="login" onSuccess={handleSettingsPasswordUnlock} />;
+		return (
+			<PageLockScreen variant="login" onSuccess={handleSettingsPasswordUnlock} />
+		);
 	}
 
 	return (
@@ -2154,17 +2177,23 @@ export function SettingsPage() {
 										{t("settings:security.loading", { defaultValue: "Checking store status..." })}
 									</p>
 								) : storeStatusQuery.isError ? (
-									<Alert variant="destructive">
-										<ShieldCheck className="h-4 w-4" />
-										<AlertTitle>
-											{t("settings:security.error.title", { defaultValue: "Status check failed" })}
-										</AlertTitle>
-										<AlertDescription>
-											{storeStatusQuery.error instanceof Error
-												? storeStatusQuery.error.message
-												: t("settings:security.error.description", { defaultValue: "Could not retrieve store status." })}
-										</AlertDescription>
-									</Alert>
+									<ErrorDisplay
+										icon={ShieldCheck}
+										title={t("settings:security.error.title", {
+											defaultValue: "Status check failed",
+										})}
+										error={
+											storeStatusQuery.error instanceof Error
+												? storeStatusQuery.error
+												: t("settings:security.error.description", {
+													defaultValue: "Could not retrieve store status.",
+												})
+										}
+										onRetry={() => void storeStatusQuery.refetch()}
+										retryLabel={t("settings:security.error.retry", {
+											defaultValue: "Retry",
+										})}
+									/>
 								) : storeStatusQuery.data ? (
 									<>
 										<div className="space-y-3">
@@ -2296,16 +2325,25 @@ export function SettingsPage() {
 													</p>
 												</div>
 												<div className="flex sm:justify-end">
-													<Segment
-														options={[
-															{ value: "operating_system", label: t("settings:security.mode.os", { defaultValue: "OS Keychain" }) },
-															{ value: "passphrase", label: t("settings:security.mode.passphrase", { defaultValue: "Password" }) },
-															{ value: "local_file", label: t("settings:security.mode.local", { defaultValue: "Local File" }) },
-														]}
-														value={selectedMode || currentProviderMode}
-														onValueChange={handleEncryptionModeChange}
-														showDots={false}
-													/>
+													{encryptionModeKnown || selectedMode ? (
+														<Segment
+															options={[
+																{ value: "operating_system", label: t("settings:security.mode.os", { defaultValue: "OS Keychain" }) },
+																{ value: "passphrase", label: t("settings:security.mode.passphrase", { defaultValue: "Password" }) },
+																{ value: "local_file", label: t("settings:security.mode.local", { defaultValue: "Local File" }) },
+															]}
+															value={selectedMode || currentProviderMode || "operating_system"}
+															onValueChange={handleEncryptionModeChange}
+															showDots={false}
+														/>
+													) : (
+														<p className="text-sm text-muted-foreground sm:text-right">
+															{t("settings:security.providerModeUnknown", {
+																defaultValue:
+																	"Encryption mode is unavailable until the secure store reports its provider.",
+															})}
+														</p>
+													)}
 												</div>
 											</div>
 											{effectiveEncryptionMode === "passphrase" ? (
@@ -2341,18 +2379,20 @@ export function SettingsPage() {
 												</div>
 											) : null}
 
-											{storeStatusQuery.data.issue ? (
-												<Alert variant="destructive">
-													<ShieldCheck className="h-4 w-4" />
-													<AlertTitle>
-														{t("settings:security.issue.title", { defaultValue: "Store Issue" })}
-													</AlertTitle>
-													<AlertDescription>
-														<strong>{storeStatusQuery.data.issue.reason_code}</strong>
-														{" — "}
-														{storeStatusQuery.data.issue.message}
-													</AlertDescription>
-												</Alert>
+											{storeStatusQuery.data ? (
+												<SecretStoreIssueAlert
+													status={storeStatusQuery.data}
+													hideSettingsLink
+													isRetrying={
+														providerRetryMutation.isPending ||
+														switchProviderMutation.isPending ||
+														storeStatusQuery.isFetching
+													}
+													onRetryStatus={() => void storeStatusQuery.refetch()}
+													onRetryProvider={(mode) =>
+														providerRetryMutation.mutate(mode)
+													}
+												/>
 											) : null}
 
 											{/* Mode description */}

--- a/board/src/pages/settings/settings-page.tsx
+++ b/board/src/pages/settings/settings-page.tsx
@@ -2324,26 +2324,29 @@ export function SettingsPage() {
 														})}
 													</p>
 												</div>
-												<div className="flex sm:justify-end">
-													{encryptionModeKnown || selectedMode ? (
-														<Segment
-															options={[
-																{ value: "operating_system", label: t("settings:security.mode.os", { defaultValue: "OS Keychain" }) },
-																{ value: "passphrase", label: t("settings:security.mode.passphrase", { defaultValue: "Password" }) },
-																{ value: "local_file", label: t("settings:security.mode.local", { defaultValue: "Local File" }) },
-															]}
-															value={selectedMode || currentProviderMode || "operating_system"}
-															onValueChange={handleEncryptionModeChange}
-															showDots={false}
-														/>
-													) : (
-														<p className="text-sm text-muted-foreground sm:text-right">
+												<div className="flex flex-col items-stretch gap-2 sm:items-end">
+													{!encryptionModeKnown && !selectedMode ? (
+														<p className="text-xs text-muted-foreground sm:text-right">
 															{t("settings:security.providerModeUnknown", {
 																defaultValue:
-																	"Encryption mode is unavailable until the secure store reports its provider.",
+																	"Current encryption mode could not be determined. Choose a mode below to switch away from a broken provider.",
 															})}
 														</p>
-													)}
+													) : null}
+													<Segment
+														options={[
+															{ value: "operating_system", label: t("settings:security.mode.os", { defaultValue: "OS Keychain" }) },
+															{ value: "passphrase", label: t("settings:security.mode.passphrase", { defaultValue: "Password" }) },
+															{ value: "local_file", label: t("settings:security.mode.local", { defaultValue: "Local File" }) },
+														]}
+														value={
+															selectedMode ||
+															currentProviderMode ||
+															"operating_system"
+														}
+														onValueChange={handleEncryptionModeChange}
+														showDots={false}
+													/>
 												</div>
 											</div>
 											{effectiveEncryptionMode === "passphrase" ? (


### PR DESCRIPTION
## Summary

- Add secure-store guidance resolution, shared status/retry hooks, and `SecretStoreIssueAlert` for degraded provider states (OS keychain, read lock, generic unavailable).
- Refactor Secrets page with `SecretCatalogEntry`, dual refresh (catalog + status), catalog write guards, URL deeplink preservation until the store is ready, and encryption unlock via embedded `PageLockScreen`.
- Wire Settings Security tab to the shared alert UX, hide the encryption mode switcher when provider metadata is unknown, and extend degradation E2E coverage (7 scenarios).

## Out of scope

- Settings Security full encryption unlock flow (#19 follow-up).
- Backend OAuth startup loader changes (`loader.rs`) and `desktop/Cargo.lock` — kept in working tree for a separate PR.

## Test plan

- [x] `cd board && bun run lint` (0 errors)
- [x] `cd board && bunx vitest run src/lib/secret-store-guidance.test.ts` (8/8)
- [x] `cd board && bun run build`
- [x] `cd board && bun run e2e e2e/secrets-status-degradation.spec.ts` (7/7)
- [ ] Manual UAT: macOS keychain denial → guided alert + retry on Secrets and Settings
- [ ] Manual UAT: passphrase unlock → encryption lock screen on Secrets (not alert)